### PR TITLE
feat(forms): add defaultValues that sets state and reflects that in DOM

### DIFF
--- a/packages/form/src/index.test.ts
+++ b/packages/form/src/index.test.ts
@@ -589,3 +589,267 @@ describe("createForm — async schema guard", () => {
     cleanup(el);
   });
 });
+
+// ---------------------------------------------------------------------------
+// createForm — defaultValues
+// ---------------------------------------------------------------------------
+
+describe("createForm — defaultValues", () => {
+  it("applies string default to a text input on mount()", () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({
+      el,
+      schema: basicSchema,
+      onSubmit: () => {},
+      defaultValues: { email: "ada@example.com", name: "Ada" },
+    });
+    form.mount();
+
+    expect((el.querySelector('[name="email"]') as HTMLInputElement).value).toBe("ada@example.com");
+    expect((el.querySelector('[name="name"]') as HTMLInputElement).value).toBe("Ada");
+
+    form.unmount();
+    cleanup(el);
+  });
+
+  it("does not apply defaults before mount()", () => {
+    const el = makeForm(basicHtml);
+    createForm({
+      el,
+      schema: basicSchema,
+      onSubmit: () => {},
+      defaultValues: { email: "ada@example.com" },
+    });
+
+    expect((el.querySelector('[name="email"]') as HTMLInputElement).value).toBe("");
+    cleanup(el);
+  });
+
+  it("default values are read by values() after mount()", () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({
+      el,
+      schema: basicSchema,
+      onSubmit: () => {},
+      defaultValues: { email: "ada@example.com", name: "Ada" },
+    });
+    form.mount();
+
+    const result = form.values();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual({ email: "ada@example.com", name: "Ada" });
+    }
+
+    form.unmount();
+    cleanup(el);
+  });
+
+  it("default values cause onSubmit to fire with pre-filled data", () => {
+    const submitted: any[] = [];
+    const el = makeForm(basicHtml);
+    const form = createForm({
+      el,
+      schema: basicSchema,
+      onSubmit: (values) => submitted.push(values),
+      defaultValues: { email: "ada@example.com", name: "Ada" },
+    });
+    const unmount = form.mount();
+
+    submit(el);
+
+    expect(submitted).toHaveLength(1);
+    expect(submitted[0]).toEqual({ email: "ada@example.com", name: "Ada" });
+    unmount();
+    cleanup(el);
+  });
+
+  it("does not mark form as dirty after applying defaults", () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({
+      el,
+      schema: basicSchema,
+      onSubmit: () => {},
+      defaultValues: { email: "ada@example.com", name: "Ada" },
+    });
+    form.mount();
+
+    expect(form.isDirty()).toBe(false);
+
+    form.unmount();
+    cleanup(el);
+  });
+
+  it("user change after defaults marks form as dirty", () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({
+      el,
+      schema: basicSchema,
+      onSubmit: () => {},
+      defaultValues: { email: "ada@example.com", name: "Ada" },
+    });
+    const unmount = form.mount();
+
+    const input = setField(el, "email", "other@example.com");
+    dispatch(input, "change");
+
+    expect(form.isDirty()).toBe(true);
+    unmount();
+    cleanup(el);
+  });
+
+  it("applies defaults to a checkbox group — checks matching values", () => {
+    const el = makeForm(`
+      <input type="checkbox" name="tags" value="a" />
+      <input type="checkbox" name="tags" value="b" />
+      <input type="checkbox" name="tags" value="c" />
+    `);
+    const form = createForm({
+      el,
+      schema: z.object({ tags: z.array(z.string()) }),
+      onSubmit: () => {},
+      defaultValues: { tags: ["a", "c"] },
+    });
+    form.mount();
+
+    const checkboxes = el.querySelectorAll<HTMLInputElement>('[name="tags"]');
+    expect(checkboxes[0]!.checked).toBe(true); // "a"
+    expect(checkboxes[1]!.checked).toBe(false); // "b"
+    expect(checkboxes[2]!.checked).toBe(true); // "c"
+
+    form.unmount();
+    cleanup(el);
+  });
+
+  it("applies defaults to radio inputs — checks matching value", () => {
+    const el = makeForm(`
+      <input type="radio" name="role" value="admin" />
+      <input type="radio" name="role" value="user" />
+      <input type="radio" name="role" value="guest" />
+    `);
+    const form = createForm({
+      el,
+      schema: z.object({ role: z.string() }),
+      onSubmit: () => {},
+      defaultValues: { role: "user" },
+    });
+    form.mount();
+
+    const radios = el.querySelectorAll<HTMLInputElement>('[name="role"]');
+    expect(radios[0]!.checked).toBe(false); // "admin"
+    expect(radios[1]!.checked).toBe(true); // "user"
+    expect(radios[2]!.checked).toBe(false); // "guest"
+
+    form.unmount();
+    cleanup(el);
+  });
+
+  it("applies defaults to a <select> element", () => {
+    const el = makeForm(`
+      <select name="country">
+        <option value="pl">Poland</option>
+        <option value="de">Germany</option>
+        <option value="fr">France</option>
+      </select>
+    `);
+    const form = createForm({
+      el,
+      schema: z.object({ country: z.string() }),
+      onSubmit: () => {},
+      defaultValues: { country: "de" },
+    });
+    form.mount();
+
+    expect((el.querySelector('[name="country"]') as HTMLSelectElement).value).toBe("de");
+
+    form.unmount();
+    cleanup(el);
+  });
+
+  it("applies defaults to a <select multiple> element", () => {
+    const el = makeForm(`
+      <select name="langs" multiple>
+        <option value="en">English</option>
+        <option value="pl">Polish</option>
+        <option value="de">German</option>
+      </select>
+    `);
+    const form = createForm({
+      el,
+      schema: z.object({ langs: z.array(z.string()) }),
+      onSubmit: () => {},
+      defaultValues: { langs: ["en", "pl"] },
+    });
+    form.mount();
+
+    const options = el.querySelectorAll<HTMLOptionElement>('[name="langs"] option');
+    expect(options[0]!.selected).toBe(true); // "en"
+    expect(options[1]!.selected).toBe(true); // "pl"
+    expect(options[2]!.selected).toBe(false); // "de"
+
+    form.unmount();
+    cleanup(el);
+  });
+
+  it("applies defaults to a <textarea>", () => {
+    const el = makeForm(`<textarea name="bio"></textarea>`);
+    const form = createForm({
+      el,
+      schema: z.object({ bio: z.string() }),
+      onSubmit: () => {},
+      defaultValues: { bio: "Hello world" },
+    });
+    form.mount();
+
+    expect((el.querySelector('[name="bio"]') as HTMLTextAreaElement).value).toBe("Hello world");
+
+    form.unmount();
+    cleanup(el);
+  });
+
+  it("re-applies defaults on each mount() call", () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({
+      el,
+      schema: basicSchema,
+      onSubmit: () => {},
+      defaultValues: { email: "ada@example.com", name: "Ada" },
+    });
+
+    const unmount1 = form.mount();
+    setField(el, "email", "changed@example.com");
+    unmount1();
+
+    // Second mount re-applies defaults
+    form.mount();
+    expect((el.querySelector('[name="email"]') as HTMLInputElement).value).toBe("ada@example.com");
+
+    form.unmount();
+    cleanup(el);
+  });
+
+  it("works fine with no defaultValues provided (undefined)", () => {
+    const el = makeForm(basicHtml);
+    expect(() => {
+      const form = createForm({ el, schema: basicSchema, onSubmit: () => {} });
+      form.mount();
+      form.unmount();
+    }).not.toThrow();
+    cleanup(el);
+  });
+
+  it("ignores defaultValues keys that have no matching DOM element", () => {
+    const el = makeForm(basicHtml);
+    expect(() => {
+      const form = createForm({
+        el,
+        schema: basicSchema,
+        onSubmit: () => {},
+        defaultValues: { email: "ada@example.com", name: "Ada" },
+      });
+      form.mount();
+      form.unmount();
+    }).not.toThrow();
+    cleanup(el);
+  });
+});

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -350,9 +350,10 @@ export function createForm<S extends StandardSchemaV1>(options: CreateFormOption
     },
 
     mount() {
+      dirty = false;
+
       if (defaultValues) {
-        applyDefaultValues(el, defaultValues);
-        // Reset stale validation state — defaults represent a fresh baseline
+        applyDefaultValues(el, defaultValues as Record<string, string | string[]>);
         currentErrors = {};
       }
 

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -52,21 +52,37 @@ export declare namespace StandardSchemaV1 {
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * Discriminated union result from reading or validating form values.
+ * Never throws — validation failures are returned as data.
+ */
 export type FormResult<T> =
   | { ok: true; data: T }
   | { ok: false; issues: ReadonlyArray<StandardSchemaV1.Issue> };
 
+/**
+ * Per-field error map. Keys are dot-separated field paths matching the
+ * schema's issue path (e.g. `"user.email"`). Values are arrays of messages
+ * so multiple failing rules on a single field are all surfaced.
+ */
 export type FormErrors = Record<string, string[]>;
 
+/**
+ * When to run schema validation automatically against field changes.
+ *
+ * - `"submit"` (default) — only on form submission
+ * - `"change"` — on `change` events (after a field loses focus with a new value)
+ * - `"input"` — on every `input` event (every keystroke)
+ */
 export type ValidateOn = "submit" | "change" | "input";
 
 /**
  * Partial map of field names to their default values.
- * Use `string` for text/select inputs and `string[]` for checkbox groups.
+ * Keys are the DOM `name` attributes — arbitrary strings, including dotted
+ * paths like `"user.email"`. Values are strings or string arrays (for
+ * checkbox groups / multi-select).
  */
-export type DefaultValues<S extends StandardSchemaV1> = Partial<
-  Record<keyof StandardSchemaV1.InferInput<S> & string, string | string[]>
->;
+export type DefaultValues = Partial<Record<string, string | string[]>>;
 
 export interface CreateFormOptions<S extends StandardSchemaV1> {
   /** The form element to bind to. */
@@ -81,7 +97,9 @@ export interface CreateFormOptions<S extends StandardSchemaV1> {
    */
   onSubmit: (values: StandardSchemaV1.InferOutput<S>, event: SubmitEvent) => void;
 
-  /** Called with structured issues when schema validation fails on submission. */
+  /**
+   * Called with structured issues when schema validation fails on submission.
+   */
   onError?: (issues: ReadonlyArray<StandardSchemaV1.Issue>, event: SubmitEvent) => void;
 
   /**
@@ -93,20 +111,48 @@ export interface CreateFormOptions<S extends StandardSchemaV1> {
   /**
    * Initial values applied to form fields on `mount()`.
    * Keys are field `name` attributes; values are strings (or string arrays
-   * for checkbox / multi-select groups).
+   * for checkbox / multi-select groups). File inputs are always skipped.
    *
    * @example
    * defaultValues: { email: "ada@example.com", role: "admin" }
    */
-  defaultValues?: DefaultValues<S>;
+  defaultValues?: DefaultValues;
 }
 
 export interface Form<S extends StandardSchemaV1> {
+  /**
+   * Read and validate the current form values synchronously against the schema.
+   * Returns a discriminated union — never throws.
+   */
   values(): FormResult<StandardSchemaV1.InferOutput<S>>;
+
+  /**
+   * The per-field error state from the last validation attempt.
+   * Empty object before the first validation runs.
+   */
   errors(): FormErrors;
+
+  /**
+   * Whether any field value has changed since `mount()` was called.
+   */
   isDirty(): boolean;
+
+  /**
+   * Manually trigger the validate → onSubmit/onError cycle programmatically.
+   */
   submit(): void;
+
+  /**
+   * Attach event listeners to the form and activate the binding.
+   * If `defaultValues` are provided they are applied to the DOM here, and
+   * any stale validation state is cleared.
+   * Returns a cleanup/unmount function.
+   */
   mount(): () => void;
+
+  /**
+   * Remove all event listeners. Idempotent.
+   */
   unmount(): void;
 }
 
@@ -164,9 +210,14 @@ export function issuesToErrors(issues: ReadonlyArray<StandardSchemaV1.Issue>): F
 
 /**
  * Applies `defaultValues` to the DOM elements inside the form.
- * - Text / number / select / textarea: sets `.value`
- * - Checkbox: checks the element if its `.value` is included in the default array (or matches string)
- * - Radio: checks the element whose `.value` matches the default string
+ *
+ * - Text / number / email / … inputs: sets `.value`
+ * - `type="file"`: skipped — browser blocks programmatic `.value` assignment
+ * - `type="checkbox"`: checks the element if its `.value` is in the default array
+ * - `type="radio"`: checks the element whose `.value` matches the default string
+ * - `<select>`: sets `.value`
+ * - `<select multiple>`: marks each matching option as `.selected`
+ * - `<textarea>`: sets `.value`
  */
 function applyDefaultValues(
   form: HTMLFormElement,
@@ -186,7 +237,8 @@ function applyDefaultValues(
           el.checked = values.includes(el.value);
         } else if (el.type === "radio") {
           el.checked = el.value === defaultValue;
-        } else {
+        } else if (el.type !== "file") {
+          // file inputs are intentionally skipped — browser blocks programmatic .value
           el.value = Array.isArray(defaultValue) ? (defaultValue[0] ?? "") : defaultValue;
         }
       } else if (el instanceof HTMLSelectElement) {
@@ -212,15 +264,38 @@ function applyDefaultValues(
  * Bind a Standard Schema to a form element. Wires up typed submission,
  * validation, and per-field error state using native DOM event listeners.
  *
+ * Designed to integrate cleanly with ilha islands — pass `el` from an
+ * `.effect()` context or resolve it inside `.on()` handlers.
+ *
  * @example
- * const form = createForm({
- *   el: formEl,
- *   schema: z.object({ email: z.string().email(), name: z.string().min(1) }),
- *   defaultValues: { email: "ada@example.com" },
- *   onSubmit(values) { console.log(values); },
- *   validateOn: "change",
- * });
- * return form.mount();
+ * const island = ilha
+ *   .state("errors", {} as FormErrors)
+ *   .effect(({ el, state }) => {
+ *     const formEl = el.querySelector("form")!;
+ *     const form = createForm({
+ *       el: formEl,
+ *       schema: z.object({
+ *         email: z.string().email(),
+ *         name: z.string().min(1),
+ *       }),
+ *       defaultValues: { email: "ada@example.com" },
+ *       onSubmit(values) {
+ *         console.log(values);
+ *       },
+ *       onError(issues) {
+ *         state.errors(issuesToErrors(issues));
+ *       },
+ *       validateOn: "change",
+ *     });
+ *     return form.mount();
+ *   })
+ *   .render(({ state }) => html`
+ *     <form>
+ *       <input name="email" />
+ *       <input name="name" />
+ *       <button>Submit</button>
+ *     </form>
+ *   `);
  */
 export function createForm<S extends StandardSchemaV1>(options: CreateFormOptions<S>): Form<S> {
   const { el, schema, onSubmit, onError, validateOn = "submit", defaultValues } = options;
@@ -275,9 +350,10 @@ export function createForm<S extends StandardSchemaV1>(options: CreateFormOption
     },
 
     mount() {
-      // Apply default values to DOM before attaching listeners
       if (defaultValues) {
-        applyDefaultValues(el, defaultValues as Record<string, string | string[]>);
+        applyDefaultValues(el, defaultValues);
+        // Reset stale validation state — defaults represent a fresh baseline
+        currentErrors = {};
       }
 
       const listeners: Array<() => void> = [];

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -19,6 +19,7 @@ export declare namespace StandardSchemaV1 {
     readonly validate: (value: unknown) => Result<Output> | Promise<Result<Output>>;
     readonly types?: Types<Input, Output> | undefined;
   }
+
   export type Result<Output> = SuccessResult<Output> | FailureResult;
   export interface SuccessResult<Output> {
     readonly value: Output;
@@ -34,10 +35,11 @@ export declare namespace StandardSchemaV1 {
   export interface PathSegment {
     readonly key: PropertyKey;
   }
-  export interface Types<Input = unknown, Output = Input> {
+  export interface Types<Input, Output> {
     readonly input: Input;
     readonly output: Output;
   }
+
   export type InferInput<S extends StandardSchemaV1> = NonNullable<
     S["~standard"]["types"]
   >["input"];
@@ -50,34 +52,24 @@ export declare namespace StandardSchemaV1 {
 // Types
 // ---------------------------------------------------------------------------
 
-/**
- * Discriminated union result from reading or validating form values.
- * Never throws — validation failures are returned as data.
- */
 export type FormResult<T> =
   | { ok: true; data: T }
   | { ok: false; issues: ReadonlyArray<StandardSchemaV1.Issue> };
 
-/**
- * Per-field error map. Keys are dot-separated field paths matching the
- * schema's issue path (e.g. `"user.email"`). Values are arrays of messages
- * so multiple failing rules on a single field are all surfaced.
- */
 export type FormErrors = Record<string, string[]>;
 
-/**
- * When to run schema validation automatically against field changes.
- *
- * - `"submit"` (default) — only on form submission
- * - `"change"` — on `change` events (after a field loses focus with a new value)
- * - `"input"` — on every `input` event (every keystroke)
- */
 export type ValidateOn = "submit" | "change" | "input";
 
-export interface CreateFormOptions<S extends StandardSchemaV1<any, any>> {
-  /**
-   * The form element to bind to.
-   */
+/**
+ * Partial map of field names to their default values.
+ * Use `string` for text/select inputs and `string[]` for checkbox groups.
+ */
+export type DefaultValues<S extends StandardSchemaV1> = Partial<
+  Record<keyof StandardSchemaV1.InferInput<S> & string, string | string[]>
+>;
+
+export interface CreateFormOptions<S extends StandardSchemaV1> {
+  /** The form element to bind to. */
   el: HTMLFormElement;
 
   /** Standard Schema — Zod, Valibot, ArkType, or any compatible library. */
@@ -89,9 +81,7 @@ export interface CreateFormOptions<S extends StandardSchemaV1<any, any>> {
    */
   onSubmit: (values: StandardSchemaV1.InferOutput<S>, event: SubmitEvent) => void;
 
-  /**
-   * Called with structured issues when schema validation fails on submission.
-   */
+  /** Called with structured issues when schema validation fails on submission. */
   onError?: (issues: ReadonlyArray<StandardSchemaV1.Issue>, event: SubmitEvent) => void;
 
   /**
@@ -99,40 +89,24 @@ export interface CreateFormOptions<S extends StandardSchemaV1<any, any>> {
    * Defaults to `"submit"`.
    */
   validateOn?: ValidateOn;
+
+  /**
+   * Initial values applied to form fields on `mount()`.
+   * Keys are field `name` attributes; values are strings (or string arrays
+   * for checkbox / multi-select groups).
+   *
+   * @example
+   * defaultValues: { email: "ada@example.com", role: "admin" }
+   */
+  defaultValues?: DefaultValues<S>;
 }
 
-export interface Form<S extends StandardSchemaV1<any, any>> {
-  /**
-   * Read and validate the current form values synchronously against the schema.
-   * Returns a discriminated union — never throws.
-   */
+export interface Form<S extends StandardSchemaV1> {
   values(): FormResult<StandardSchemaV1.InferOutput<S>>;
-
-  /**
-   * The per-field error state from the last validation attempt.
-   * Empty object before the first validation runs.
-   */
   errors(): FormErrors;
-
-  /**
-   * Whether any field value has changed since `mount()` was called.
-   */
   isDirty(): boolean;
-
-  /**
-   * Manually trigger the validate → onSubmit/onError cycle programmatically.
-   */
   submit(): void;
-
-  /**
-   * Attach event listeners to the form and activate the binding.
-   * Returns a cleanup/unmount function.
-   */
   mount(): () => void;
-
-  /**
-   * Remove all event listeners. Idempotent.
-   */
   unmount(): void;
 }
 
@@ -150,7 +124,7 @@ function extractFormData(form: HTMLFormElement): Record<string, unknown> {
   return result;
 }
 
-function runSchemaSync<S extends StandardSchemaV1<any, any>>(
+function runSchemaSync<S extends StandardSchemaV1>(
   schema: S,
   data: unknown,
 ): FormResult<StandardSchemaV1.InferOutput<S>> {
@@ -188,6 +162,48 @@ export function issuesToErrors(issues: ReadonlyArray<StandardSchemaV1.Issue>): F
   return errors;
 }
 
+/**
+ * Applies `defaultValues` to the DOM elements inside the form.
+ * - Text / number / select / textarea: sets `.value`
+ * - Checkbox: checks the element if its `.value` is included in the default array (or matches string)
+ * - Radio: checks the element whose `.value` matches the default string
+ */
+function applyDefaultValues(
+  form: HTMLFormElement,
+  defaults: Record<string, string | string[]>,
+): void {
+  for (const [name, defaultValue] of Object.entries(defaults)) {
+    const elements = Array.from(
+      form.querySelectorAll<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>(
+        `[name="${CSS.escape(name)}"]`,
+      ),
+    );
+
+    for (const el of elements) {
+      if (el instanceof HTMLInputElement) {
+        if (el.type === "checkbox") {
+          const values = Array.isArray(defaultValue) ? defaultValue : [defaultValue];
+          el.checked = values.includes(el.value);
+        } else if (el.type === "radio") {
+          el.checked = el.value === defaultValue;
+        } else {
+          el.value = Array.isArray(defaultValue) ? (defaultValue[0] ?? "") : defaultValue;
+        }
+      } else if (el instanceof HTMLSelectElement) {
+        if (el.multiple && Array.isArray(defaultValue)) {
+          for (const option of el.options) {
+            option.selected = defaultValue.includes(option.value);
+          }
+        } else {
+          el.value = Array.isArray(defaultValue) ? (defaultValue[0] ?? "") : defaultValue;
+        }
+      } else if (el instanceof HTMLTextAreaElement) {
+        el.value = Array.isArray(defaultValue) ? (defaultValue[0] ?? "") : defaultValue;
+      }
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // createForm
 // ---------------------------------------------------------------------------
@@ -196,42 +212,18 @@ export function issuesToErrors(issues: ReadonlyArray<StandardSchemaV1.Issue>): F
  * Bind a Standard Schema to a form element. Wires up typed submission,
  * validation, and per-field error state using native DOM event listeners.
  *
- * Designed to integrate cleanly with ilha islands — pass `el` from an
- * `.effect()` context or resolve it inside `.on()` handlers.
- *
  * @example
- * const island = ilha
- *   .state("errors", {} as FormErrors)
- *   .effect(({ el, state }) => {
- *     const formEl = el.querySelector("form")!;
- *     const form = createForm({
- *       el: formEl,
- *       schema: z.object({
- *         email: z.string().email(),
- *         name: z.string().min(1),
- *       }),
- *       onSubmit(values) {
- *         console.log(values);
- *       },
- *       onError(issues) {
- *         state.errors(issuesToErrors(issues));
- *       },
- *       validateOn: "change",
- *     });
- *     return form.mount();
- *   })
- *   .render(({ state }) => html`
- *     <form>
- *       <input name="email" />
- *       <input name="name" />
- *       <button type="submit">Submit</button>
- *     </form>
- *   `);
+ * const form = createForm({
+ *   el: formEl,
+ *   schema: z.object({ email: z.string().email(), name: z.string().min(1) }),
+ *   defaultValues: { email: "ada@example.com" },
+ *   onSubmit(values) { console.log(values); },
+ *   validateOn: "change",
+ * });
+ * return form.mount();
  */
-export function createForm<S extends StandardSchemaV1<any, any>>(
-  options: CreateFormOptions<S>,
-): Form<S> {
-  const { el, schema, onSubmit, onError, validateOn = "submit" } = options;
+export function createForm<S extends StandardSchemaV1>(options: CreateFormOptions<S>): Form<S> {
+  const { el, schema, onSubmit, onError, validateOn = "submit", defaultValues } = options;
 
   let currentErrors: FormErrors = {};
   let dirty = false;
@@ -283,6 +275,11 @@ export function createForm<S extends StandardSchemaV1<any, any>>(
     },
 
     mount() {
+      // Apply default values to DOM before attaching listeners
+      if (defaultValues) {
+        applyDefaultValues(el, defaultValues as Record<string, string | string[]>);
+      }
+
       const listeners: Array<() => void> = [];
 
       function on<K extends keyof HTMLElementEventMap>(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `defaultValues` option to pre-fill form controls (text, checkboxes, radios, selects, textareas) when the form is mounted, without marking the form as dirty; defaults are re-applied on each mount and stale validation errors are cleared when defaults are provided.

* **Tests**
  * Added comprehensive tests for default application, submission values, dirty-state behavior, multiple input types, repeated mounts, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->