### PR TITLE
chore(form): revalidate on any change after error in field

### DIFF
--- a/packages/form/src/index.test.ts
+++ b/packages/form/src/index.test.ts
@@ -1420,4 +1420,24 @@ describe("createForm — error clearing on fix", () => {
     unmount();
     cleanup(el);
   });
+
+  it("does not revalidate on input when there are no errors (validateOn: submit)", () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({
+      el,
+      schema: basicSchema,
+      onSubmit: () => {},
+      validateOn: "submit",
+    });
+    const unmount = form.mount();
+
+    // no prior submission — errors are empty
+    const input = setField(el, "email", "bad");
+    dispatch(input, "input");
+
+    // should stay empty — no proactive validation when clean
+    expect(form.errors()).toEqual({});
+    unmount();
+    cleanup(el);
+  });
 });

--- a/packages/form/src/index.test.ts
+++ b/packages/form/src/index.test.ts
@@ -1363,3 +1363,61 @@ describe("createForm — re-render resilience", () => {
     cleanup(el);
   });
 });
+
+describe("createForm — error clearing on fix", () => {
+  it("clears errors on change after failed submission", () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({ el, schema: basicSchema, onSubmit: () => {} });
+    const unmount = form.mount();
+
+    setField(el, "email", "bad");
+    submit(el);
+    expect(Object.keys(form.errors()).length).toBeGreaterThan(0);
+
+    const input = setField(el, "email", "ada@example.com");
+    setField(el, "name", "Ada");
+    dispatch(input, "change");
+
+    expect(form.errors()).toEqual({});
+    unmount();
+    cleanup(el);
+  });
+
+  it("clears errors on input keystroke after failed submission", () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({ el, schema: basicSchema, onSubmit: () => {} });
+    const unmount = form.mount();
+
+    setField(el, "email", "bad");
+    submit(el);
+    expect(Object.keys(form.errors()).length).toBeGreaterThan(0);
+
+    const input = setField(el, "email", "ada@example.com");
+    setField(el, "name", "Ada");
+    dispatch(input, "input");
+
+    expect(form.errors()).toEqual({});
+    unmount();
+    cleanup(el);
+  });
+
+  it("does not revalidate on change when there are no errors (validateOn: submit)", () => {
+    const el = makeForm(basicHtml);
+    const form = createForm({
+      el,
+      schema: basicSchema,
+      onSubmit: () => {},
+      validateOn: "submit",
+    });
+    const unmount = form.mount();
+
+    // no prior submission — errors are empty
+    const input = setField(el, "email", "bad");
+    dispatch(input, "change");
+
+    // should stay empty — no proactive validation when clean
+    expect(form.errors()).toEqual({});
+    unmount();
+    cleanup(el);
+  });
+});

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -421,6 +421,7 @@ export function createForm<S extends StandardSchemaV1>(options: CreateFormOption
 
       on(el, "input", () => {
         trackCurrentValues();
+        markDirty();
         if (validateOn === "input") {
           runFieldValidation();
         } else {

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -347,11 +347,8 @@ export function createForm<S extends StandardSchemaV1>(options: CreateFormOption
 
     mount() {
       dirty = false;
-      currentErrors = {}; // always reset on every mount
+      currentErrors = {};
 
-      // Tracks the latest value per field — seeded with defaults, updated on
-      // change/input. The MutationObserver restores these after re-renders so
-      // user-edited values survive DOM reconstruction.
       const trackedValues = new Map<string, string | string[]>();
 
       if (defaultValues) {
@@ -402,12 +399,21 @@ export function createForm<S extends StandardSchemaV1>(options: CreateFormOption
         }
       }
 
+      // Revalidate on change/input when there are active errors — clears stale
+      // error state as soon as the user fixes a field, regardless of validateOn.
+      function runFieldValidationIfErrors(): void {
+        if (Object.keys(currentErrors).length > 0) runFieldValidation();
+      }
+
       on(el, "submit", (e) => runSubmit(e as SubmitEvent));
       on(el, "change", () => {
         trackCurrentValues();
         markDirty();
       });
-      on(el, "input", trackCurrentValues); // always track on input, regardless of validateOn
+      on(el, "input", trackCurrentValues);
+
+      on(el, "change", runFieldValidationIfErrors);
+      on(el, "input", runFieldValidationIfErrors);
 
       if (validateOn === "change") on(el, "change", runFieldValidation);
       if (validateOn === "input") on(el, "input", runFieldValidation);

--- a/packages/form/src/index.ts
+++ b/packages/form/src/index.ts
@@ -70,9 +70,13 @@ export type FormErrors = Record<string, string[]>;
 /**
  * When to run schema validation automatically against field changes.
  *
- * - `"submit"` (default) — only on form submission
- * - `"change"` — on `change` events (after a field loses focus with a new value)
- * - `"input"` — on every `input` event (every keystroke)
+ * - `"submit"` (default) — defers validation to submission while the form is
+ *   clean (no active errors). Once a submission fails, the form automatically
+ *   revalidates on every `change` and `input` event until all errors are
+ *   cleared, at which point it returns to submit-only validation.
+ * - `"change"` — validates on every `change` event (and on `input` when errors
+ *   are active).
+ * - `"input"` — validates on every `input` event (every keystroke).
  */
 export type ValidateOn = "submit" | "change" | "input";
 
@@ -399,24 +403,30 @@ export function createForm<S extends StandardSchemaV1>(options: CreateFormOption
         }
       }
 
-      // Revalidate on change/input when there are active errors — clears stale
-      // error state as soon as the user fixes a field, regardless of validateOn.
       function runFieldValidationIfErrors(): void {
         if (Object.keys(currentErrors).length > 0) runFieldValidation();
       }
 
       on(el, "submit", (e) => runSubmit(e as SubmitEvent));
+
       on(el, "change", () => {
         trackCurrentValues();
         markDirty();
+        if (validateOn === "change") {
+          runFieldValidation();
+        } else {
+          runFieldValidationIfErrors();
+        }
       });
-      on(el, "input", trackCurrentValues);
 
-      on(el, "change", runFieldValidationIfErrors);
-      on(el, "input", runFieldValidationIfErrors);
-
-      if (validateOn === "change") on(el, "change", runFieldValidation);
-      if (validateOn === "input") on(el, "input", runFieldValidation);
+      on(el, "input", () => {
+        trackCurrentValues();
+        if (validateOn === "input") {
+          runFieldValidation();
+        } else {
+          runFieldValidationIfErrors();
+        }
+      });
 
       let observer: MutationObserver | null = null;
       if (defaultValues) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Forms now clear validation errors when users fix previously invalid fields by typing or changing values; after a failed submit the form will revalidate on subsequent input/change until errors are cleared.

* **Tests**
  * Added tests covering error-clearing behavior and ensuring validateOn modes do not trigger proactive validation before a failed submit.

* **Documentation**
  * Clarified validateOn semantics for submit/change/input and conditional revalidation after a failed submit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->