### PR TITLE
feat(router): add loaders for pages and layouts

### DIFF
--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -85,9 +85,21 @@ Returns a `RouterBuilder`.
 
 ---
 
-#### `.route(pattern, island)`
+#### `.route(pattern, island, loader?)`
 
 Registers a route. Patterns are matched in **declaration order** — first match wins. Uses [rou3](https://github.com/h3js/rou3) for matching, the same engine as Nitro.
+
+The optional `loader` is a data-fetching function that runs before the page renders. Its return value is passed as input props to the island. On the client, loaders are fetched via the `/_ilha/loader` endpoint exposed by the Vite plugin.
+
+```ts
+import { loader } from "@ilha/router";
+
+const userLoader = loader(async ({ params }) => {
+  return { user: await fetchUser(params.id) };
+});
+
+router().route("/user/:id", userPage, userLoader).mount("#app");
+```
 
 | Pattern         | Matches             | `routeParams()`                   |
 | --------------- | ------------------- | --------------------------------- |
@@ -141,9 +153,9 @@ Renders `<div data-router-empty></div>` when no route matches.
 
 ---
 
-#### `.renderHydratable(url, registry, options?)` — server / SSR
+#### `.renderHydratable(url, registry, options?, request?)` — server / SSR
 
-Async variant of `.render()` that outputs HTML with `data-ilha` hydration markers so the client can rehydrate without a full re-render.
+Async variant of `.render()` that outputs HTML with `data-ilha` hydration markers so the client can rehydrate without a full re-render. If a loader is registered for the matched route, it runs first and its return value is passed as input props to the island. Redirects from loaders are encoded as a `<meta http-equiv="refresh">` tag; prefer `.renderResponse()` to handle redirects at the HTTP layer.
 
 ```ts
 const html = await router().route("/", homePage).renderHydratable("/", registry);
@@ -157,6 +169,53 @@ If the active island is not found in the registry, falls back to plain SSR and e
 | Option     | Type      | Default | Description                                           |
 | ---------- | --------- | ------- | ----------------------------------------------------- |
 | `snapshot` | `boolean` | `true`  | Embed island state as `data-ilha-state` for hydration |
+
+---
+
+#### `.renderResponse(url, registry, options?, request?)` — server / SSR
+
+Structured-envelope variant of `.renderHydratable()`. Returns a `RenderResponse` discriminated union instead of a raw HTML string, so the host server can emit proper HTTP status codes for redirects and errors rather than baking them into the HTML.
+
+```ts
+const res = await router()
+  .route("/protected", protectedPage, authLoader)
+  .renderResponse("/protected", registry);
+
+if (res.kind === "redirect") {
+  return Response.redirect(res.to, res.status);
+}
+if (res.kind === "error") {
+  return new Response(res.html, { status: res.status });
+}
+return new Response(res.html, { headers: { "content-type": "text/html" } });
+```
+
+| `kind`       | Fields                                              | When                                       |
+| ------------ | --------------------------------------------------- | ------------------------------------------ |
+| `"html"`     | `html: string`, `status?: number`                   | Normal render; `status` is 404 if no match |
+| `"redirect"` | `to: string`, `status: number`                      | Loader called `redirect()`                 |
+| `"error"`    | `status: number`, `message: string`, `html: string` | Loader called `error()`                    |
+
+---
+
+#### `.runLoader(url, request?)` — server / SSR
+
+Runs the loader chain for the matched route without rendering any HTML. Returns a discriminated union result. Used by the `/_ilha/loader` endpoint the Vite plugin exposes for client-side navigation.
+
+```ts
+const result = await router().route("/user/:id", userPage, userLoader).runLoader("/user/42");
+
+if (result.kind === "data") {
+  console.log(result.data); // → { user: { id: "42" } }
+}
+```
+
+| `kind`        | Fields                              | When                             |
+| ------------- | ----------------------------------- | -------------------------------- |
+| `"data"`      | `data: Record<string, unknown>`     | Loader succeeded (or no loader)  |
+| `"redirect"`  | `to: string`, `status: number`      | Loader called `redirect()`       |
+| `"error"`     | `status: number`, `message: string` | Loader called `error()` or threw |
+| `"not-found"` | —                                   | No route matched the URL         |
 
 ---
 
@@ -220,6 +279,102 @@ import { prime } from "@ilha/router";
 
 prime();
 ```
+
+---
+
+### `loader(fn)`
+
+Identity function for declaring a typed data loader. Exists as a type anchor and as a marker the Vite plugin uses to detect exported loaders automatically. The loader receives a `LoaderContext` and must return a plain object (or a `Promise` of one).
+
+```ts
+import { loader } from "@ilha/router";
+
+export const load = loader(async ({ params, request, url, signal }) => {
+  const user = await fetchUser(params.id, { signal });
+  return { user };
+});
+```
+
+Inside a loader, call `redirect()` or `error()` to short-circuit rendering:
+
+```ts
+import { loader, redirect, error } from "@ilha/router";
+
+export const load = loader(async ({ params }) => {
+  const session = await getSession();
+  if (!session) redirect("/login", 302);
+  const post = await getPost(params.id);
+  if (!post) error(404, "Post not found");
+  return { post };
+});
+```
+
+Returns `fn` unchanged.
+
+---
+
+### `redirect(to, status?)`
+
+Throws a `Redirect` sentinel that is caught by the loader execution pipeline. Always use inside a loader — do not catch it yourself.
+
+```ts
+import { redirect } from "@ilha/router";
+
+redirect("/login"); // 302 by default
+redirect("/moved", 301); // permanent redirect
+```
+
+---
+
+### `error(status, message)`
+
+Throws a `LoaderError` sentinel that is caught by the loader execution pipeline. The rendered output will be an inline error element; use `.renderResponse()` on the server to intercept loader errors before they reach the HTML layer.
+
+```ts
+import { error } from "@ilha/router";
+
+error(404, "Not found");
+error(403, "Forbidden");
+```
+
+---
+
+### `composeLoaders(...loaders)`
+
+Merges multiple loaders into a single loader. All loaders run **concurrently** via `Promise.all`. Later loaders win on key collision — the page loader overrides a layout loader for the same key.
+
+Used internally by the Vite plugin to compose layout loaders with the page loader. Also available for manual composition.
+
+```ts
+import { composeLoaders, loader } from "@ilha/router";
+
+const layoutLoader = loader(async () => ({ user: await getCurrentUser() }));
+const pageLoader = loader(async ({ params }) => ({ post: await getPost(params.id) }));
+
+const combined = composeLoaders(layoutLoader, pageLoader);
+// → { user: …, post: … }
+```
+
+If any loader in the chain throws a `Redirect` or `LoaderError`, the composed loader re-throws it immediately.
+
+---
+
+### `prefetch(pathWithSearch)`
+
+Prefetches the loader data for a given path by calling the `/_ilha/loader` endpoint in the background. The result is cached and consumed on the next navigation to that path, making the transition feel instant.
+
+Safe to call repeatedly — an in-flight request for the same path is reused until it resolves and is consumed, avoiding duplicate network requests.
+
+```ts
+import { prefetch } from "@ilha/router";
+
+prefetch("/user/42");
+prefetch("/dashboard?tab=overview");
+```
+
+No-op on the server, for paths with no registered loader, or for unmatched paths.
+
+`RouterLink` automatically calls `prefetch()` on `mouseenter` for links that carry the `data-prefetch` attribute (set by default). You can opt a specific link out with `data-prefetch="false"`.
 
 ---
 
@@ -298,13 +453,13 @@ RouterView.mount(el); // client
 
 ### `RouterLink`
 
-A declarative link island that calls `navigate()` on click.
+A declarative link island that calls `navigate()` on click. Automatically prefetches loader data for the target path on `mouseenter` (opt out per-link with `data-prefetch="false"`).
 
 ```ts
 import { RouterLink } from "@ilha/router";
 
 RouterLink.toString({ href: "/about", label: "About" });
-// → '<a data-link href="/about">About</a>'
+// → '<a data-link data-prefetch href="/about">About</a>'
 ```
 
 ---
@@ -359,6 +514,8 @@ const safe = wrapError(myErrorHandler, myPage);
 
 The nearest (innermost) `wrapError` boundary catches first. If the inner handler re-throws, the next outer boundary takes over.
 
+> **Note:** Error boundaries wrap the _page island's render_, not the loader. Loader errors (thrown via `error()`) are surfaced through `.renderResponse()` — they do not currently route through `+error.ts`. Use `.renderResponse()` on the server to handle loader errors at the HTTP layer.
+
 ---
 
 ## TypeScript Types
@@ -377,8 +534,28 @@ interface AppError {
   stack?: string;
 }
 
+interface LoaderContext {
+  params: Record<string, string>;
+  request: Request;
+  url: URL;
+  signal: AbortSignal;
+}
+
+type Loader<T> = (ctx: LoaderContext) => Promise<T> | T;
+
+// Extract the return type of a loader
+type InferLoader<L> = L extends Loader<infer T> ? Awaited<T> : never;
+
+// Merge multiple loader return types — later loaders win on key collision
+type MergeLoaders<Ls extends readonly Loader<any>[]> = /* … */;
+
 type LayoutHandler = (children: Island) => Island;
 type ErrorHandler = (error: AppError, route: RouteSnapshot) => Island;
+
+type RenderResponse =
+  | { kind: "html"; html: string; status?: number }
+  | { kind: "redirect"; to: string; status: number }
+  | { kind: "error"; status: number; message: string; html: string };
 
 interface NavigateOptions {
   replace?: boolean;
@@ -396,6 +573,18 @@ interface HydrateOptions {
 
 // Helper — returns fn as-is with LayoutHandler type enforced
 function defineLayout(fn: LayoutHandler): LayoutHandler;
+
+// Identity — type anchor and Vite plugin marker
+function loader<T>(fn: Loader<T>): Loader<T>;
+
+// Throws a Redirect sentinel — use inside loaders only
+function redirect(to: string, status?: number): never;
+
+// Throws a LoaderError sentinel — use inside loaders only
+function error(status: number, message: string): never;
+
+// Merges loaders — later loaders win on key collision
+function composeLoaders<Ls extends readonly Loader<any>[]>(...loaders: Ls): Loader<MergeLoaders<Ls>>;
 ```
 
 ---
@@ -543,6 +732,42 @@ src/pages/
   about.ts            ← wrapped by root layout only
 ```
 
+### Page loaders
+
+A page file can export a `loader` alongside its default island export. The Vite plugin automatically detects the named `loader` export, composes it with any layout loaders in the chain (outermost layout first, page last), and passes the merged result as input props to the island.
+
+```ts
+// src/pages/user/[id].ts
+import { loader } from "@ilha/router";
+import ilha from "ilha";
+
+export const load = loader(async ({ params }) => {
+  const user = await fetchUser(params.id);
+  return { user };
+});
+
+export default ilha.input<{ user: User }>().render((input) => `<h1>${input.user.name}</h1>`);
+```
+
+The `load` export must be declared with the `loader()` helper so the Vite plugin can identify it via export name.
+
+### Layout loaders
+
+A `+layout.ts` can also export a loader. Layout loaders run concurrently with the page loader. The page loader wins on key collision.
+
+```ts
+// src/pages/+layout.ts
+import { defineLayout, loader } from "@ilha/router";
+
+export const load = loader(async () => {
+  return { currentUser: await getCurrentUser() };
+});
+
+export default defineLayout((children) => /* … */);
+```
+
+Layout loaders are composed automatically — you do not need to call `composeLoaders()` manually.
+
 ### Error boundaries
 
 A `+error.ts` catches any error thrown during rendering of pages in its directory and all subdirectories. The nearest boundary wins. If an inner boundary re-throws, the next outer boundary takes over. Receives the error and the current route snapshot.
@@ -633,6 +858,21 @@ renderHydratable(url, registry)  pageRouter.prime()        ← sync signals firs
 ```
 
 Or use the one-liner: `pageRouter.hydrate(registry)`.
+
+### Loader data flow
+
+On the **server**, loaders run inside `.renderHydratable()` / `.renderResponse()`. Their return value is serialised into `data-ilha-props` on the island element so the client can rehydrate without re-fetching.
+
+On the **client**, navigations fetch loader data from the `/_ilha/loader` endpoint before mounting the next island. The endpoint is served automatically by the Vite plugin (dev) and the Nitro adapter (production). `RouterLink` and `prefetch()` both call this endpoint proactively on hover so the data is already in cache when the user clicks.
+
+```
+server                         client (navigation)
+────────────────────────────   ──────────────────────────────────────────────
+renderHydratable               GET /_ilha/loader?path=/user/42
+  → executeLoader(…)             → runLoader("/user/42")
+  → island.hydratable(props)     → fetchLoaderData("/user/42")
+  → data-ilha-props="{…}"        → mountRouteWithHydration(island, host, …)
+```
 
 ---
 

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -89,7 +89,7 @@ Returns a `RouterBuilder`.
 
 Registers a route. Patterns are matched in **declaration order** — first match wins. Uses [rou3](https://github.com/h3js/rou3) for matching, the same engine as Nitro.
 
-The optional `loader` is a data-fetching function that runs before the page renders. Its return value is passed as input props to the island. On the client, loaders are fetched via the `/_ilha/loader` endpoint exposed by the Vite plugin.
+The optional `loader` is a data-fetching function that runs before the page renders. Its return value is passed as input props to the island. On the client, loaders are fetched via the `/__ilha/loader` endpoint exposed by the Vite plugin.
 
 ```ts
 import { loader } from "@ilha/router";
@@ -200,7 +200,7 @@ return new Response(res.html, { headers: { "content-type": "text/html" } });
 
 #### `.runLoader(url, request?)` — server / SSR
 
-Runs the loader chain for the matched route without rendering any HTML. Returns a discriminated union result. Used by the `/_ilha/loader` endpoint the Vite plugin exposes for client-side navigation.
+Runs the loader chain for the matched route without rendering any HTML. Returns a discriminated union result. Used by the `/__ilha/loader` endpoint the Vite plugin exposes for client-side navigation.
 
 ```ts
 const result = await router().route("/user/:id", userPage, userLoader).runLoader("/user/42");
@@ -339,7 +339,7 @@ error(403, "Forbidden");
 
 ---
 
-### `composeLoaders(...loaders)`
+### `composeLoaders(loaders)`
 
 Merges multiple loaders into a single loader. All loaders run **concurrently** via `Promise.all`. Later loaders win on key collision — the page loader overrides a layout loader for the same key.
 
@@ -351,7 +351,7 @@ import { composeLoaders, loader } from "@ilha/router";
 const layoutLoader = loader(async () => ({ user: await getCurrentUser() }));
 const pageLoader = loader(async ({ params }) => ({ post: await getPost(params.id) }));
 
-const combined = composeLoaders(layoutLoader, pageLoader);
+const combined = composeLoaders([layoutLoader, pageLoader]);
 // → { user: …, post: … }
 ```
 
@@ -361,7 +361,7 @@ If any loader in the chain throws a `Redirect` or `LoaderError`, the composed lo
 
 ### `prefetch(pathWithSearch)`
 
-Prefetches the loader data for a given path by calling the `/_ilha/loader` endpoint in the background. The result is cached and consumed on the next navigation to that path, making the transition feel instant.
+Prefetches the loader data for a given path by calling the `/__ilha/loader` endpoint in the background. The result is cached and consumed on the next navigation to that path, making the transition feel instant.
 
 Safe to call repeatedly — an in-flight request for the same path is reused until it resolves and is consumed, avoiding duplicate network requests.
 
@@ -584,7 +584,7 @@ function redirect(to: string, status?: number): never;
 function error(status: number, message: string): never;
 
 // Merges loaders — later loaders win on key collision
-function composeLoaders<Ls extends readonly Loader<any>[]>(...loaders: Ls): Loader<MergeLoaders<Ls>>;
+function composeLoaders<Ls extends readonly Loader<any>[]>(loaders: Ls): Loader<MergeLoaders<Ls>>;
 ```
 
 ---
@@ -863,12 +863,12 @@ Or use the one-liner: `pageRouter.hydrate(registry)`.
 
 On the **server**, loaders run inside `.renderHydratable()` / `.renderResponse()`. Their return value is serialised into `data-ilha-props` on the island element so the client can rehydrate without re-fetching.
 
-On the **client**, navigations fetch loader data from the `/_ilha/loader` endpoint before mounting the next island. The endpoint is served automatically by the Vite plugin (dev) and the Nitro adapter (production). `RouterLink` and `prefetch()` both call this endpoint proactively on hover so the data is already in cache when the user clicks.
+On the **client**, navigations fetch loader data from the `/__ilha/loader` endpoint before mounting the next island. The endpoint is served automatically by the Vite plugin (dev) and the Nitro adapter (production). `RouterLink` and `prefetch()` both call this endpoint proactively on hover so the data is already in cache when the user clicks.
 
 ```
 server                         client (navigation)
 ────────────────────────────   ──────────────────────────────────────────────
-renderHydratable               GET /_ilha/loader?path=/user/42
+renderHydratable               GET /__ilha/loader?path=/user/42
   → executeLoader(…)             → runLoader("/user/42")
   → island.hydratable(props)     → fetchLoaderData("/user/42")
   → data-ilha-props="{…}"        → mountRouteWithHydration(island, host, …)

--- a/packages/router/src/index.test.ts
+++ b/packages/router/src/index.test.ts
@@ -13,11 +13,38 @@ import {
   routeParams,
   routeSearch,
   defineLayout,
+  loader,
+  redirect,
+  Redirect,
+  error,
+  LoaderError,
+  composeLoaders,
+  prefetch,
+  RouterLink,
 } from "./index";
 
 // ─────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────
+
+// Simple schema helper for tests - creates a StandardSchemaV1 compatible schema
+function createSchema<T>(): {
+  "~standard": {
+    version: 1;
+    vendor: "test";
+    types: { input: T; output: T };
+    validate: (value: unknown) => { value: T };
+  };
+} {
+  return {
+    "~standard": {
+      version: 1 as const,
+      vendor: "test",
+      types: undefined as unknown as { input: any; output: any },
+      validate: (value: unknown) => ({ value: value as any }),
+    },
+  } as any;
+}
 
 function makeEl(inner = ""): Element {
   const el = document.createElement("div");
@@ -1010,5 +1037,573 @@ describe("defineLayout()", () => {
     expect(html).toContain("<p>page</p>");
     expect(html.indexOf("<outer>")).toBeLessThan(html.indexOf("<inner>"));
     expect(html.indexOf("<inner>")).toBeLessThan(html.indexOf("<p>page</p>"));
+  });
+});
+
+// ─────────────────────────────────────────────
+// loader() identity + type anchor
+// ─────────────────────────────────────────────
+
+describe("loader()", () => {
+  it("returns the function unchanged (identity)", () => {
+    const fn = async () => ({ x: 1 });
+    expect(loader(fn)).toBe(fn);
+  });
+
+  it("works with sync loaders", () => {
+    const fn = () => ({ x: 1 });
+    expect(loader(fn)).toBe(fn);
+  });
+});
+
+// ─────────────────────────────────────────────
+// redirect() / error() sentinels
+// ─────────────────────────────────────────────
+
+describe("redirect()", () => {
+  it("throws a Redirect instance", () => {
+    expect(() => redirect("/login")).toThrow();
+    try {
+      redirect("/login");
+    } catch (e) {
+      expect(e).toBeInstanceOf(Redirect);
+    }
+  });
+
+  it("defaults to status 302", () => {
+    try {
+      redirect("/login");
+    } catch (e: any) {
+      expect(e.status).toBe(302);
+      expect(e.to).toBe("/login");
+    }
+  });
+
+  it("accepts a custom status", () => {
+    try {
+      redirect("/new", 301);
+    } catch (e: any) {
+      expect(e.status).toBe(301);
+    }
+  });
+
+  it("Redirect instances have the __ilhaRedirect marker", () => {
+    try {
+      redirect("/x");
+    } catch (e: any) {
+      expect(e.__ilhaRedirect).toBe(true);
+    }
+  });
+});
+
+describe("error()", () => {
+  it("throws a LoaderError instance", () => {
+    expect(() => error(404, "not found")).toThrow();
+    try {
+      error(404, "not found");
+    } catch (e) {
+      expect(e).toBeInstanceOf(LoaderError);
+    }
+  });
+
+  it("carries status and message", () => {
+    try {
+      error(403, "forbidden");
+    } catch (e: any) {
+      expect(e.status).toBe(403);
+      expect(e.message).toBe("forbidden");
+    }
+  });
+
+  it("LoaderError instances have the __ilhaLoaderError marker", () => {
+    try {
+      error(500, "oops");
+    } catch (e: any) {
+      expect(e.__ilhaLoaderError).toBe(true);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────
+// composeLoaders() — merges layout + page loaders
+// ─────────────────────────────────────────────
+
+describe("composeLoaders()", () => {
+  const ctx = () => ({
+    params: {},
+    request: new Request("http://localhost/"),
+    url: new URL("http://localhost/"),
+    signal: new AbortController().signal,
+  });
+
+  it("returns an empty object for an empty list", async () => {
+    const composed = composeLoaders([] as const);
+    expect(await composed(ctx())).toEqual({});
+  });
+
+  it("returns the single loader unchanged when given one", () => {
+    const fn = async () => ({ x: 1 });
+    expect(composeLoaders([fn])).toBe(fn);
+  });
+
+  it("merges results from multiple loaders", async () => {
+    const a = async () => ({ a: 1 });
+    const b = async () => ({ b: 2 });
+    const composed = composeLoaders([a, b]);
+    expect(await composed(ctx())).toEqual({ a: 1, b: 2 });
+  });
+
+  it("later loader wins on key collision (page overrides layout)", async () => {
+    const layout = async () => ({ user: "layout-user", extra: 1 });
+    const page = async () => ({ user: "page-user" });
+    const composed = composeLoaders([layout, page]);
+    const result = await composed(ctx());
+    expect(result).toEqual({ user: "page-user", extra: 1 });
+  });
+
+  it("runs loaders in parallel (concurrent, not sequential)", async () => {
+    const order: string[] = [];
+    const slow = async () => {
+      order.push("slow-start");
+      await new Promise((r) => setTimeout(r, 30));
+      order.push("slow-end");
+      return { slow: true };
+    };
+    const fast = async () => {
+      order.push("fast-start");
+      await new Promise((r) => setTimeout(r, 5));
+      order.push("fast-end");
+      return { fast: true };
+    };
+    await composeLoaders([slow, fast])(ctx());
+    // Both starts happen before either end — proves parallelism
+    expect(order.indexOf("slow-start")).toBeLessThan(order.indexOf("fast-end"));
+    expect(order.indexOf("fast-start")).toBeLessThan(order.indexOf("slow-end"));
+  });
+
+  it("passes the same ctx to all loaders", async () => {
+    const seen: any[] = [];
+    const a = async (c: any) => {
+      seen.push(c);
+      return {};
+    };
+    const b = async (c: any) => {
+      seen.push(c);
+      return {};
+    };
+    const c = ctx();
+    await composeLoaders([a, b])(c);
+    expect(seen[0]).toBe(c);
+    expect(seen[1]).toBe(c);
+  });
+
+  it("propagates a Redirect thrown by any loader", async () => {
+    const ok = async () => ({ a: 1 });
+    const redirects = async () => {
+      redirect("/login");
+    };
+    await expect(composeLoaders([ok, redirects])(ctx())).rejects.toBeInstanceOf(Redirect);
+  });
+
+  it("propagates a LoaderError thrown by any loader", async () => {
+    const ok = async () => ({ a: 1 });
+    const errs = async () => {
+      error(404, "nope");
+    };
+    await expect(composeLoaders([ok, errs])(ctx())).rejects.toBeInstanceOf(LoaderError);
+  });
+
+  it("tolerates null/undefined loader return (treats as empty)", async () => {
+    // Loaders should generally return objects, but undefined should not corrupt the merge.
+    const a = async () => ({ a: 1 });
+    const b = async () => undefined as any;
+    const composed = composeLoaders([a, b]);
+    const result = await composed(ctx());
+    expect(result).toEqual({ a: 1 });
+  });
+});
+
+// ─────────────────────────────────────────────
+// router.runLoader() — the loader endpoint entry
+// ─────────────────────────────────────────────
+
+describe("router.runLoader()", () => {
+  it("returns { kind: 'data', data: {} } for routes without a loader", async () => {
+    const r = router().route("/", homePage);
+    const result = await r.runLoader("/");
+    expect(result).toEqual({ kind: "data", data: {} });
+  });
+
+  it("returns { kind: 'not-found' } for unmatched paths", async () => {
+    const r = router().route("/", homePage);
+    const result = await r.runLoader("/missing");
+    expect(result).toEqual({ kind: "not-found" });
+  });
+
+  it("runs the loader and returns its data", async () => {
+    const load = loader(async () => ({ user: "alice" }));
+    const r = router().route("/", homePage, load);
+    const result = await r.runLoader("/");
+    expect(result).toEqual({ kind: "data", data: { user: "alice" } });
+  });
+
+  it("passes decoded params to the loader", async () => {
+    const captured: any[] = [];
+    const load = loader(async (c) => {
+      captured.push(c.params);
+      return { id: c.params.id };
+    });
+    const r = router().route("/user/:id", userPage, load);
+    const result = await r.runLoader("/user/42");
+    expect(captured[0]).toEqual({ id: "42" });
+    expect(result).toEqual({ kind: "data", data: { id: "42" } });
+  });
+
+  it("decodes URL-encoded params before passing to loader", async () => {
+    const captured: any[] = [];
+    const load = loader(async (c) => {
+      captured.push(c.params);
+      return {};
+    });
+    const r = router().route("/user/:id", userPage, load);
+    await r.runLoader("/user/hello%20world");
+    expect(captured[0]).toEqual({ id: "hello world" });
+  });
+
+  it("passes the URL object to the loader", async () => {
+    let capturedUrl: URL | undefined;
+    const load = loader(async (c) => {
+      capturedUrl = c.url;
+      return {};
+    });
+    const r = router().route("/about", aboutPage, load);
+    await r.runLoader("/about?tab=docs");
+    expect(capturedUrl).toBeInstanceOf(URL);
+    expect(capturedUrl!.pathname).toBe("/about");
+    expect(capturedUrl!.search).toBe("?tab=docs");
+  });
+
+  it("provides an AbortSignal to the loader", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const load = loader(async (c) => {
+      capturedSignal = c.signal;
+      return {};
+    });
+    const r = router().route("/", homePage, load);
+    await r.runLoader("/");
+    expect(capturedSignal).toBeDefined();
+    expect(typeof capturedSignal!.aborted).toBe("boolean");
+  });
+
+  it("forwards the supplied Request to the loader", async () => {
+    let capturedRequest: Request | undefined;
+    const load = loader(async (c) => {
+      capturedRequest = c.request;
+      return {};
+    });
+    const r = router().route("/", homePage, load);
+    const req = new Request("http://example.com/", { headers: { "x-custom": "yes" } });
+    await r.runLoader("/", req);
+    expect(capturedRequest).toBe(req);
+  });
+
+  it("synthesises a Request when none is supplied", async () => {
+    let capturedRequest: Request | undefined;
+    const load = loader(async (c) => {
+      capturedRequest = c.request;
+      return {};
+    });
+    const r = router().route("/", homePage, load);
+    await r.runLoader("http://example.com/");
+    expect(capturedRequest).toBeDefined();
+  });
+
+  it("catches redirect() and returns { kind: 'redirect' }", async () => {
+    const load = loader(async () => {
+      redirect("/login", 301);
+    });
+    const r = router().route("/", homePage, load);
+    const result = await r.runLoader("/");
+    expect(result).toEqual({ kind: "redirect", to: "/login", status: 301 });
+  });
+
+  it("catches error() and returns { kind: 'error' }", async () => {
+    const load = loader(async () => {
+      error(404, "not found");
+    });
+    const r = router().route("/", homePage, load);
+    const result = await r.runLoader("/");
+    expect(result).toEqual({ kind: "error", status: 404, message: "not found" });
+  });
+
+  it("catches generic thrown errors as 500", async () => {
+    const load = loader(async () => {
+      throw new Error("boom");
+    });
+    const r = router().route("/", homePage, load);
+    const result = await r.runLoader("/");
+    expect(result).toEqual({ kind: "error", status: 500, message: "boom" });
+  });
+
+  it("honours error.status on generic thrown errors", async () => {
+    const load = loader(async () => {
+      const e: any = new Error("bad");
+      e.status = 418;
+      throw e;
+    });
+    const r = router().route("/", homePage, load);
+    const result = await r.runLoader("/");
+    expect(result).toEqual({ kind: "error", status: 418, message: "bad" });
+  });
+
+  it("accepts a URL object as the first argument", async () => {
+    const load = loader(async () => ({ ok: true }));
+    const r = router().route("/", homePage, load);
+    const result = await r.runLoader(new URL("http://example.com/"));
+    expect(result).toEqual({ kind: "data", data: { ok: true } });
+  });
+});
+
+// ─────────────────────────────────────────────
+// router.renderHydratable() — loader-fed input
+// ─────────────────────────────────────────────
+
+describe("renderHydratable() with loader", () => {
+  const greeter = ilha
+    .input(createSchema<{ name?: string }>())
+    .render(({ input }) => `<p>hello ${input.name ?? "stranger"}</p>`);
+
+  it("feeds loader output into the island as input", async () => {
+    const load = loader(async () => ({ name: "world" }));
+    const html = await router().route("/", greeter, load).renderHydratable("/", { greeter });
+    expect(html).toContain("hello world");
+  });
+
+  it("loader receives params from the matched route", async () => {
+    const userIsland = ilha
+      .input(createSchema<{ id?: string }>())
+      .render(({ input }) => `<p>u:${input.id ?? "?"}</p>`);
+    const load = loader(async ({ params }) => ({ id: params.id }));
+    const html = await router()
+      .route("/user/:id", userIsland, load)
+      .renderHydratable("/user/7", { u: userIsland });
+    expect(html).toContain("u:7");
+  });
+
+  it("renders empty-route HTML when no route matches (loader not invoked)", async () => {
+    let called = false;
+    const load = loader(async () => {
+      called = true;
+      return {};
+    });
+    const html = await router().route("/", greeter, load).renderHydratable("/missing", { greeter });
+    expect(html).toContain("data-router-empty");
+    expect(called).toBe(false);
+  });
+
+  it("routes without loaders still render (backward-compat)", async () => {
+    const html = await router().route("/", homePage).renderHydratable("/", registry);
+    expect(html).toContain("home");
+  });
+
+  it("forwards the supplied Request to the loader", async () => {
+    let captured: Request | undefined;
+    const load = loader(async ({ request }) => {
+      captured = request;
+      return {};
+    });
+    const req = new Request("http://example.com/", { headers: { "x-trace": "abc" } });
+    await router().route("/", greeter, load).renderHydratable("/", { greeter }, {}, req);
+    expect(captured).toBe(req);
+  });
+
+  it("loader data appears in data-ilha-props when snapshot is on", async () => {
+    const load = loader(async () => ({ name: "alice" }));
+    const html = await router()
+      .route("/", greeter, load)
+      .renderHydratable("/", { greeter }, { snapshot: true });
+    // Loader return is the island's input — ilha serialises it in data-ilha-props
+    expect(html).toContain("data-ilha-props");
+    expect(html).toContain("alice");
+  });
+
+  it("renders meta-refresh for redirects (string-return compat)", async () => {
+    const load = loader(async () => {
+      redirect("/login");
+    });
+    const html = await router().route("/", greeter, load).renderHydratable("/", { greeter });
+    expect(html).toContain('meta http-equiv="refresh"');
+    expect(html).toContain("/login");
+  });
+});
+
+// ─────────────────────────────────────────────
+// router.renderResponse() — structured envelope
+// ─────────────────────────────────────────────
+
+describe("renderResponse()", () => {
+  const greeter = ilha
+    .input(createSchema<{ name?: string }>())
+    .render(({ input }) => `<p>hi ${input.name ?? "anon"}</p>`);
+
+  it("returns { kind: 'html' } for successful renders", async () => {
+    const load = loader(async () => ({ name: "bob" }));
+    const res = await router().route("/", greeter, load).renderResponse("/", { greeter });
+    expect(res.kind).toBe("html");
+    if (res.kind === "html") {
+      expect(res.html).toContain("hi bob");
+    }
+  });
+
+  it("returns { kind: 'redirect' } when loader calls redirect()", async () => {
+    const load = loader(async () => {
+      redirect("/signin", 307);
+    });
+    const res = await router()
+      .route("/protected", greeter, load)
+      .renderResponse("/protected", { greeter });
+    expect(res).toEqual({ kind: "redirect", to: "/signin", status: 307 });
+  });
+
+  it("returns { kind: 'error' } when loader calls error()", async () => {
+    const load = loader(async () => {
+      error(404, "gone");
+    });
+    const res = await router().route("/", greeter, load).renderResponse("/", { greeter });
+    expect(res.kind).toBe("error");
+    if (res.kind === "error") {
+      expect(res.status).toBe(404);
+      expect(res.message).toBe("gone");
+      expect(typeof res.html).toBe("string");
+    }
+  });
+
+  it("returns { kind: 'html', status: 404 } for unmatched routes", async () => {
+    const res = await router().route("/", greeter).renderResponse("/nowhere", { greeter });
+    expect(res.kind).toBe("html");
+    if (res.kind === "html") {
+      expect(res.status).toBe(404);
+      expect(res.html).toContain("data-router-empty");
+    }
+  });
+
+  it("renders html without invoking a loader when none is registered", async () => {
+    const res = await router().route("/", homePage).renderResponse("/", registry);
+    expect(res.kind).toBe("html");
+    if (res.kind === "html") expect(res.html).toContain("home");
+  });
+});
+
+// ─────────────────────────────────────────────
+// route() — backward compatibility with 2-arg form
+// ─────────────────────────────────────────────
+
+describe("route() backward compatibility", () => {
+  it("2-argument .route() still registers the route", () => {
+    const r = router().route("/", homePage).route("/about", aboutPage);
+    // Use isActive as a cheap probe that the route is registered
+    setLocation("/about");
+    // Need a sync that doesn't require .mount() — renderHydratable() does it
+    // but is async. Just check that runLoader reports data+island resolved.
+    return r.runLoader("/about").then((res) => {
+      expect(res.kind).toBe("data");
+    });
+  });
+
+  it("mixing loader and non-loader routes on the same builder works", async () => {
+    const load = loader(async () => ({ x: 1 }));
+    const r = router().route("/", homePage).route("/with-loader", homePage, load);
+
+    const a = await r.runLoader("/");
+    const b = await r.runLoader("/with-loader");
+    expect(a).toEqual({ kind: "data", data: {} });
+    expect(b).toEqual({ kind: "data", data: { x: 1 } });
+  });
+});
+
+// ─────────────────────────────────────────────
+// prefetch() — opt-out when no loader registered
+// ─────────────────────────────────────────────
+
+describe("prefetch()", () => {
+  let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">>;
+
+  beforeEach(() => {
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => {
+      return new Response(JSON.stringify({ kind: "data", data: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("does not fetch when the route has no loader", () => {
+    router().route("/no-loader-a", homePage); // no loader
+    prefetch("/no-loader-a");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch for unmatched paths", () => {
+    router().route(
+      "/has-loader",
+      homePage,
+      loader(async () => ({})),
+    );
+    prefetch("/not-a-route");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fetches the loader endpoint when the route has a loader", () => {
+    router().route(
+      "/pf-fetch",
+      homePage,
+      loader(async () => ({})),
+    );
+    prefetch("/pf-fetch");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const url = (fetchSpy.mock.calls[0] as any[])[0] as string;
+    expect(url).toContain("/__ilha/loader");
+    expect(url).toContain("path=");
+  });
+
+  it("is idempotent — second call with same path does not fetch again", () => {
+    router().route(
+      "/pf-idem",
+      homePage,
+      loader(async () => ({})),
+    );
+    prefetch("/pf-idem");
+    prefetch("/pf-idem");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("encodes the path into the query string", () => {
+    router().route(
+      "/pf-enc/:id",
+      homePage,
+      loader(async () => ({})),
+    );
+    prefetch("/pf-enc/abc?tab=reviews");
+    const url = (fetchSpy.mock.calls[0] as any[])[0] as string;
+    expect(url).toContain(encodeURIComponent("/pf-enc/abc?tab=reviews"));
+  });
+});
+
+// ─────────────────────────────────────────────
+// RouterLink — data-prefetch attribute + hover
+// ─────────────────────────────────────────────
+
+describe("RouterLink", () => {
+  it("renders with data-prefetch attribute and data-link marker", () => {
+    // RouterLink uses .state() so toString props don't seed state — the SSR
+    // markup carries the empty defaults. We just assert the static markers
+    // that enable click interception and hover prefetch are present.
+    const html = RouterLink.toString();
+    expect(html).toContain("data-prefetch");
+    expect(html).toContain("data-link");
   });
 });

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -16,6 +16,8 @@ const isBrowser = typeof window !== "undefined" && typeof document !== "undefine
 export interface RouteRecord {
   pattern: string;
   island: Island<any, any>;
+  /** Merged loader chain (layouts outer→inner, then page) — `undefined` if no loaders. */
+  loader?: Loader<any>;
 }
 
 export interface RouteSnapshot {
@@ -33,6 +35,105 @@ export interface AppError {
 
 export type LayoutHandler = (children: Island<any, any>) => Island<any, any>;
 export type ErrorHandler = (error: AppError, route: RouteSnapshot) => Island<any, any>;
+
+// ─────────────────────────────────────────────
+// Loader types
+// ─────────────────────────────────────────────
+
+export interface LoaderContext {
+  params: Record<string, string>;
+  request: Request;
+  url: URL;
+  signal: AbortSignal;
+}
+
+export type Loader<T> = (ctx: LoaderContext) => Promise<T> | T;
+
+/**
+ * Identity function for declaring a loader. Exists purely as a type anchor and
+ * a marker for the Vite plugin to detect by export name.
+ */
+export function loader<T>(fn: Loader<T>): Loader<T> {
+  return fn;
+}
+
+/** Extract the return type of a loader. */
+export type InferLoader<L> = L extends Loader<infer T> ? Awaited<T> : never;
+
+/**
+ * Merge multiple loader return types into a single object type.
+ * Later loaders override earlier ones on key collision — matching runtime merge.
+ *
+ * @example
+ * type PageInput = MergeLoaders<[typeof rootLayoutLoad, typeof sectionLayoutLoad, typeof pageLoad]>;
+ */
+export type MergeLoaders<Ls extends readonly Loader<any>[]> = Ls extends readonly [
+  infer First extends Loader<any>,
+  ...infer Rest extends readonly Loader<any>[],
+]
+  ? Rest extends readonly []
+    ? InferLoader<First>
+    : Omit<InferLoader<First>, keyof MergeLoaders<Rest>> & MergeLoaders<Rest>
+  : {};
+
+// ─────────────────────────────────────────────
+// Loader sentinels — redirect / error
+// ─────────────────────────────────────────────
+
+export class Redirect {
+  readonly __ilhaRedirect = true as const;
+  readonly to: string;
+  readonly status: number;
+  constructor(to: string, status: number = 302) {
+    this.to = to;
+    this.status = status;
+  }
+}
+
+export class LoaderError {
+  readonly __ilhaLoaderError = true as const;
+  readonly status: number;
+  readonly message: string;
+  constructor(status: number, message: string) {
+    this.status = status;
+    this.message = message;
+  }
+}
+
+export function redirect(to: string, status = 302): never {
+  throw new Redirect(to, status);
+}
+
+export function error(status: number, message: string): never {
+  throw new LoaderError(status, message);
+}
+
+// ─────────────────────────────────────────────
+// Merge loader chain — layouts outer→inner, then page
+// ─────────────────────────────────────────────
+
+/**
+ * Compose a list of loaders into a single loader. Later loaders win on key
+ * collision (page loader overrides layout loader for the same key). All loaders
+ * run concurrently within a chain since they share the same abort signal and
+ * request — re-fetching is cheap with a request-scoped cache (future work).
+ *
+ * For v1 we run them in parallel via `Promise.all`. If a loader throws a
+ * `Redirect` or `LoaderError`, the composed loader re-throws it unchanged.
+ */
+export function composeLoaders<Ls extends readonly Loader<any>[]>(
+  loaders: Ls,
+): Loader<MergeLoaders<Ls>> {
+  if (loaders.length === 0) return async () => ({}) as MergeLoaders<Ls>;
+  if (loaders.length === 1) return loaders[0] as Loader<MergeLoaders<Ls>>;
+
+  return async (ctx) => {
+    // Run all loaders in parallel. They share the same ctx/signal.
+    const results = await Promise.all(loaders.map((l) => l(ctx)));
+    // Shallow merge — later results win.
+    return Object.assign({}, ...results) as MergeLoaders<Ls>;
+  };
+}
 
 // ─────────────────────────────────────────────
 // Runtime helpers — wrapLayout / wrapError
@@ -101,8 +202,19 @@ export interface MountOptions {
   registry?: Record<string, Island<any, any>>;
 }
 
+/** Response envelope returned by `renderResponse` — lets the host app handle redirects. */
+export type RenderResponse =
+  | { kind: "html"; html: string; status?: number }
+  | { kind: "redirect"; to: string; status: number }
+  | { kind: "error"; status: number; message: string; html: string };
+
 export interface RouterBuilder {
-  route(pattern: string, island: Island<any, any>): RouterBuilder;
+  /**
+   * Register a route. The optional `loader` is the merged loader chain
+   * (layout loaders outer→inner followed by the page loader) produced by
+   * the FS-routing codegen.
+   */
+  route(pattern: string, island: Island<any, any>, loader?: Loader<any>): RouterBuilder;
   prime(): void;
   mount(target: string | Element, options?: MountOptions): () => void;
   render(url: string | URL): string;
@@ -110,7 +222,34 @@ export interface RouterBuilder {
     url: string | URL,
     registry: Record<string, Island<any, any>>,
     options?: HydratableRenderOptions,
+    request?: Request,
   ): Promise<string>;
+  /**
+   * Like `renderHydratable` but surfaces loader redirects and errors as
+   * structured responses instead of baking them into HTML. Prefer this from
+   * host server code so you can emit proper 302 / 4xx responses.
+   */
+  renderResponse(
+    url: string | URL,
+    registry: Record<string, Island<any, any>>,
+    options?: HydratableRenderOptions,
+    request?: Request,
+  ): Promise<RenderResponse>;
+  /**
+   * Run the loader chain for a given URL without rendering. Used by the
+   * `/__ilha/loader` endpoint the Vite plugin exposes for client-side
+   * navigation. Returns the raw loader result, a redirect sentinel, or an
+   * error sentinel.
+   */
+  runLoader(
+    url: string | URL,
+    request?: Request,
+  ): Promise<
+    | { kind: "data"; data: Record<string, unknown> }
+    | { kind: "redirect"; to: string; status: number }
+    | { kind: "error"; status: number; message: string }
+    | { kind: "not-found" }
+  >;
   /**
    * Hydrate the application - combines prime(), mount(), and router.mount() into one call.
    * @param registry - The island registry from ilha:registry
@@ -135,17 +274,90 @@ function buildReverseRegistry(
 }
 
 // ─────────────────────────────────────────────
+// Client-side loader data fetch
+// ─────────────────────────────────────────────
+
+/** Path of the loader endpoint served by the Vite plugin / production adapter. */
+export const LOADER_ENDPOINT = "/__ilha/loader";
+
+/** In-memory cache for prefetched loader data, keyed by path+search. */
+const prefetchCache = new Map<string, Promise<LoaderFetchResult>>();
+
+type LoaderFetchResult =
+  | { kind: "data"; data: Record<string, unknown> }
+  | { kind: "redirect"; to: string; status: number }
+  | { kind: "error"; status: number; message: string }
+  | { kind: "not-found" };
+
+async function fetchLoaderData(
+  pathWithSearch: string,
+  signal?: AbortSignal,
+): Promise<LoaderFetchResult> {
+  // Check prefetch cache first — if a prefetch is in flight, piggy-back on it.
+  const cached = prefetchCache.get(pathWithSearch);
+  if (cached) {
+    // Consume the cache entry — prefetches are single-use to avoid serving
+    // stale data across navigations.
+    prefetchCache.delete(pathWithSearch);
+    try {
+      return await cached;
+    } catch {
+      // Prefetch failed — fall through to a fresh fetch
+    }
+  }
+
+  const url = `${LOADER_ENDPOINT}?path=${encodeURIComponent(pathWithSearch)}`;
+  try {
+    const res = await fetch(url, { signal, headers: { accept: "application/json" } });
+    if (!res.ok) {
+      // Try to parse structured error; fall back to generic.
+      try {
+        const body = (await res.json()) as LoaderFetchResult;
+        if (body && typeof body === "object" && "kind" in body) return body;
+      } catch {
+        /* fall through */
+      }
+      return { kind: "error", status: res.status, message: res.statusText };
+    }
+    return (await res.json()) as LoaderFetchResult;
+  } catch (e: any) {
+    if (e?.name === "AbortError") throw e;
+    return { kind: "error", status: 0, message: e?.message ?? "network error" };
+  }
+}
+
+/**
+ * Prefetch loader data for a given path. Safe to call repeatedly — a single
+ * inflight request is reused until it either resolves (and is consumed by
+ * navigation) or is superseded by another prefetch.
+ */
+export function prefetch(pathWithSearch: string): void {
+  if (!isBrowser) return;
+  if (prefetchCache.has(pathWithSearch)) return;
+  // Don't prefetch routes that have no loader — nothing to fetch.
+  const pathOnly = pathWithSearch.split("?")[0];
+  const match = findRoute(_rou3, "GET", pathOnly);
+  if (!match?.data?.loader) return;
+  const promise = fetchLoaderData(pathWithSearch).catch((e) => {
+    return { kind: "error", status: 0, message: e?.message ?? "prefetch failed" } as const;
+  });
+  prefetchCache.set(pathWithSearch, promise);
+}
+
+// ─────────────────────────────────────────────
 // Client-side navigation hydration helper
 // ─────────────────────────────────────────────
 
 /**
  * Mounts a route island with proper hydration for client-side navigation.
- * Looks up the island in the reverse registry, renders it with hydration
- * markers, and mounts it for interactivity.
+ * Looks up the island in the reverse registry, runs the loader (via fetch),
+ * renders it with hydration markers, and mounts it for interactivity.
  */
 async function mountRouteWithHydration(
   island: Island<any, any> | null,
   host: Element,
+  pathWithSearch: string,
+  signal: AbortSignal,
   registry?: Record<string, Island<any, any>>,
   reverseRegistry?: Map<Island<any, any>, string>,
 ): Promise<() => void> {
@@ -154,12 +366,43 @@ async function mountRouteWithHydration(
     return () => {};
   }
 
+  // Fetch loader data *only if* the matched route has a loader registered.
+  // Routes registered client-side have `loader: undefined` when the Vite
+  // plugin emits server-only loader imports behind `import.meta.env.SSR`.
+  const clientMatch = findRoute(_rou3, "GET", pathWithSearch.split("?")[0]);
+  const hasLoader = !!clientMatch?.data?.loader;
+
+  let props: Record<string, unknown> = {};
+  const loaderResult: LoaderFetchResult = hasLoader
+    ? await fetchLoaderData(pathWithSearch, signal)
+    : { kind: "data", data: {} };
+
+  if (loaderResult.kind === "redirect") {
+    navigate(loaderResult.to, { replace: true });
+    return () => {};
+  }
+  if (loaderResult.kind === "error") {
+    // Render a minimal inline error. See renderResponse for why loader errors
+    // don't currently route through the page's +error.ts boundary.
+    const escaped = String(loaderResult.message)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+    host.innerHTML = `<div data-router-view data-router-error="${loaderResult.status}">${escaped}</div>`;
+    return () => {};
+  }
+  if (loaderResult.kind === "not-found") {
+    host.innerHTML = `<div data-router-empty></div>`;
+    return () => {};
+  }
+  props = loaderResult.data;
+
   // If no registry provided, fall back to static rendering (no interactivity)
   if (!registry) {
     console.warn(
       "[ilha-router] No registry provided for client-side navigation. Island will not be interactive.",
     );
-    host.innerHTML = `<div data-router-view>${island.toString()}</div>`;
+    host.innerHTML = `<div data-router-view>${island.toString(props)}</div>`;
     return () => {};
   }
 
@@ -169,12 +412,12 @@ async function mountRouteWithHydration(
 
   if (!name) {
     console.warn("[ilha-router] Island not found in registry for client-side navigation.");
-    host.innerHTML = `<div data-router-view>${island.toString()}</div>`;
+    host.innerHTML = `<div data-router-view>${island.toString(props)}</div>`;
     return () => {};
   }
 
   // Render with hydration markers and mount for interactivity
-  const html = await island.hydratable({}, { name, as: "div", snapshot: true });
+  const html = await island.hydratable(props, { name, as: "div", snapshot: true });
   host.innerHTML = `<div data-router-view>${html}</div>`;
 
   // Mount the island for interactivity
@@ -209,8 +452,13 @@ const activeIsland = context<Island<any, any> | null>("router.active", null);
 // Route registry
 // ─────────────────────────────────────────────
 
+interface RouteData {
+  island: Island<any, any>;
+  loader?: Loader<any>;
+}
+
 let _records: RouteRecord[] = [];
-let _rou3 = createRouter<Island<any, any>>();
+let _rou3 = createRouter<RouteData>();
 
 // ─────────────────────────────────────────────
 // Island → pattern reverse map (O(1) isActive)
@@ -245,7 +493,7 @@ function syncRouteFromURL(url: string | URL): void {
   routeParams(extractParams(match?.params as Record<string, string> | undefined));
   routeSearch(parsed.search);
   routeHash(parsed.hash);
-  activeIsland(match?.data ?? null);
+  activeIsland(match?.data?.island ?? null);
 }
 
 /** Client-only fast path — reads directly from `location` instead of parsing a URL. */
@@ -256,7 +504,7 @@ function syncRouteFromLocation(): void {
   routeParams(extractParams(match?.params as Record<string, string> | undefined));
   routeSearch(location.search);
   routeHash(location.hash);
-  activeIsland(match?.data ?? null);
+  activeIsland(match?.data?.island ?? null);
 }
 
 // ─────────────────────────────────────────────
@@ -267,19 +515,6 @@ function syncRouteFromLocation(): void {
  * Prime route context signals from the current `location` so that islands
  * hydrated by `ilha.mount()` see the correct route values on their first
  * render — preventing a mismatch morph that would destroy hydrated bindings.
- *
- * Call this **before** `ilha.mount()` and **after** all routes have been
- * registered (i.e. after the `router().route(…).route(…)` chain).
- *
- * ```ts
- * import { mount } from "ilha";
- * import { pageRouter } from "ilha:pages";
- * import { registry } from "ilha:registry";
- *
- * pageRouter.prime();              // ← sync signals first
- * mount(registry, { root: … });   // ← then hydrate islands
- * pageRouter.mount("#app", { hydrate: true });
- * ```
  */
 export function prime(): void {
   if (isBrowser) syncRouteFromLocation();
@@ -302,39 +537,74 @@ export function navigate(to: string, opts: NavigateOptions = {}): void {
 }
 
 // ─────────────────────────────────────────────
-// Link interception
+// Link interception — with optional hover prefetch
 // ─────────────────────────────────────────────
 
-export function enableLinkInterception(root: Element | Document = document): () => void {
+export interface LinkInterceptionOptions {
+  /**
+   * Prefetch loader data on `mouseenter` for eligible links. Links opt in via
+   * the `data-prefetch` attribute (set `data-prefetch="false"` to opt out a
+   * specific link even when the framework is configured to prefetch by default).
+   * Default: `true` — prefetches on hover for any link with `data-prefetch`.
+   */
+  prefetch?: boolean;
+}
+
+export function enableLinkInterception(
+  root: Element | Document = document,
+  options: LinkInterceptionOptions = {},
+): () => void {
   if (!isBrowser) return () => {};
 
-  const handler = (e: Event) => {
-    // Respect other handlers that already handled this event
-    if (e.defaultPrevented) return;
+  const prefetchEnabled = options.prefetch !== false;
 
-    const target = (e.target as Element).closest("a");
-    if (!target) return;
-
+  /** Determine whether this anchor is a same-origin in-app link we should handle. */
+  function eligibleLink(target: HTMLAnchorElement, e?: Event): boolean {
     const href = target.getAttribute("href");
-    if (!href) return;
-
+    if (!href) return false;
     const isAnchorOnly = href.startsWith("#");
     const isBlank = target.getAttribute("target") === "_blank";
     const hasModifier =
-      (e as MouseEvent).ctrlKey || (e as MouseEvent).metaKey || (e as MouseEvent).shiftKey;
+      !!e && ((e as MouseEvent).ctrlKey || (e as MouseEvent).metaKey || (e as MouseEvent).shiftKey);
     const isExternal =
       !!target.hostname &&
       (target.hostname !== location.hostname || target.protocol !== location.protocol);
     const hasNoIntercept = target.hasAttribute("data-no-intercept");
+    return !(isExternal || isAnchorOnly || isBlank || hasModifier || hasNoIntercept);
+  }
 
-    if (isExternal || isAnchorOnly || isBlank || hasModifier || hasNoIntercept) return;
+  const clickHandler = (e: Event) => {
+    if (e.defaultPrevented) return;
+    const target = (e.target as Element).closest("a") as HTMLAnchorElement | null;
+    if (!target) return;
+    if (!eligibleLink(target, e)) return;
 
     e.preventDefault();
     navigate(target.pathname + target.search + target.hash);
   };
 
-  root.addEventListener("click", handler);
-  return () => root.removeEventListener("click", handler);
+  const hoverHandler = (e: Event) => {
+    const target = (e.target as Element).closest("a") as HTMLAnchorElement | null;
+    if (!target) return;
+    // Opt-in only: link must have `data-prefetch` (and not `data-prefetch="false"`)
+    const flag = target.getAttribute("data-prefetch");
+    if (flag === null || flag === "false") return;
+    if (!eligibleLink(target)) return;
+    prefetch(target.pathname + target.search);
+  };
+
+  root.addEventListener("click", clickHandler);
+  if (prefetchEnabled) {
+    // `mouseenter` does not bubble — use `mouseover` which does, then gate by closest('a').
+    root.addEventListener("mouseover", hoverHandler, { passive: true } as AddEventListenerOptions);
+  }
+
+  return () => {
+    root.removeEventListener("click", clickHandler);
+    if (prefetchEnabled) {
+      root.removeEventListener("mouseover", hoverHandler);
+    }
+  };
 }
 
 // ─────────────────────────────────────────────
@@ -348,7 +618,7 @@ export const RouterView = ilha.render((): string => {
 });
 
 // ─────────────────────────────────────────────
-// RouterLink island
+// RouterLink island — prefetches on hover by default
 // ─────────────────────────────────────────────
 
 export const RouterLink = ilha
@@ -358,7 +628,23 @@ export const RouterLink = ilha
     event.preventDefault();
     navigate(state.href());
   })
-  .render(({ state }) => html`<a data-link href="${state.href}">${state.label}</a>`);
+  .on("[data-link]@mouseenter", ({ state }) => {
+    const href = state.href();
+    if (!href) return;
+    // Only prefetch same-origin paths — href is usually "/foo" but could be absolute.
+    if (/^https?:\/\//i.test(href)) {
+      try {
+        const u = new URL(href);
+        if (u.origin !== location.origin) return;
+        prefetch(u.pathname + u.search);
+        return;
+      } catch {
+        return;
+      }
+    }
+    prefetch(href);
+  })
+  .render(({ state }) => html`<a data-link data-prefetch href="${state.href}">${state.label}</a>`);
 
 // ─────────────────────────────────────────────
 // isActive()
@@ -368,7 +654,47 @@ export function isActive(pattern: string): boolean {
   const match = findRoute(_rou3, "GET", routePath());
   if (!match) return false;
   // O(1) lookup via reverse map instead of linear scan through _records
-  return _islandToPattern.get(match.data) === pattern;
+  return _islandToPattern.get(match.data.island) === pattern;
+}
+
+// ─────────────────────────────────────────────
+// Internal helpers for loader execution
+// ─────────────────────────────────────────────
+
+function parsedURL(url: string | URL): URL {
+  return typeof url === "string" ? new URL(url, "http://localhost") : url;
+}
+
+function defaultRequest(url: URL): Request {
+  // Best-effort synthesised Request for SSR callers that don't supply one.
+  try {
+    return new Request(url.toString());
+  } catch {
+    // Some environments may not have global Request; return a minimal shim.
+    return { url: url.toString(), headers: new Headers() } as unknown as Request;
+  }
+}
+
+async function executeLoader(
+  loader: Loader<any>,
+  url: URL,
+  params: Record<string, string>,
+  request: Request,
+  signal: AbortSignal,
+): Promise<
+  | { kind: "data"; data: Record<string, unknown> }
+  | { kind: "redirect"; to: string; status: number }
+  | { kind: "error"; status: number; message: string }
+> {
+  try {
+    const data = await loader({ params, request, url, signal });
+    return { kind: "data", data: (data ?? {}) as Record<string, unknown> };
+  } catch (e: any) {
+    if (e instanceof Redirect) return { kind: "redirect", to: e.to, status: e.status };
+    if (e instanceof LoaderError) return { kind: "error", status: e.status, message: e.message };
+    // Non-sentinel error — surface as 500.
+    return { kind: "error", status: e?.status ?? 500, message: e?.message ?? "Loader failed" };
+  }
 }
 
 // ─────────────────────────────────────────────
@@ -377,16 +703,16 @@ export function isActive(pattern: string): boolean {
 
 export function router(): RouterBuilder {
   _records = [];
-  _rou3 = createRouter<Island<any, any>>();
+  _rou3 = createRouter<RouteData>();
   _islandToPattern = new Map();
 
   let _popstateCleanup: (() => void) | null = null;
   let _linkCleanup: (() => void) | null = null;
 
   const builder: RouterBuilder = {
-    route(pattern: string, island: Island<any, any>): RouterBuilder {
-      _records.push({ pattern, island });
-      addRoute(_rou3, "GET", pattern, island);
+    route(pattern: string, island: Island<any, any>, loader?: Loader<any>): RouterBuilder {
+      _records.push({ pattern, island, loader });
+      addRoute(_rou3, "GET", pattern, { island, loader });
       // First pattern registered for an island wins (most specific due to sort order)
       if (!_islandToPattern.has(island)) {
         _islandToPattern.set(island, pattern);
@@ -410,10 +736,7 @@ export function router(): RouterBuilder {
         return () => {};
       }
 
-      // Ensure route signals are current.  If prime() was already called this
-      // is a no-op (same values); if not, this syncs now — which is fine for
-      // non-hydrate mounts but may be too late for hydrate mounts if
-      // ilha.mount() already ran (see prime() docs above).
+      // Ensure route signals are current.
       syncRouteFromLocation();
 
       const popHandler = () => syncRouteFromLocation();
@@ -422,59 +745,61 @@ export function router(): RouterBuilder {
       _linkCleanup = enableLinkInterception(document);
 
       let unmountView: (() => void) | null = null;
+      // Per-navigation AbortController — canceled when navigation is superseded
+      // or the router unmounts. Used to abort in-flight loader fetches.
+      let navAbort: AbortController | null = null;
 
       if (hydrate) {
         // SSR HTML is already in the DOM and ilha.mount() has already hydrated
         // [data-ilha] nodes with reactivity.  We must NOT mount RouterView now —
         // any morph (even with identical HTML) would replace the live DOM nodes,
         // destroying the event listeners and signal bindings ilha.mount() wired up.
-        //
-        // Instead we mount a "navigation handler" island that subscribes to activeIsland.
-        // It tracks the current island and re-renders with hydration whenever the route changes.
         const viewHost = host.querySelector<Element>("[data-router-view]") ?? host;
         let currentMountedIsland: Island<any, any> | null = activeIsland();
 
-        // Build reverse registry once for O(1) lookups during navigation
         const reverseRegistry = registry ? buildReverseRegistry(registry) : undefined;
 
-        // Navigation version counter — prevents stale microtasks from applying
         let navVersion = 0;
 
         const navHandler = ilha.render((): string => {
           const current = activeIsland();
           if (current !== currentMountedIsland) {
-            // activeIsland changed — a navigation happened.
-            // Capture version so stale microtasks are discarded.
             const thisNav = ++navVersion;
-            // Schedule re-hydration after this render completes.
+            // Cancel any in-flight loader fetch for the previous nav
+            navAbort?.abort();
+            navAbort = new AbortController();
+            const signal = navAbort.signal;
+
             queueMicrotask(async () => {
-              // Discard if a newer navigation has superseded this one
               if (thisNav !== navVersion) return;
-              // Clean up previous view
               unmountView?.();
-              // Mount the new route with hydration if registry is available
-              unmountView = await mountRouteWithHydration(
-                current,
-                viewHost,
-                registry,
-                reverseRegistry,
-              );
+              try {
+                unmountView = await mountRouteWithHydration(
+                  current,
+                  viewHost,
+                  location.pathname + location.search,
+                  signal,
+                  registry,
+                  reverseRegistry,
+                );
+              } catch (e: any) {
+                if (e?.name === "AbortError") return;
+                throw e;
+              }
               currentMountedIsland = current;
             });
           }
-          // Navigation handler produces no visible markup — it just tracks route changes.
           return "";
         });
 
-        // Mount nav handler on a hidden helper node so it doesn't interfere with
-        // the existing [data-router-view] children.
         const navHost = document.createElement("div");
         navHost.style.display = "none";
         host.appendChild(navHost);
         const unmountNavHandler = navHandler.mount(navHost);
 
         return () => {
-          ++navVersion; // cancel any pending microtask
+          ++navVersion;
+          navAbort?.abort();
           unmountNavHandler();
           navHost.remove();
           unmountView?.();
@@ -486,38 +811,63 @@ export function router(): RouterBuilder {
       }
 
       // SPA mode — RouterView renders HTML but islands need .mount() for interactivity.
-      // We use the same navHandler pattern as hydrate mode: a hidden sentinel island
-      // subscribes to activeIsland and mounts/unmounts page islands on navigation.
       let unmountIsland: (() => void) | null = null;
       let currentMountedIsland: Island<any, any> | null = null;
       let navVersion = 0;
 
       unmountView = RouterView.mount(host);
 
-      /** Mount the active island onto the [data-router-view] container for interactivity. */
-      function mountActiveIsland(island: Island<any, any> | null): void {
+      /**
+       * Fetch loader data and mount the active island. SPA mode also fetches
+       * from the loader endpoint — otherwise navigation after the initial SSR
+       * render would have no access to loader data.
+       */
+      async function mountActiveIsland(
+        island: Island<any, any> | null,
+        signal: AbortSignal,
+      ): Promise<void> {
         unmountIsland?.();
         unmountIsland = null;
         currentMountedIsland = island;
         if (!island) return;
         const viewHost = host?.querySelector<Element>("[data-router-view]");
-        if (viewHost) {
-          unmountIsland = island.mount(viewHost);
+        if (!viewHost) return;
+
+        // Fetch loader data only if the matched route has a loader registered.
+        const clientMatch = findRoute(_rou3, "GET", location.pathname);
+        const hasLoader = !!clientMatch?.data?.loader;
+        const result: LoaderFetchResult = hasLoader
+          ? await fetchLoaderData(location.pathname + location.search, signal)
+          : { kind: "data", data: {} };
+        if (signal.aborted) return;
+        if (result.kind === "redirect") {
+          navigate(result.to, { replace: true });
+          return;
         }
+        const props = result.kind === "data" ? result.data : {};
+
+        // In SPA mode RouterView is already showing the island's no-props HTML.
+        // Re-render with props, morph, and mount for interactivity.
+        viewHost.innerHTML = island.toString(props);
+        unmountIsland = island.mount(viewHost, props);
       }
 
-      // Mount the initial page island (RouterView has already rendered the HTML)
-      mountActiveIsland(activeIsland());
+      // Initial mount — no need to wait for a loader fetch since the first
+      // render already ran synchronously via RouterView. However, for SPA mode
+      // the initial render had no props, so we fetch and re-render once.
+      navAbort = new AbortController();
+      mountActiveIsland(activeIsland(), navAbort.signal);
 
-      // Watch for navigation — re-mount the new island after RouterView morphs the DOM
       const navHandler = ilha.render((): string => {
         const current = activeIsland();
         if (current !== currentMountedIsland) {
           const thisNav = ++navVersion;
-          // Schedule after RouterView's morph completes in this same reactive tick
+          navAbort?.abort();
+          navAbort = new AbortController();
+          const signal = navAbort.signal;
           queueMicrotask(() => {
             if (thisNav !== navVersion) return;
-            mountActiveIsland(current);
+            mountActiveIsland(current, signal);
           });
         }
         return "";
@@ -530,6 +880,7 @@ export function router(): RouterBuilder {
 
       return () => {
         ++navVersion;
+        navAbort?.abort();
         unmountIsland?.();
         unmountNavHandler();
         navHost.remove();
@@ -552,13 +903,68 @@ export function router(): RouterBuilder {
       url: string | URL,
       registry: Record<string, Island<any, any>>,
       options: HydratableRenderOptions = {},
+      request?: Request,
     ): Promise<string> {
-      syncRouteFromURL(url);
+      const response = await this.renderResponse(url, registry, options, request);
+      if (response.kind === "html") return response.html;
+      if (response.kind === "error") return response.html;
+      // Redirects encoded as meta-refresh for callers that use the string API
+      // directly. Prefer `renderResponse` to handle redirects at the HTTP layer.
+      return `<meta http-equiv="refresh" content="0; url=${response.to}">`;
+    },
 
-      const island = activeIsland();
-      if (!island) return `<div data-router-empty></div>`;
+    // ── Server-side — structured response (preferred) ────────────────────────
+    async renderResponse(
+      url: string | URL,
+      registry: Record<string, Island<any, any>>,
+      options: HydratableRenderOptions = {},
+      request?: Request,
+    ): Promise<RenderResponse> {
+      const parsed = parsedURL(url);
+      syncRouteFromURL(parsed);
 
-      // O(1) reverse lookup instead of Object.entries().find()
+      const match = findRoute(_rou3, "GET", parsed.pathname);
+      const island = match?.data?.island ?? null;
+      if (!island) {
+        return {
+          kind: "html",
+          html: `<div data-router-empty></div>`,
+          status: 404,
+        };
+      }
+
+      // Run loader (if any)
+      let props: Record<string, unknown> = {};
+      if (match?.data?.loader) {
+        const req = request ?? defaultRequest(parsed);
+        const ctrl = new AbortController();
+        const result = await executeLoader(
+          match.data.loader,
+          parsed,
+          routeParams(),
+          req,
+          ctrl.signal,
+        );
+        if (result.kind === "redirect") {
+          return { kind: "redirect", to: result.to, status: result.status };
+        }
+        if (result.kind === "error") {
+          // Loader errors render a minimal inline error page. The page's
+          // `+error.ts` boundary (applied via `wrapError` at codegen time)
+          // wraps the page island's *render*, not the loader — so loader
+          // errors cannot currently route through it. Host apps should
+          // inspect `response.status` and substitute their own error page
+          // if finer control is needed.
+          const escapedMessage = String(result.message)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;");
+          const html = `<div data-router-view data-router-error="${result.status}">${escapedMessage}</div>`;
+          return { kind: "error", status: result.status, message: result.message, html };
+        }
+        props = result.data;
+      }
+
       const reverseRegistry = buildReverseRegistry(registry);
       const name = reverseRegistry.get(island);
       if (!name) {
@@ -566,20 +972,37 @@ export function router(): RouterBuilder {
           `[ilha-router] renderHydratable: active island for "${routePath()}" is not in the registry. ` +
             `Falling back to plain SSR — the island will not be interactive on the client.`,
         );
-        return `<div data-router-view>${island.toString()}</div>`;
+        return {
+          kind: "html",
+          html: `<div data-router-view>${island.toString(props)}</div>`,
+        };
       }
 
-      const rendered = await island.hydratable(
-        {},
-        {
-          name,
-          as: "div",
-          snapshot: true,
-          ...options,
-        },
-      );
+      const rendered = await island.hydratable(props, {
+        name,
+        as: "div",
+        snapshot: true,
+        ...options,
+      });
 
-      return `<div data-router-view>${rendered}</div>`;
+      return { kind: "html", html: `<div data-router-view>${rendered}</div>` };
+    },
+
+    // ── Server-side — run loader for a URL (loader endpoint) ────────────────
+    async runLoader(url: string | URL, request?: Request) {
+      const parsed = parsedURL(url);
+
+      const match = findRoute(_rou3, "GET", parsed.pathname);
+      if (!match?.data?.island) return { kind: "not-found" as const };
+
+      if (!match.data.loader) {
+        return { kind: "data" as const, data: {} };
+      }
+
+      const params = extractParams(match.params as Record<string, string> | undefined);
+      const req = request ?? defaultRequest(parsed);
+      const ctrl = new AbortController();
+      return executeLoader(match.data.loader, parsed, params, req, ctrl.signal);
     },
 
     hydrate(registry: Record<string, Island<any, any>>, options: HydrateOptions = {}): () => void {
@@ -591,13 +1014,8 @@ export function router(): RouterBuilder {
       const root = options.root ?? document.body;
       const target = options.target ?? root;
 
-      // 1. Prime route signals first so islands see correct values on first render
       prime();
-
-      // 2. Mount islands for interactivity
       const { unmount } = mount(registry, { root });
-
-      // 3. Setup router for client-side navigation (pass registry for hydration on navigation)
       const unmountRouter = this.mount(target, { hydrate: true, registry });
 
       return () => {
@@ -621,6 +1039,11 @@ export default {
   isActive,
   enableLinkInterception,
   prime,
+  prefetch,
   RouterView,
   RouterLink,
+  loader,
+  redirect,
+  error,
+  composeLoaders,
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-route loaders that run before render and supply data to components
  * Automatic link prefetch on hover (opt-out available) and prefetch API for improved navigation
  * New server-rendering APIs that return structured html/redirect/error results and surface loader redirects

* **Documentation**
  * Expanded docs and TypeScript types for loaders, redirects, errors, composition, and routing behavior

* **Tests**
  * Extensive new tests covering loader behaviors, composition, SSR integration, prefetching, and link attributes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->