### PR TITLE
feat(router): extend vite codegen with loaders

### DIFF
--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -82,22 +82,18 @@ export type MergeLoaders<Ls extends readonly Loader<any>[]> = Ls extends readonl
 
 export class Redirect {
   readonly __ilhaRedirect = true as const;
-  readonly to: string;
-  readonly status: number;
-  constructor(to: string, status: number = 302) {
-    this.to = to;
-    this.status = status;
-  }
+  constructor(
+    public readonly to: string,
+    public readonly status: number = 302,
+  ) {}
 }
 
 export class LoaderError {
   readonly __ilhaLoaderError = true as const;
-  readonly status: number;
-  readonly message: string;
-  constructor(status: number, message: string) {
-    this.status = status;
-    this.message = message;
-  }
+  constructor(
+    public readonly status: number,
+    public readonly message: string,
+  ) {}
 }
 
 export function redirect(to: string, status = 302): never {
@@ -215,6 +211,13 @@ export interface RouterBuilder {
    * the FS-routing codegen.
    */
   route(pattern: string, island: Island<any, any>, loader?: Loader<any>): RouterBuilder;
+  /**
+   * Attach (or replace) a loader on an already-registered route pattern.
+   * Used by the `ilha:loaders` virtual module to wire server-only loaders
+   * onto the client-safe `pageRouter` at SSR time. No-op if the pattern
+   * was never registered via `.route()`.
+   */
+  attachLoader(pattern: string, loader: Loader<any>): RouterBuilder;
   prime(): void;
   mount(target: string | Element, options?: MountOptions): () => void;
   render(url: string | URL): string;
@@ -335,7 +338,7 @@ export function prefetch(pathWithSearch: string): void {
   if (!isBrowser) return;
   if (prefetchCache.has(pathWithSearch)) return;
   // Don't prefetch routes that have no loader — nothing to fetch.
-  const pathOnly = pathWithSearch.split("?")[0] ?? "";
+  const pathOnly = pathWithSearch.split("?")[0];
   const match = findRoute(_rou3, "GET", pathOnly);
   if (!match?.data?.loader) return;
   const promise = fetchLoaderData(pathWithSearch).catch((e) => {
@@ -369,7 +372,7 @@ async function mountRouteWithHydration(
   // Fetch loader data *only if* the matched route has a loader registered.
   // Routes registered client-side have `loader: undefined` when the Vite
   // plugin emits server-only loader imports behind `import.meta.env.SSR`.
-  const clientMatch = findRoute(_rou3, "GET", pathWithSearch.split("?")[0] ?? "");
+  const clientMatch = findRoute(_rou3, "GET", pathWithSearch.split("?")[0]);
   const hasLoader = !!clientMatch?.data?.loader;
 
   let props: Record<string, unknown> = {};
@@ -465,6 +468,14 @@ let _rou3 = createRouter<RouteData>();
 // ─────────────────────────────────────────────
 
 let _islandToPattern = new Map<Island<any, any>, string>();
+
+// ─────────────────────────────────────────────
+// Pattern → RouteData map — lets attachLoader() mutate the loader in place
+// on an already-registered route. The object stored here is the SAME
+// reference stored in rou3, so mutating it is visible at findRoute time.
+// ─────────────────────────────────────────────
+
+let _patternToData = new Map<string, RouteData>();
 
 // ─────────────────────────────────────────────
 // Shared match → params extraction
@@ -705,18 +716,37 @@ export function router(): RouterBuilder {
   _records = [];
   _rou3 = createRouter<RouteData>();
   _islandToPattern = new Map();
+  _patternToData = new Map();
 
   let _popstateCleanup: (() => void) | null = null;
   let _linkCleanup: (() => void) | null = null;
 
   const builder: RouterBuilder = {
     route(pattern: string, island: Island<any, any>, loader?: Loader<any>): RouterBuilder {
+      const data: RouteData = { island, loader };
       _records.push({ pattern, island, loader });
-      addRoute(_rou3, "GET", pattern, { island, loader });
+      addRoute(_rou3, "GET", pattern, data);
+      _patternToData.set(pattern, data);
       // First pattern registered for an island wins (most specific due to sort order)
       if (!_islandToPattern.has(island)) {
         _islandToPattern.set(island, pattern);
       }
+      return builder;
+    },
+
+    attachLoader(pattern: string, loader: Loader<any>): RouterBuilder {
+      const data = _patternToData.get(pattern);
+      if (!data) {
+        console.warn(
+          `[ilha-router] attachLoader("${pattern}", …): pattern was never registered via .route(). ` +
+            `The loader will be ignored.`,
+        );
+        return builder;
+      }
+      data.loader = loader;
+      // Keep _records in sync for consumers that read it directly
+      const rec = _records.find((r) => r.pattern === pattern);
+      if (rec) rec.loader = loader;
       return builder;
     },
 

--- a/packages/router/src/vite.test.ts
+++ b/packages/router/src/vite.test.ts
@@ -924,3 +924,442 @@ describe("pages — Vite plugin", () => {
     await removeDir(root);
   });
 });
+
+// ─────────────────────────────────────────────
+// codegen — loader detection & ?client suffix
+// ─────────────────────────────────────────────
+
+describe("codegen — loader detection", () => {
+  let pagesDir: string;
+  let outFile: string;
+  let loadersFile: string;
+  let root: string;
+
+  beforeEach(async () => {
+    root = await makeDir("loaders");
+    pagesDir = join(root, "src/pages");
+    outFile = join(root, ".ilha/routes.ts");
+    loadersFile = join(root, ".ilha/loaders.ts");
+    await mkdir(pagesDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await removeDir(root);
+  });
+
+  async function runCodegen() {
+    const plugin = pages({ dir: pagesDir, generated: outFile }) as any;
+    plugin.configResolved({ root });
+    await plugin.buildStart();
+    return {
+      routes: await readFile(outFile, "utf8"),
+      loaders: await readFile(loadersFile, "utf8").catch(() => ""),
+    };
+  }
+
+  // ── client-safe routes file ────────────────────────────────────────────
+
+  it("page imports in routes.ts use the ?client suffix", async () => {
+    await writePage(pagesDir, "index.ts", `export default null;`);
+    const { routes } = await runCodegen();
+    const pageImport = routes
+      .split("\n")
+      .find((l) => l.startsWith("import") && l.includes("_page0"));
+    expect(pageImport).toBeDefined();
+    expect(pageImport!).toContain("?client");
+  });
+
+  it("layout imports in routes.ts use the ?client suffix", async () => {
+    await writePage(pagesDir, "index.ts", `export default null;`);
+    await writePage(pagesDir, "+layout.ts", `export default null;`);
+    const { routes } = await runCodegen();
+    const layoutImport = routes
+      .split("\n")
+      .find((l) => l.startsWith("import") && l.includes("+layout"));
+    expect(layoutImport).toBeDefined();
+    expect(layoutImport!).toContain("?client");
+  });
+
+  it("error imports in routes.ts use the ?client suffix", async () => {
+    await writePage(pagesDir, "index.ts", `export default null;`);
+    await writePage(pagesDir, "+error.ts", `export default null;`);
+    const { routes } = await runCodegen();
+    const errorImport = routes
+      .split("\n")
+      .find((l) => l.startsWith("import") && l.includes("+error"));
+    expect(errorImport).toBeDefined();
+    expect(errorImport!).toContain("?client");
+  });
+
+  it("routes.ts does not reference loaders", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const load = async () => ({}); export default null;`,
+    );
+    const { routes } = await runCodegen();
+    expect(routes).not.toContain("attachLoader");
+    expect(routes).not.toContain("composeLoaders");
+    expect(routes).not.toContain("import { load");
+  });
+
+  // ── loaders.ts — written only when needed ──────────────────────────────
+
+  it("emits an empty loaders.ts when no page or layout has a loader", async () => {
+    await writePage(pagesDir, "index.ts", `export default null;`);
+    await writePage(pagesDir, "about.ts", `export default null;`);
+    const { loaders } = await runCodegen();
+    expect(loaders).toContain("intentionally empty");
+    expect(loaders).not.toContain("attachLoader");
+  });
+
+  it("emits attachLoader when a page has a load export", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const load = async () => ({ x: 1 }); export default null;`,
+    );
+    const { loaders } = await runCodegen();
+    expect(loaders).toContain(`pageRouter.attachLoader("/",`);
+  });
+
+  it("imports load from the page module (no ?client suffix) in loaders.ts", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const load = async () => ({}); export default null;`,
+    );
+    const { loaders } = await runCodegen();
+    const loadImport = loaders
+      .split("\n")
+      .find((l) => l.startsWith("import") && l.includes("{ load as"));
+    expect(loadImport).toBeDefined();
+    expect(loadImport!).not.toContain("?client");
+  });
+
+  it("detects `export async function load`", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export async function load() { return {}; }\nexport default null;`,
+    );
+    const { loaders } = await runCodegen();
+    expect(loaders).toContain("attachLoader");
+  });
+
+  it("detects `export function load`", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export function load() { return {}; }\nexport default null;`,
+    );
+    const { loaders } = await runCodegen();
+    expect(loaders).toContain("attachLoader");
+  });
+
+  it("does not treat `export const loader` as a loader", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const loader = "not a loader";\nexport default null;`,
+    );
+    const { loaders } = await runCodegen();
+    expect(loaders).not.toContain("attachLoader");
+  });
+
+  it("does not treat `export const loaded` as a loader", async () => {
+    await writePage(pagesDir, "index.ts", `export const loaded = true;\nexport default null;`);
+    const { loaders } = await runCodegen();
+    expect(loaders).not.toContain("attachLoader");
+  });
+
+  it("ignores commented-out `// export const load`", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `// export const load = () => ({});\nexport default null;`,
+    );
+    const { loaders } = await runCodegen();
+    expect(loaders).not.toContain("attachLoader");
+  });
+
+  // ── layout loaders ─────────────────────────────────────────────────────
+
+  it("layout's load export is attached to pages in its subtree", async () => {
+    await writePage(pagesDir, "index.ts", `export default null;`);
+    await writePage(
+      pagesDir,
+      "+layout.ts",
+      `export const load = async () => ({ layout: true });\nexport default null;`,
+    );
+    const { loaders } = await runCodegen();
+    expect(loaders).toContain(`pageRouter.attachLoader("/",`);
+    expect(loaders).toContain("+layout.ts");
+  });
+
+  it("composeLoaders is used when page and layout both have loaders", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const load = async () => ({ page: true });\nexport default null;`,
+    );
+    await writePage(
+      pagesDir,
+      "+layout.ts",
+      `export const load = async () => ({ layout: true });\nexport default null;`,
+    );
+    const { loaders } = await runCodegen();
+    expect(loaders).toContain("composeLoaders(");
+    // Layout loader appears BEFORE page loader in the composed array (outer→inner; page last)
+    const composeCall = loaders.match(/composeLoaders\(\[([^\]]+)\]\)/)?.[1];
+    expect(composeCall).toBeDefined();
+    const ids = composeCall!.split(",").map((s) => s.trim());
+    // Layout id contains `_l`, page id is just `_pN`
+    expect(ids[0]).toMatch(/_l\d+/);
+    expect(ids[ids.length - 1]).not.toMatch(/_l\d+/);
+  });
+
+  it("no composeLoaders when only one loader in the chain", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const load = async () => ({}); export default null;`,
+    );
+    const { loaders } = await runCodegen();
+    expect(loaders).not.toContain("composeLoaders");
+    expect(loaders).toContain("attachLoader");
+  });
+
+  it("nested layout loader is applied only to pages in its subtree", async () => {
+    await writePage(pagesDir, "about.ts", `export default null;`);
+    await writePage(pagesDir, "user/index.ts", `export default null;`);
+    await writePage(
+      pagesDir,
+      "user/+layout.ts",
+      `export const load = async () => ({ inUser: true });\nexport default null;`,
+    );
+    const { loaders } = await runCodegen();
+    // /user is attached; /about is not
+    expect(loaders).toContain(`attachLoader("/user",`);
+    expect(loaders).not.toContain(`attachLoader("/about",`);
+  });
+
+  it("root layout loader wraps all pages, nested layout loader wraps only its subtree", async () => {
+    await writePage(pagesDir, "about.ts", `export default null;`);
+    await writePage(pagesDir, "user/index.ts", `export default null;`);
+    await writePage(
+      pagesDir,
+      "+layout.ts",
+      `export const load = async () => ({ root: true });\nexport default null;`,
+    );
+    await writePage(
+      pagesDir,
+      "user/+layout.ts",
+      `export const load = async () => ({ inUser: true });\nexport default null;`,
+    );
+    const { loaders } = await runCodegen();
+    // Both routes get attachLoader calls
+    const attachLines = loaders.split("\n").filter((l) => l.includes("attachLoader"));
+    expect(attachLines).toHaveLength(2);
+    // /user should have 2 loader ids composed; /about should have just 1
+    const userLine = attachLines.find((l) => l.includes(`"/user"`));
+    const aboutLine = attachLines.find((l) => l.includes(`"/about"`));
+    expect(userLine).toContain("composeLoaders");
+    expect(aboutLine).not.toContain("composeLoaders");
+  });
+
+  it("+error.ts loaders are ignored even if the file has `export const load`", async () => {
+    // Pathological but worth defending against.
+    await writePage(pagesDir, "index.ts", `export default null;`);
+    await writePage(
+      pagesDir,
+      "+error.ts",
+      `export const load = async () => ({ err: true });\nexport default null;`,
+    );
+    const { loaders } = await runCodegen();
+    expect(loaders).not.toContain("+error.ts");
+    expect(loaders).not.toContain("attachLoader");
+  });
+});
+
+// ─────────────────────────────────────────────
+// codegen — loaders.ts structure
+// ─────────────────────────────────────────────
+
+describe("codegen — loaders.ts file", () => {
+  let pagesDir: string;
+  let outFile: string;
+  let loadersFile: string;
+  let root: string;
+
+  beforeEach(async () => {
+    root = await makeDir("loaders-struct");
+    pagesDir = join(root, "src/pages");
+    outFile = join(root, ".ilha/routes.ts");
+    loadersFile = join(root, ".ilha/loaders.ts");
+    await mkdir(pagesDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await removeDir(root);
+  });
+
+  async function runCodegen() {
+    const plugin = pages({ dir: pagesDir, generated: outFile }) as any;
+    plugin.configResolved({ root });
+    await plugin.buildStart();
+    return readFile(loadersFile, "utf8");
+  }
+
+  it("has the @generated header", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const load = async () => ({}); export default null;`,
+    );
+    expect(await runCodegen()).toContain("@generated by @ilha/router");
+  });
+
+  it("imports composeLoaders from @ilha/router", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const load = async () => ({}); export default null;`,
+    );
+    await writePage(
+      pagesDir,
+      "+layout.ts",
+      `export const load = async () => ({}); export default null;`,
+    );
+    const code = await runCodegen();
+    expect(code).toContain(`import { composeLoaders } from "@ilha/router"`);
+  });
+
+  it("imports pageRouter from the routes file", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const load = async () => ({}); export default null;`,
+    );
+    const code = await runCodegen();
+    expect(code).toContain(`import { pageRouter } from`);
+    expect(code).toContain("routes");
+  });
+
+  it("all imports are relative (no absolute paths)", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const load = async () => ({}); export default null;`,
+    );
+    const code = await runCodegen();
+    const importLines = code
+      .split("\n")
+      .filter((l) => l.startsWith("import") && !l.includes("@ilha/router"));
+    for (const line of importLines) {
+      expect(line).toMatch(/from ["']\.\.?/);
+    }
+  });
+
+  it("emits one attachLoader per page with loaders", async () => {
+    await writePage(pagesDir, "a.ts", `export const load = async () => ({}); export default null;`);
+    await writePage(pagesDir, "b.ts", `export const load = async () => ({}); export default null;`);
+    await writePage(pagesDir, "c.ts", `export default null;`); // no loader
+    const code = await runCodegen();
+    const attaches = code.split("\n").filter((l) => l.includes("attachLoader"));
+    expect(attaches).toHaveLength(2);
+    expect(code).not.toContain(`"/c"`);
+  });
+
+  it("does not include export default", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const load = async () => ({}); export default null;`,
+    );
+    const code = await runCodegen();
+    expect(code).not.toContain("export default");
+  });
+
+  it("writes loaders.ts to the same directory as routes.ts", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const load = async () => ({}); export default null;`,
+    );
+    await runCodegen();
+    // File must exist at the expected path
+    expect(readFile(loadersFile, "utf8")).resolves.toBeDefined();
+  });
+});
+
+// ─────────────────────────────────────────────
+// Vite plugin — ?client virtual module
+// ─────────────────────────────────────────────
+
+describe("pages — ?client virtual module", () => {
+  it("resolveId returns the id with ?client suffix for a relative ?client import", () => {
+    const plugin = pages() as any;
+    const resolved = plugin.resolveId("./foo.ts?client", "/proj/.ilha/routes.ts");
+    expect(resolved).toBe("/proj/.ilha/foo.ts?client");
+  });
+
+  it("resolveId resolves ../ paths relative to importer", () => {
+    const plugin = pages() as any;
+    const resolved = plugin.resolveId("../src/pages/index.ts?client", "/proj/.ilha/routes.ts");
+    expect(resolved).toBe("/proj/src/pages/index.ts?client");
+  });
+
+  it("resolveId without ?client suffix is unaffected", () => {
+    const plugin = pages() as any;
+    expect(plugin.resolveId("./foo.ts", "/proj/.ilha/routes.ts")).toBeUndefined();
+  });
+
+  it("load(?client) emits `export { default }` from the bare path", () => {
+    const plugin = pages() as any;
+    const result = plugin.load("/proj/src/pages/index.ts?client");
+    expect(result).toContain("export { default }");
+    expect(result).toContain(`"/proj/src/pages/index.ts"`);
+    // No other exports — the whole point of the suffix
+    expect(result).not.toContain("load");
+  });
+
+  it("load(?client) result does not re-export non-default symbols", () => {
+    const plugin = pages() as any;
+    const result = plugin.load("/abs/path.ts?client");
+    // The re-export is specifically of `default`, nothing else
+    expect(result).toMatch(/export\s*\{\s*default\s*\}/);
+    expect(result).not.toContain("*");
+  });
+});
+
+// ─────────────────────────────────────────────
+// Vite plugin — ilha:loaders virtual module
+// ─────────────────────────────────────────────
+
+describe("pages — ilha:loaders virtual module", () => {
+  it("resolves ilha:loaders virtual id", () => {
+    const plugin = pages() as any;
+    expect(plugin.resolveId("ilha:loaders")).toBe("\0ilha:loaders");
+  });
+
+  it("load for ilha:loaders imports the generated loaders file for side effects", async () => {
+    const root = await makeDir("loaders-virt");
+    const pagesDir = join(root, "src/pages");
+    const outFile = join(root, ".ilha/routes.ts");
+    await mkdir(pagesDir, { recursive: true });
+    const plugin = pages({ dir: pagesDir, generated: outFile }) as any;
+    plugin.configResolved({ root });
+    const result = plugin.load("\0ilha:loaders");
+    expect(result).toContain("loaders.ts");
+    // Must be a bare import (side-effect) not a named re-export
+    expect(result).toMatch(/import\s+["']/);
+    expect(result).not.toContain("export");
+    await removeDir(root);
+  });
+
+  it("plugin.resolveId returns undefined for unrelated ids", () => {
+    const plugin = pages() as any;
+    expect(plugin.resolveId("random-module")).toBeUndefined();
+  });
+});

--- a/packages/router/src/vite.ts
+++ b/packages/router/src/vite.ts
@@ -23,6 +23,10 @@ interface PageEntry {
   name: string;
   layouts: string[];
   errors: string[];
+  /** True if the page module declares `export const load` / `export … function load`. */
+  hasLoader: boolean;
+  /** Subset of `layouts` whose modules declare a `load` export. */
+  loaderLayouts: string[];
 }
 
 // ─────────────────────────────────────────────
@@ -31,6 +35,30 @@ interface PageEntry {
 
 /** Files that should never be treated as pages even if they match the ts/tsx extension. */
 const EXCLUDED_RE = /\.(test|spec|d)\.(ts|tsx)$/;
+
+// ─────────────────────────────────────────────
+// Codegen — loader export detection
+// ─────────────────────────────────────────────
+
+/**
+ * Match a top-of-statement `export const load`, `export let load`,
+ * `export function load`, or `export async function load`. Intentionally
+ * conservative: `export { load } from "./x"` re-exports are NOT detected
+ * in v1. Declare `load` directly in the file to be picked up.
+ */
+const LOADER_EXPORT_RE = /^\s*export\s+(?:const|let|var|async\s+function|function)\s+load\b/m;
+
+async function hasLoaderExport(file: string): Promise<boolean> {
+  try {
+    const src = await readFile(file, "utf8");
+    // Strip single-line comments at the start of lines to avoid matching
+    // commented-out loaders. Block comments are rare enough to skip.
+    const stripped = src.replace(/^\s*\/\/.*$/gm, "");
+    return LOADER_EXPORT_RE.test(stripped);
+  } catch {
+    return false;
+  }
+}
 
 // ─────────────────────────────────────────────
 // Codegen — filename → rou3 pattern
@@ -144,16 +172,41 @@ async function scanPages(pagesDir: string): Promise<PageEntry[]> {
   const all = await collectFiles(pagesDir);
   const allSet = new Set(all);
   const pages = all.filter((f) => !basename(f).startsWith("+"));
-  return pages.map((file) => {
-    const pattern = fileToPattern(pagesDir, file);
-    return {
-      file,
-      pattern,
-      name: patternToName(pattern),
-      layouts: chainForFile(pagesDir, file, allSet, "+layout.ts"),
-      errors: chainForFile(pagesDir, file, allSet, "+error.ts"),
-    };
-  });
+
+  // Detect loader exports on pages and on +layout.ts files in parallel. Error
+  // sentinels don't carry loaders so we skip them. Cache layout results since
+  // the same layout can apply to many pages.
+  const layoutLoaderCache = new Map<string, Promise<boolean>>();
+  const getLayoutHasLoader = (file: string): Promise<boolean> => {
+    let cached = layoutLoaderCache.get(file);
+    if (!cached) {
+      cached = hasLoaderExport(file);
+      layoutLoaderCache.set(file, cached);
+    }
+    return cached;
+  };
+
+  return Promise.all(
+    pages.map(async (file) => {
+      const pattern = fileToPattern(pagesDir, file);
+      const layouts = chainForFile(pagesDir, file, allSet, "+layout.ts");
+      const errors = chainForFile(pagesDir, file, allSet, "+error.ts");
+      const [pageHasLoader, ...layoutFlags] = await Promise.all([
+        hasLoaderExport(file),
+        ...layouts.map(getLayoutHasLoader),
+      ]);
+      const loaderLayouts = layouts.filter((_, i) => layoutFlags[i]);
+      return {
+        file,
+        pattern,
+        name: patternToName(pattern),
+        layouts,
+        errors,
+        hasLoader: pageHasLoader,
+        loaderLayouts,
+      };
+    }),
+  );
 }
 
 // ─────────────────────────────────────────────
@@ -211,6 +264,7 @@ async function generate(pagesDir: string, outFile: string): Promise<void> {
     return r.startsWith(".") ? r : `./${r}`;
   };
 
+  // ─── Client-safe routes file ────────────────────────────────────────────
   const imports: string[] = [
     `import { router, wrapLayout, wrapError } from "@ilha/router";`,
     `import type { Island } from "ilha";`,
@@ -220,15 +274,26 @@ async function generate(pagesDir: string, outFile: string): Promise<void> {
   const registryLines: string[] = [];
   const routeLines: string[] = [];
 
+  // The `?client` query suffix resolves (via the plugin) to a virtual module
+  // that re-exports only the default. This strips `load` and any symbol only
+  // reachable from `load`, keeping server-only code out of the client bundle.
+  const clientImport = (abs: string) => `${rel(abs)}?client`;
+
   for (const [i, entry] of entries.entries()) {
     const pageId = `_page${i}`;
-    imports.push(`import { default as ${pageId} } from ${JSON.stringify(rel(entry.file))};`);
+    imports.push(
+      `import { default as ${pageId} } from ${JSON.stringify(clientImport(entry.file))};`,
+    );
 
     for (const [j, l] of entry.layouts.entries())
-      imports.push(`import { default as _layout${i}_${j} } from ${JSON.stringify(rel(l))};`);
+      imports.push(
+        `import { default as _layout${i}_${j} } from ${JSON.stringify(clientImport(l))};`,
+      );
 
     for (const [j, e] of entry.errors.entries())
-      imports.push(`import { default as _error${i}_${j} } from ${JSON.stringify(rel(e))};`);
+      imports.push(
+        `import { default as _error${i}_${j} } from ${JSON.stringify(clientImport(e))};`,
+      );
 
     let expr = pageId;
     for (let j = entry.errors.length - 1; j >= 0; j--) expr = `wrapError(_error${i}_${j}, ${expr})`;
@@ -263,10 +328,90 @@ async function generate(pagesDir: string, outFile: string): Promise<void> {
 
   // Only write if content actually changed — avoids unnecessary HMR invalidation
   await mkdir(dirname(outFile), { recursive: true });
-  const changed = await writeIfChanged(outFile, code);
-  if (changed) {
+  const routesChanged = await writeIfChanged(outFile, code);
+
+  // ─── Server-only loaders file ───────────────────────────────────────────
+  const loadersFile = join(dirname(outFile), "loaders.ts");
+  const loadersCode = buildLoadersFile(entries, loadersFile, outFile);
+  const loadersChanged = await writeIfChanged(loadersFile, loadersCode);
+
+  if (routesChanged || loadersChanged) {
     await generateTypes(outFile);
   }
+}
+
+// ─────────────────────────────────────────────
+// Codegen — build the server-only loaders file
+// ─────────────────────────────────────────────
+
+function buildLoadersFile(entries: PageEntry[], loadersFile: string, routesFile: string): string {
+  const relFromLoaders = (abs: string) => {
+    const r = relative(dirname(loadersFile), abs);
+    return r.startsWith(".") ? r : `./${r}`;
+  };
+
+  // Only include pages that have at least one loader in their chain (page or
+  // any layout). Pages without any loaders don't need an attachLoader call.
+  const withLoaders = entries.filter((e) => e.hasLoader || e.loaderLayouts.length > 0);
+
+  if (withLoaders.length === 0) {
+    return [
+      `// @generated by @ilha/router — do not edit`,
+      `// This project has no loader exports; this file is intentionally empty.`,
+      ``,
+      `export {};`,
+      ``,
+    ].join("\n");
+  }
+
+  const routesRel = relFromLoaders(routesFile).replace(/\.ts$/, "");
+
+  const imports: string[] = [`import { pageRouter } from ${JSON.stringify(routesRel)};`];
+  let needsComposeLoaders = false;
+
+  const attachLines: string[] = [];
+
+  for (const [i, entry] of withLoaders.entries()) {
+    // Unique local names per page index to avoid collisions when the same
+    // layout file is imported by many pages (we import it once per page for
+    // clarity — Vite dedupes the underlying module anyway).
+    const loaderIds: string[] = [];
+
+    for (const [j, layout] of entry.loaderLayouts.entries()) {
+      const id = `_p${i}_l${j}`;
+      imports.push(`import { load as ${id} } from ${JSON.stringify(relFromLoaders(layout))};`);
+      loaderIds.push(id);
+    }
+
+    if (entry.hasLoader) {
+      const id = `_p${i}`;
+      imports.push(`import { load as ${id} } from ${JSON.stringify(relFromLoaders(entry.file))};`);
+      loaderIds.push(id);
+    }
+
+    const loadersExpr =
+      loaderIds.length === 1 ? loaderIds[0] : `composeLoaders([${loaderIds.join(", ")}])`;
+    if (loaderIds.length > 1) needsComposeLoaders = true;
+
+    attachLines.push(`pageRouter.attachLoader(${JSON.stringify(entry.pattern)}, ${loadersExpr});`);
+  }
+
+  // Only import composeLoaders if at least one page needs it (multiple loaders)
+  if (needsComposeLoaders) {
+    imports.unshift(`import { composeLoaders } from "@ilha/router";`);
+  }
+
+  return [
+    `// @generated by @ilha/router — do not edit`,
+    `// Server-only. Import this module from your SSR entry to wire loaders`,
+    `// onto pageRouter. Importing it from the client is a no-op but wastes`,
+    `// bundle size — rely on the default build pipeline to keep it out.`,
+    ``,
+    ...imports,
+    ``,
+    ...attachLines,
+    ``,
+  ].join("\n");
 }
 
 // ─────────────────────────────────────────────
@@ -304,6 +449,10 @@ async function generateTypes(outFile: string): Promise<void> {
     `  export const registry: Record<string, Island<any, any>>;`,
     `}`,
     ``,
+    `declare module "ilha:loaders" {`,
+    `  // Side-effect-only module. Importing it attaches loaders to pageRouter.`,
+    `}`,
+    ``,
   ].join("\n");
 
   await writeIfChanged(dtsFile, types);
@@ -315,8 +464,13 @@ async function generateTypes(outFile: string): Promise<void> {
 
 const VIRTUAL_PAGES = "ilha:pages";
 const VIRTUAL_REGISTRY = "ilha:registry";
+const VIRTUAL_LOADERS = "ilha:loaders";
 const RESOLVED_PAGES = "\0ilha:pages";
 const RESOLVED_REGISTRY = "\0ilha:registry";
+const RESOLVED_LOADERS = "\0ilha:loaders";
+
+/** Query suffix used on page/layout imports in the client-safe routes file. */
+const CLIENT_QUERY = "?client";
 
 export interface IlhaPagesOptions {
   /** Directory containing page files. Default: `src/pages` */
@@ -328,6 +482,7 @@ export interface IlhaPagesOptions {
 export function pages(options: IlhaPagesOptions = {}): Plugin {
   let pagesDir: string;
   let outFile: string;
+  let loadersFile: string;
 
   async function regen() {
     try {
@@ -343,6 +498,7 @@ export function pages(options: IlhaPagesOptions = {}): Plugin {
     configResolved(config) {
       pagesDir = resolve(config.root, options.dir ?? "src/pages");
       outFile = resolve(config.root, options.generated ?? ".ilha/routes.ts");
+      loadersFile = join(dirname(outFile), "loaders.ts");
     },
 
     async buildStart() {
@@ -352,43 +508,64 @@ export function pages(options: IlhaPagesOptions = {}): Plugin {
     configureServer(server) {
       server.watcher.add(pagesDir);
 
-      // Only regen on structural changes (add/remove), not content edits.
-      // Content edits to page files are handled by Vite's normal HMR.
+      // Structural changes (add/remove, +layout/+error edits, AND any edit
+      // that could toggle the presence of a `load` export) trigger regen.
       const structuralInvalidate = async (file: string) => {
         if (!file.startsWith(pagesDir)) return;
         await regen();
-        for (const id of [RESOLVED_PAGES, RESOLVED_REGISTRY]) {
+        for (const id of [RESOLVED_PAGES, RESOLVED_REGISTRY, RESOLVED_LOADERS]) {
           const mod = server.moduleGraph.getModuleById(id);
           if (mod) server.moduleGraph.invalidateModule(mod);
         }
         server.hot.send({ type: "full-reload" });
       };
 
-      // Structural events: file/dir added or removed
       server.watcher.on("add", structuralInvalidate);
       server.watcher.on("addDir", structuralInvalidate);
       server.watcher.on("unlink", structuralInvalidate);
 
-      // Content changes to sentinel files (+layout.ts, +error.ts) affect wrapping,
-      // so we treat those as structural. Regular page content changes are HMR'd by Vite.
+      // Edits to page/layout files may add or remove a `load` export, which
+      // changes whether attachLoader() is emitted. Run the regen; if the
+      // generated files are byte-identical, writeIfChanged is a no-op.
       server.watcher.on("change", async (file: string) => {
         if (!file.startsWith(pagesDir)) return;
         const base = basename(file);
-        if (base.startsWith("+")) {
+        if (base.startsWith("+") || /\.(ts|tsx)$/.test(base)) {
           await structuralInvalidate(file);
         }
-        // else: normal page content change — Vite HMR handles it
       });
     },
 
-    resolveId(id) {
+    resolveId(id, importer) {
       if (id === VIRTUAL_PAGES) return RESOLVED_PAGES;
       if (id === VIRTUAL_REGISTRY) return RESOLVED_REGISTRY;
+      if (id === VIRTUAL_LOADERS) return RESOLVED_LOADERS;
+
+      // `?client` suffix — resolve to a virtual module wrapping the real file.
+      // We keep the suffix in the resolved id so `load()` can branch on it.
+      if (id.endsWith(CLIENT_QUERY)) {
+        const bare = id.slice(0, -CLIENT_QUERY.length);
+        // Resolve relative to importer if we have one; otherwise use as-is.
+        const resolved = importer
+          ? resolve(dirname(importer.replace(/\?.*$/, "")), bare)
+          : resolve(bare);
+        return resolved + CLIENT_QUERY;
+      }
     },
 
     load(id) {
       if (id === RESOLVED_PAGES) return `export { pageRouter } from ${JSON.stringify(outFile)};`;
       if (id === RESOLVED_REGISTRY) return `export { registry } from ${JSON.stringify(outFile)};`;
+      if (id === RESOLVED_LOADERS) {
+        return `import ${JSON.stringify(loadersFile)};`;
+      }
+
+      // `?client` virtual: re-export only `default` from the underlying file.
+      // Rollup DCE will drop any non-default export and its dependency tree.
+      if (id.endsWith(CLIENT_QUERY)) {
+        const bare = id.slice(0, -CLIENT_QUERY.length);
+        return `export { default } from ${JSON.stringify(bare)};`;
+      }
     },
   };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `attachLoader()` method to route builder for attaching loaders to specific routes.
  * Automatic loader detection and composition for pages and layouts in the routing hierarchy.

* **Tests**
  * Added comprehensive test coverage for router code generation and Vite integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->