### PR TITLE
feat(form): add persistence for rerenders

### DIFF
--- a/packages/form/src/index.test.ts
+++ b/packages/form/src/index.test.ts
@@ -1095,3 +1095,212 @@ describe("createForm — setValue()", () => {
     cleanup(el);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Helpers — simulate re-render by replacing form innerHTML
+// ---------------------------------------------------------------------------
+
+function rerender(form: HTMLFormElement, html: string) {
+  form.innerHTML = html;
+}
+
+// ---------------------------------------------------------------------------
+// createForm — MutationObserver / re-render resilience
+// ---------------------------------------------------------------------------
+
+describe("createForm — re-render resilience", () => {
+  it("re-applies defaultValues to a field that reappears after re-render", async () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({
+      el,
+      schema: basicSchema,
+      onSubmit: () => {},
+      defaultValues: { email: "ada@example.com", name: "Ada" },
+    });
+    form.mount();
+
+    // simulate re-render — replaces DOM nodes, wiping values
+    rerender(el, basicHtml);
+
+    await Promise.resolve(); // let MutationObserver fire
+
+    expect((el.querySelector('[name="email"]') as HTMLInputElement).value).toBe("ada@example.com");
+    expect((el.querySelector('[name="name"]') as HTMLInputElement).value).toBe("Ada");
+
+    form.unmount();
+    cleanup(el);
+  });
+
+  it("restores user-changed value after re-render, not the default", async () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({
+      el,
+      schema: basicSchema,
+      onSubmit: () => {},
+      defaultValues: { email: "default@example.com", name: "Default" },
+    });
+    form.mount();
+
+    // user changes the value
+    const input = setField(el, "email", "user@example.com");
+    dispatch(input, "change");
+
+    // re-render wipes DOM
+    rerender(el, basicHtml);
+    await Promise.resolve();
+
+    // should restore user value, not the default
+    expect((el.querySelector('[name="email"]') as HTMLInputElement).value).toBe("user@example.com");
+
+    form.unmount();
+    cleanup(el);
+  });
+
+  it("restores default for untouched fields even if another field was changed", async () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({
+      el,
+      schema: basicSchema,
+      onSubmit: () => {},
+      defaultValues: { email: "default@example.com", name: "Default Name" },
+    });
+    form.mount();
+
+    // only change email, leave name untouched
+    const input = setField(el, "email", "user@example.com");
+    dispatch(input, "change");
+
+    rerender(el, basicHtml);
+    await Promise.resolve();
+
+    expect((el.querySelector('[name="email"]') as HTMLInputElement).value).toBe("user@example.com");
+    expect((el.querySelector('[name="name"]') as HTMLInputElement).value).toBe("Default Name");
+
+    form.unmount();
+    cleanup(el);
+  });
+
+  it("does not restore values after unmount — observer is disconnected", async () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({
+      el,
+      schema: basicSchema,
+      onSubmit: () => {},
+      defaultValues: { email: "ada@example.com", name: "Ada" },
+    });
+    form.mount();
+    form.unmount();
+
+    rerender(el, basicHtml);
+    await Promise.resolve();
+
+    // observer disconnected — values stay empty after re-render
+    expect((el.querySelector('[name="email"]') as HTMLInputElement).value).toBe("");
+
+    cleanup(el);
+  });
+
+  it("restores checkbox group state after re-render", async () => {
+    const el = makeForm(`
+      <input type="checkbox" name="tags" value="a" />
+      <input type="checkbox" name="tags" value="b" />
+      <input type="checkbox" name="tags" value="c" />
+    `);
+    const form = createForm({
+      el,
+      schema: z.object({ tags: z.array(z.string()) }),
+      onSubmit: () => {},
+      defaultValues: { tags: ["a", "c"] },
+    });
+    form.mount();
+
+    rerender(
+      el,
+      `
+      <input type="checkbox" name="tags" value="a" />
+      <input type="checkbox" name="tags" value="b" />
+      <input type="checkbox" name="tags" value="c" />
+    `,
+    );
+    await Promise.resolve();
+
+    const checkboxes = el.querySelectorAll<HTMLInputElement>('[name="tags"]');
+    expect(checkboxes[0]!.checked).toBe(true); // "a"
+    expect(checkboxes[1]!.checked).toBe(false); // "b"
+    expect(checkboxes[2]!.checked).toBe(true); // "c"
+
+    form.unmount();
+    cleanup(el);
+  });
+
+  it("restores user-checked checkboxes after re-render", async () => {
+    const el = makeForm(`
+      <input type="checkbox" name="tags" value="a" />
+      <input type="checkbox" name="tags" value="b" />
+    `);
+    const form = createForm({
+      el,
+      schema: z.object({ tags: z.array(z.string()) }),
+      onSubmit: () => {},
+      defaultValues: { tags: ["a"] },
+    });
+    form.mount();
+
+    // user also checks "b"
+    const b = el.querySelector<HTMLInputElement>('[value="b"]')!;
+    b.checked = true;
+    dispatch(b, "change");
+
+    rerender(
+      el,
+      `
+      <input type="checkbox" name="tags" value="a" />
+      <input type="checkbox" name="tags" value="b" />
+    `,
+    );
+    await Promise.resolve();
+
+    const checkboxes = el.querySelectorAll<HTMLInputElement>('[name="tags"]');
+    expect(checkboxes[0]!.checked).toBe(true); // "a" — default
+    expect(checkboxes[1]!.checked).toBe(true); // "b" — user checked
+
+    form.unmount();
+    cleanup(el);
+  });
+
+  it("no observer is set up when defaultValues is not provided", async () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({ el, schema: basicSchema, onSubmit: () => {} });
+
+    expect(() => {
+      form.mount();
+      rerender(el, basicHtml);
+      form.unmount();
+    }).not.toThrow();
+
+    cleanup(el);
+  });
+
+  it("values() reflects restored values after re-render", async () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({
+      el,
+      schema: basicSchema,
+      onSubmit: () => {},
+      defaultValues: { email: "ada@example.com", name: "Ada" },
+    });
+    form.mount();
+
+    rerender(el, basicHtml);
+    await Promise.resolve();
+
+    const result = form.values();
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual({ email: "ada@example.com", name: "Ada" });
+    }
+
+    form.unmount();
+    cleanup(el);
+  });
+});

--- a/packages/form/src/index.test.ts
+++ b/packages/form/src/index.test.ts
@@ -33,6 +33,10 @@ function submit(form: HTMLFormElement) {
   form.dispatchEvent(new SubmitEvent("submit", { bubbles: true, cancelable: true }));
 }
 
+function rerender(form: HTMLFormElement, html: string) {
+  form.innerHTML = html;
+}
+
 const basicSchema = z.object({
   email: z.string().email("Invalid email"),
   name: z.string().min(1, "Name is required"),
@@ -81,7 +85,7 @@ describe("createForm — mount/unmount", () => {
     unmount();
 
     submit(el);
-    expect(calls).toHaveLength(0); // listeners removed
+    expect(calls).toHaveLength(0);
     cleanup(el);
   });
 });
@@ -179,12 +183,10 @@ describe("createForm — submission", () => {
     });
     const unmount = form.mount();
 
-    // first submit → fail
     setField(el, "email", "bad");
     submit(el);
     expect(Object.keys(form.errors()).length).toBeGreaterThan(0);
 
-    // second submit → pass
     setField(el, "email", "ada@example.com");
     setField(el, "name", "Ada");
     submit(el);
@@ -348,11 +350,27 @@ describe("createForm — errors()", () => {
     setField(el, "user.email", "not-an-email");
     submit(el);
 
-    // path should be "user.email" or "" depending on validator — just check issues exist
     const errors = form.errors();
     const hasErrors = Object.values(errors).flat().length > 0;
     expect(hasErrors).toBe(true);
     unmount();
+    cleanup(el);
+  });
+
+  it("errors() is empty after remount even if errors existed before unmount", () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({ el, schema: basicSchema, onSubmit: () => {} });
+    const unmount = form.mount();
+
+    setField(el, "email", "bad");
+    submit(el);
+    expect(Object.keys(form.errors()).length).toBeGreaterThan(0);
+
+    unmount();
+    form.mount();
+    expect(form.errors()).toEqual({});
+
+    form.unmount();
     cleanup(el);
   });
 });
@@ -394,6 +412,23 @@ describe("createForm — isDirty()", () => {
     unmount();
 
     expect(form.isDirty()).toBe(true);
+    cleanup(el);
+  });
+
+  it("resets to false on remount", () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({ el, schema: basicSchema, onSubmit: () => {} });
+    const unmount = form.mount();
+
+    const input = setField(el, "email", "x");
+    dispatch(input, "change");
+    expect(form.isDirty()).toBe(true);
+
+    unmount();
+    form.mount();
+    expect(form.isDirty()).toBe(false);
+
+    form.unmount();
     cleanup(el);
   });
 });
@@ -489,9 +524,8 @@ describe("createForm — validateOn", () => {
     });
     const unmount = form.mount();
 
-    // Only fire change, not input — errors should not appear
     const input = setField(el, "email", "bad");
-    dispatch(input, "change"); // dirty tracking fires but not validation
+    dispatch(input, "change");
 
     expect(form.errors()).toEqual({});
     unmount();
@@ -820,7 +854,6 @@ describe("createForm — defaultValues", () => {
     setField(el, "email", "changed@example.com");
     unmount1();
 
-    // Second mount re-applies defaults
     form.mount();
     expect((el.querySelector('[name="email"]') as HTMLInputElement).value).toBe("ada@example.com");
 
@@ -1088,7 +1121,6 @@ describe("createForm — setValue()", () => {
     });
     form.mount();
 
-    // file inputs must not throw when setValue is called
     expect(() => form.setValue("avatar" as any, "ignored")).not.toThrow();
 
     form.unmount();
@@ -1097,15 +1129,7 @@ describe("createForm — setValue()", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Helpers — simulate re-render by replacing form innerHTML
-// ---------------------------------------------------------------------------
-
-function rerender(form: HTMLFormElement, html: string) {
-  form.innerHTML = html;
-}
-
-// ---------------------------------------------------------------------------
-// createForm — MutationObserver / re-render resilience
+// createForm — re-render resilience
 // ---------------------------------------------------------------------------
 
 describe("createForm — re-render resilience", () => {
@@ -1119,10 +1143,8 @@ describe("createForm — re-render resilience", () => {
     });
     form.mount();
 
-    // simulate re-render — replaces DOM nodes, wiping values
     rerender(el, basicHtml);
-
-    await Promise.resolve(); // let MutationObserver fire
+    await Promise.resolve();
 
     expect((el.querySelector('[name="email"]') as HTMLInputElement).value).toBe("ada@example.com");
     expect((el.querySelector('[name="name"]') as HTMLInputElement).value).toBe("Ada");
@@ -1141,15 +1163,12 @@ describe("createForm — re-render resilience", () => {
     });
     form.mount();
 
-    // user changes the value
     const input = setField(el, "email", "user@example.com");
     dispatch(input, "change");
 
-    // re-render wipes DOM
     rerender(el, basicHtml);
     await Promise.resolve();
 
-    // should restore user value, not the default
     expect((el.querySelector('[name="email"]') as HTMLInputElement).value).toBe("user@example.com");
 
     form.unmount();
@@ -1166,7 +1185,6 @@ describe("createForm — re-render resilience", () => {
     });
     form.mount();
 
-    // only change email, leave name untouched
     const input = setField(el, "email", "user@example.com");
     dispatch(input, "change");
 
@@ -1194,18 +1212,18 @@ describe("createForm — re-render resilience", () => {
     rerender(el, basicHtml);
     await Promise.resolve();
 
-    // observer disconnected — values stay empty after re-render
     expect((el.querySelector('[name="email"]') as HTMLInputElement).value).toBe("");
 
     cleanup(el);
   });
 
   it("restores checkbox group state after re-render", async () => {
-    const el = makeForm(`
+    const checkboxHtml = `
       <input type="checkbox" name="tags" value="a" />
       <input type="checkbox" name="tags" value="b" />
       <input type="checkbox" name="tags" value="c" />
-    `);
+    `;
+    const el = makeForm(checkboxHtml);
     const form = createForm({
       el,
       schema: z.object({ tags: z.array(z.string()) }),
@@ -1214,14 +1232,7 @@ describe("createForm — re-render resilience", () => {
     });
     form.mount();
 
-    rerender(
-      el,
-      `
-      <input type="checkbox" name="tags" value="a" />
-      <input type="checkbox" name="tags" value="b" />
-      <input type="checkbox" name="tags" value="c" />
-    `,
-    );
+    rerender(el, checkboxHtml);
     await Promise.resolve();
 
     const checkboxes = el.querySelectorAll<HTMLInputElement>('[name="tags"]');
@@ -1234,10 +1245,11 @@ describe("createForm — re-render resilience", () => {
   });
 
   it("restores user-checked checkboxes after re-render", async () => {
-    const el = makeForm(`
+    const checkboxHtml = `
       <input type="checkbox" name="tags" value="a" />
       <input type="checkbox" name="tags" value="b" />
-    `);
+    `;
+    const el = makeForm(checkboxHtml);
     const form = createForm({
       el,
       schema: z.object({ tags: z.array(z.string()) }),
@@ -1246,23 +1258,70 @@ describe("createForm — re-render resilience", () => {
     });
     form.mount();
 
-    // user also checks "b"
     const b = el.querySelector<HTMLInputElement>('[value="b"]')!;
     b.checked = true;
     dispatch(b, "change");
 
-    rerender(
-      el,
-      `
-      <input type="checkbox" name="tags" value="a" />
-      <input type="checkbox" name="tags" value="b" />
-    `,
-    );
+    rerender(el, checkboxHtml);
     await Promise.resolve();
 
     const checkboxes = el.querySelectorAll<HTMLInputElement>('[name="tags"]');
     expect(checkboxes[0]!.checked).toBe(true); // "a" — default
     expect(checkboxes[1]!.checked).toBe(true); // "b" — user checked
+
+    form.unmount();
+    cleanup(el);
+  });
+
+  it("restores <select multiple> selected options after re-render", async () => {
+    const selectHtml = `
+      <select name="langs" multiple>
+        <option value="en">English</option>
+        <option value="pl">Polish</option>
+        <option value="de">German</option>
+      </select>
+    `;
+    const el = makeForm(selectHtml);
+    const form = createForm({
+      el,
+      schema: z.object({ langs: z.array(z.string()) }),
+      onSubmit: () => {},
+      defaultValues: { langs: ["en", "pl"] },
+    });
+    form.mount();
+
+    rerender(el, selectHtml);
+    await Promise.resolve();
+
+    const options = el.querySelectorAll<HTMLOptionElement>('[name="langs"] option');
+    expect(options[0]!.selected).toBe(true); // "en"
+    expect(options[1]!.selected).toBe(true); // "pl"
+    expect(options[2]!.selected).toBe(false); // "de"
+
+    form.unmount();
+    cleanup(el);
+  });
+
+  it("restores value edited via input event (without change) after re-render", async () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({
+      el,
+      schema: basicSchema,
+      onSubmit: () => {},
+      defaultValues: { email: "default@example.com", name: "Default" },
+    });
+    form.mount();
+
+    const input = el.querySelector<HTMLInputElement>('[name="email"]')!;
+    input.value = "typed@example.com";
+    dispatch(input, "input");
+
+    rerender(el, basicHtml);
+    await Promise.resolve();
+
+    expect((el.querySelector('[name="email"]') as HTMLInputElement).value).toBe(
+      "typed@example.com",
+    );
 
     form.unmount();
     cleanup(el);

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -367,13 +367,20 @@ export function createForm<S extends StandardSchemaV1>(options: CreateFormOption
     },
 
     mount() {
-      dirty = false; // reset: isDirty() reflects "since this mount() call"
+      dirty = false;
+
+      // Tracks the latest value per field name — updated on every change/input
+      // event. After a re-render the observer restores this instead of the default.
+      const trackedValues = new Map<string, string | string[]>();
 
       if (defaultValues) {
         for (const [name, value] of Object.entries(defaultValues)) {
-          if (value !== undefined) applyValueToField(el, name, value);
+          if (value !== undefined) {
+            applyValueToField(el, name, value);
+            trackedValues.set(name, value); // seed with default
+          }
         }
-        currentErrors = {}; // reset stale validation state after defaults are applied
+        currentErrors = {};
       }
 
       const listeners: Array<() => void> = [];
@@ -387,14 +394,58 @@ export function createForm<S extends StandardSchemaV1>(options: CreateFormOption
         listeners.push(() => target.removeEventListener(type, handler as EventListener));
       }
 
+      // Track value changes so we can restore them after re-renders
+      function trackCurrentValues(): void {
+        if (!defaultValues) return;
+        for (const name of Object.keys(defaultValues)) {
+          const elements = Array.from(
+            el.querySelectorAll<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>(
+              `[name="${CSS.escape(name)}"]`,
+            ),
+          );
+          if (elements.length === 0) continue;
+          const first = elements[0]!;
+          if (first instanceof HTMLInputElement && first.type === "checkbox") {
+            // array of checked values
+            const checked = (elements as HTMLInputElement[])
+              .filter((e) => e.checked)
+              .map((e) => e.value);
+            trackedValues.set(name, checked);
+          } else if (first instanceof HTMLInputElement && first.type === "radio") {
+            const checked = (elements as HTMLInputElement[]).find((e) => e.checked);
+            if (checked) trackedValues.set(name, checked.value);
+          } else if (!(first instanceof HTMLInputElement && first.type === "file")) {
+            trackedValues.set(name, first.value);
+          }
+        }
+      }
+
       on(el, "submit", (e) => runSubmit(e as SubmitEvent));
-      on(el, "change", markDirty);
+      on(el, "change", () => {
+        trackCurrentValues();
+        markDirty();
+      });
 
       if (validateOn === "change") on(el, "change", runFieldValidation);
-      if (validateOn === "input") on(el, "input", runFieldValidation);
+      if (validateOn === "input") {
+        on(el, "input", () => trackCurrentValues());
+        on(el, "input", runFieldValidation);
+      }
+
+      // After re-render, restore tracked values (user-changed or default)
+      let observer: MutationObserver | null = null;
+      if (defaultValues) {
+        observer = new MutationObserver(() => {
+          for (const [name, value] of trackedValues) {
+            applyValueToField(el, name, value);
+          }
+        });
+        observer.observe(el, { childList: true, subtree: true });
+      }
 
       const unmountFn = () => {
         listeners.forEach((off) => off());
+        observer?.disconnect();
         activeUnmount = null;
       };
 

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -121,6 +121,10 @@ export interface CreateFormOptions<S extends StandardSchemaV1> {
    * Keys are field `name` attributes; values are strings (or string arrays
    * for checkbox / multi-select groups). File inputs are always skipped.
    *
+   * These values are tracked and automatically re-applied after re-renders
+   * (via MutationObserver). If the user has changed a field, their value is
+   * preserved instead of the default.
+   *
    * @example
    * defaultValues: { email: "ada@example.com", role: "admin" }
    */
@@ -153,9 +157,6 @@ export interface Form<S extends StandardSchemaV1> {
    * - `type="radio"`: checks the matching option
    * - `<select multiple>`: sets `.selected` per option
    * - `type="file"`: skipped
-   *
-   * Useful for controlled steps, discriminator fields backed by a
-   * `<input type="hidden">`, or any programmatic state change.
    */
   setValue(
     name: (keyof StandardSchemaV1.InferInput<S> & string) | (string & {}),
@@ -169,14 +170,14 @@ export interface Form<S extends StandardSchemaV1> {
 
   /**
    * Attach event listeners to the form and activate the binding.
-   * If `defaultValues` are provided they are applied to the DOM here, and
-   * any stale validation and dirty state is cleared.
+   * Applies `defaultValues` to the DOM, resets dirty + validation state,
+   * and starts a MutationObserver to re-apply values after re-renders.
    * Returns a cleanup/unmount function.
    */
   mount(): () => void;
 
   /**
-   * Remove all event listeners. Idempotent.
+   * Remove all event listeners and disconnect the MutationObserver. Idempotent.
    */
   unmount(): void;
 }
@@ -235,7 +236,7 @@ export function issuesToErrors(issues: ReadonlyArray<StandardSchemaV1.Issue>): F
 
 /**
  * Applies a value to all DOM elements matching `name` inside `form`.
- * Same rules as `defaultValues` — file inputs are skipped.
+ * File inputs are skipped. Silently ignores missing elements.
  */
 function applyValueToField(form: HTMLFormElement, name: string, value: string | string[]): void {
   const elements = Array.from(
@@ -277,38 +278,16 @@ function applyValueToField(form: HTMLFormElement, name: string, value: string | 
  * Bind a Standard Schema to a form element. Wires up typed submission,
  * validation, and per-field error state using native DOM event listeners.
  *
- * Designed to integrate cleanly with ilha islands — pass `el` from an
- * `.effect()` context or resolve it inside `.on()` handlers.
- *
  * @example
- * const island = ilha
- *   .state("errors", {} as FormErrors)
- *   .effect(({ el, state }) => {
- *     const formEl = el.querySelector("form")!;
- *     const form = createForm({
- *       el: formEl,
- *       schema: z.object({
- *         email: z.string().email(),
- *         name: z.string().min(1),
- *       }),
- *       defaultValues: { email: "ada@example.com" },
- *       onSubmit(values) {
- *         console.log(values);
- *       },
- *       onError(issues) {
- *         state.errors(issuesToErrors(issues));
- *       },
- *       validateOn: "change",
- *     });
- *     return form.mount();
- *   })
- *   .render(({ state }) => html`
- *     <form>
- *       <input name="email" />
- *       <input name="name" />
- *       <button>Submit</button>
- *     </form>
- *   `);
+ * const form = createForm({
+ *   el: formEl,
+ *   schema: z.object({ email: z.string().email(), name: z.string().min(1) }),
+ *   defaultValues: { email: "ada@example.com" },
+ *   onSubmit(values) { console.log(values); },
+ *   onError(issues) { state.errors(issuesToErrors(issues)); },
+ *   validateOn: "change",
+ * });
+ * return form.mount();
  */
 export function createForm<S extends StandardSchemaV1>(options: CreateFormOptions<S>): Form<S> {
   const { el, schema, onSubmit, onError, validateOn = "submit", defaultValues } = options;
@@ -368,19 +347,20 @@ export function createForm<S extends StandardSchemaV1>(options: CreateFormOption
 
     mount() {
       dirty = false;
+      currentErrors = {}; // always reset on every mount
 
-      // Tracks the latest value per field name — updated on every change/input
-      // event. After a re-render the observer restores this instead of the default.
+      // Tracks the latest value per field — seeded with defaults, updated on
+      // change/input. The MutationObserver restores these after re-renders so
+      // user-edited values survive DOM reconstruction.
       const trackedValues = new Map<string, string | string[]>();
 
       if (defaultValues) {
         for (const [name, value] of Object.entries(defaultValues)) {
           if (value !== undefined) {
             applyValueToField(el, name, value);
-            trackedValues.set(name, value); // seed with default
+            trackedValues.set(name, value);
           }
         }
-        currentErrors = {};
       }
 
       const listeners: Array<() => void> = [];
@@ -394,7 +374,6 @@ export function createForm<S extends StandardSchemaV1>(options: CreateFormOption
         listeners.push(() => target.removeEventListener(type, handler as EventListener));
       }
 
-      // Track value changes so we can restore them after re-renders
       function trackCurrentValues(): void {
         if (!defaultValues) return;
         for (const name of Object.keys(defaultValues)) {
@@ -405,8 +384,8 @@ export function createForm<S extends StandardSchemaV1>(options: CreateFormOption
           );
           if (elements.length === 0) continue;
           const first = elements[0]!;
+
           if (first instanceof HTMLInputElement && first.type === "checkbox") {
-            // array of checked values
             const checked = (elements as HTMLInputElement[])
               .filter((e) => e.checked)
               .map((e) => e.value);
@@ -414,6 +393,9 @@ export function createForm<S extends StandardSchemaV1>(options: CreateFormOption
           } else if (first instanceof HTMLInputElement && first.type === "radio") {
             const checked = (elements as HTMLInputElement[]).find((e) => e.checked);
             if (checked) trackedValues.set(name, checked.value);
+          } else if (first instanceof HTMLSelectElement && first.multiple) {
+            const selected = Array.from(first.selectedOptions).map((o) => o.value);
+            trackedValues.set(name, selected);
           } else if (!(first instanceof HTMLInputElement && first.type === "file")) {
             trackedValues.set(name, first.value);
           }
@@ -425,14 +407,11 @@ export function createForm<S extends StandardSchemaV1>(options: CreateFormOption
         trackCurrentValues();
         markDirty();
       });
+      on(el, "input", trackCurrentValues); // always track on input, regardless of validateOn
 
       if (validateOn === "change") on(el, "change", runFieldValidation);
-      if (validateOn === "input") {
-        on(el, "input", () => trackCurrentValues());
-        on(el, "input", runFieldValidation);
-      }
+      if (validateOn === "input") on(el, "input", runFieldValidation);
 
-      // After re-render, restore tracked values (user-changed or default)
       let observer: MutationObserver | null = null;
       if (defaultValues) {
         observer = new MutationObserver(() => {


### PR DESCRIPTION
Persistence that applies default values to untouched fields, and persists touched fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve user edits across DOM re-renders; reapply default values when fields reappear; reset errors and dirty state on remount; observer no longer restores values after unmount; observer is only active when default values are provided.

* **Tests**
  * Added comprehensive re-render resilience tests covering value preservation, default reapplication, checkbox/select groups, input-event edits, and observer lifecycle.

* **Documentation**
  * Updated mounting/observer examples and parameter descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->