### PR TITLE
feat(ilha): add .css and css`` for applying scoped styling to islands

### DIFF
--- a/packages/ilha/README.md
+++ b/packages/ilha/README.md
@@ -262,7 +262,7 @@ ilha.css(styles).render(() => `<div class="card">…</div>`);
 
 ```html
 <style data-ilha-css>
-  @scope {
+  @scope (:scope) to ([data-ilha]) {
     .title {
       font-weight: 700;
     }

--- a/packages/ilha/README.md
+++ b/packages/ilha/README.md
@@ -129,7 +129,6 @@ ilha
   .on("@click", ({ state }) => state.count(state.count() + 1)) // host click
   .on("button.inc@click", ({ state }) => state.count(state.count() + 1)) // child click
   .on("input@input:debounce", ({ state, event }) => {
-    // with modifier
     state.query((event.target as HTMLInputElement).value);
   })
   .render(({ state }) => html`<div><button class="inc">+</button></div>`);
@@ -220,6 +219,63 @@ You can also bind to an external signal created with `context()`:
 ```ts
 .bind("input", myContextSignal)
 ```
+
+---
+
+### `.css(strings, ...values)`
+
+Attaches scoped styles to the island. Accepts a tagged template literal or a plain string. The CSS is automatically wrapped in a `@scope` rule bounded to the island host, so styles are contained within the island and do not leak into child islands.
+
+```ts
+import { css } from "ilha";
+
+const Card = ilha.state("active", false).css`
+    .title { font-weight: 700; }
+    button { background: teal; color: white; }
+  `.render(
+  ({ state }) => html`
+    <div>
+      <p class="title">Hello</p>
+      <button>Toggle</button>
+    </div>
+  `,
+);
+```
+
+Interpolations are supported:
+
+```ts
+const accent = "teal";
+
+ilha.css`button { background: ${accent}; }`.render(() => `<button>Go</button>`);
+```
+
+You can also pass a plain string (e.g. from an external `.css` file):
+
+```ts
+import styles from "./card.css?raw";
+
+ilha.css(styles).render(() => `<div class="card">…</div>`);
+```
+
+**SSR output** — a `<style data-ilha-css>` tag is prepended as the first child of the island's rendered HTML:
+
+```html
+<style data-ilha-css>
+  @scope {
+    .title {
+      font-weight: 700;
+    }
+  }
+</style>
+<div>…</div>
+```
+
+**Client mount** — the style element is injected once as the first child of the host and preserved across re-renders (morph never replaces it). During hydration, the SSR-emitted `<style>` node is reused and not duplicated.
+
+**`.hydratable()` integration** — the style tag is included inside the `data-ilha` wrapper regardless of the `snapshot` option.
+
+> **Note:** Calling `.css()` more than once on the same builder chain is not supported. In dev mode a warning is logged and only the last stylesheet is used. Compose all your styles into a single `.css()` call.
 
 ---
 
@@ -427,6 +483,41 @@ import { raw } from "ilha";
 
 raw("<strong>bold</strong>"); // → passes through unescaped
 ```
+
+---
+
+### `css\`\`` tagged template
+
+A passthrough tagged template for CSS strings. Functionally identical to a plain template literal — no runtime transformation occurs. Its purpose is purely to enable editor tooling (LSP syntax highlighting, Prettier formatting) to recognise the contents as CSS.
+
+```ts
+import { css } from "ilha";
+
+const styles = css`
+  button {
+    background: teal;
+    color: white;
+  }
+  .label {
+    font-weight: 700;
+  }
+`;
+
+ilha.css(styles).render(() => `<button class="label">Go</button>`);
+```
+
+Interpolations work as normal string concatenation:
+
+```ts
+const accent = "coral";
+const styles = css`
+  button {
+    background: ${accent};
+  }
+`;
+```
+
+> **Note:** `css` (the named export) is the plain passthrough tag for tooling. `ilha.css` is the builder chain method that attaches styles to an island. They are intentionally separate.
 
 ---
 

--- a/packages/ilha/src/index.test.ts
+++ b/packages/ilha/src/index.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { z } from "zod";
 
 import type { SlotAccessor } from "./index";
-import ilha, { html, raw, mount, from, context } from "./index";
+import ilha, { html, raw, css, mount, from, context } from "./index";
 
 // ---------------------------------------------
 // Helpers
@@ -3099,5 +3099,425 @@ describe("diagnostic: derived + slot + whitespace", () => {
 
     unmount();
     cleanup(el);
+  });
+});
+
+// ---------------------------------------------
+// .css() — scoped stylesheets
+// ---------------------------------------------
+//
+// The .css() chain method attaches a stylesheet that is scoped to the island
+// host via the CSS @scope at-rule. The wrapped stylesheet is emitted as a
+// <style data-ilha-css> element prepended to the island's rendered HTML in
+// both SSR and client-mount paths. These tests cover:
+//
+//   1. Backwards compatibility — no style tag when .css() is not called
+//   2. Output shape — SSR + hydratable contain exactly one <style> wrapped in @scope
+//   3. Scoping semantics — wrapper uses (:scope) upper + ([data-ilha]) lower
+//   4. Passthrough tag — the `css` tagged-template export is a plain string builder
+//   5. Dev warning on double-call
+//   6. Morph preserves <style> on state-driven re-renders (no flicker, no rebuild)
+//   7. Works alongside all other builder features (slots, derived, events, etc.)
+
+describe(".css()", () => {
+  describe("backwards compatibility", () => {
+    it("emits no <style> tag when .css() is not called", () => {
+      const island = ilha.state("count", 0).render(({ state }) => `<p>${state.count()}</p>`);
+
+      expect(island.toString()).toBe("<p>0</p>");
+      expect(island.toString()).not.toContain("<style");
+    });
+
+    it("emits no <style> tag for mount() when .css() is not called", () => {
+      const island = ilha.state("count", 0).render(({ state }) => `<p>${state.count()}</p>`);
+
+      const el = makeEl();
+      const unmount = island.mount(el);
+      expect(el.querySelector("style")).toBeNull();
+      unmount();
+      cleanup(el);
+    });
+  });
+
+  describe("SSR output shape", () => {
+    it("prepends a <style data-ilha-css> tag as the first child of the island", () => {
+      const island = ilha
+        .state("count", 0)
+        .css("button { color: red; }")
+        .render(({ state }) => `<p>${state.count()}</p>`);
+
+      const out = island.toString();
+      expect(out.startsWith("<style data-ilha-css>")).toBe(true);
+    });
+
+    it("emits exactly one <style> tag per render", () => {
+      const island = ilha
+        .state("count", 0)
+        .css("p { color: red; }")
+        .render(({ state }) => `<p>${state.count()}</p>`);
+
+      const out = island.toString();
+      const matches = out.match(/<style/g) ?? [];
+      expect(matches.length).toBe(1);
+    });
+
+    it("wraps user CSS in @scope (:scope) to ([data-ilha]) { ... }", () => {
+      const island = ilha.css("button { color: red; }").render(() => `<button>go</button>`);
+
+      const out = island.toString();
+      expect(out).toContain("@scope (:scope) to ([data-ilha]){");
+      expect(out).toContain("button { color: red; }");
+    });
+
+    it("preserves raw CSS verbatim inside the @scope wrapper", () => {
+      const src = "p { font-weight: 600; } .box > .item:hover { opacity: 0.5; }";
+      const island = ilha.css(src).render(() => `<div class="box"></div>`);
+      expect(island.toString()).toContain(src);
+    });
+
+    it("accepts a tagged-template literal and renders the same as a plain string", () => {
+      // Both should produce identical output: the tag is pure passthrough, so a
+      // tagged call and a plain call with the same source text are equivalent.
+      const src = `button { color: red; }`;
+      const tagged = ilha.css`button { color: red; }`.render(() => `<button>a</button>`);
+      const plain = ilha.css(src).render(() => `<button>a</button>`);
+      expect(tagged.toString()).toBe(plain.toString());
+    });
+
+    it("interpolates template expressions into the CSS source", () => {
+      // Whatever whitespace the formatter imposes on the tagged template, the
+      // interpolated value itself ("red") must appear in the rendered stylesheet.
+      const accent = "red";
+      const island = ilha.css`button { color: ${accent}; }`.render(() => `<button>x</button>`);
+      const out = island.toString();
+      expect(out).toContain(accent);
+      // The declaration must be syntactically intact regardless of whitespace,
+      // so strip the style block and normalise whitespace for comparison.
+      const normalised = out.replace(/\s+/g, " ");
+      expect(normalised).toContain("color: red");
+    });
+
+    it("preserves island content after the <style> tag", () => {
+      const island = ilha.css("p { color: red; }").render(() => `<p>hi</p>`);
+
+      const out = island.toString();
+      expect(out).toBe(
+        "<style data-ilha-css>@scope (:scope) to ([data-ilha]){p { color: red; }}</style><p>hi</p>",
+      );
+    });
+  });
+
+  describe(".hydratable() output shape", () => {
+    it("places the <style> tag inside the data-ilha wrapper", async () => {
+      const island = ilha
+        .state("count", 0)
+        .css("button { color: red; }")
+        .render(({ state }) => `<p>${state.count()}</p><button>+</button>`);
+
+      const out = await island.hydratable({}, { name: "styled", snapshot: false });
+      const doc = new DOMParser().parseFromString(out, "text/html");
+      const wrapper = doc.querySelector("[data-ilha='styled']");
+      expect(wrapper).not.toBeNull();
+      const style = wrapper!.querySelector("style[data-ilha-css]");
+      expect(style).not.toBeNull();
+      expect(style!.textContent).toContain("@scope (:scope) to ([data-ilha])");
+    });
+
+    it("still emits the <style> tag when snapshot=true", async () => {
+      const island = ilha
+        .state("count", 5)
+        .css(".label { font-weight: 700; }")
+        .render(({ state }) => `<p class="label">${state.count()}</p>`);
+
+      const out = await island.hydratable({}, { name: "counted", snapshot: true });
+      expect(out).toContain("<style data-ilha-css>");
+      expect(out).toContain("data-ilha-state=");
+    });
+  });
+
+  describe("passthrough `css` tag export", () => {
+    it("returns a string equal to what a plain untagged template would produce", () => {
+      // Deliberately written so the formatter can break it across lines however
+      // it likes. The contract is: `css\`X\`` === the plain template literal `X`.
+      const color = "red";
+      const tagged = css`button { color: ${color}; }`;
+      const plain = `button { color: ${color}; }`;
+      expect(tagged).toBe(plain);
+    });
+
+    it("does not perform any dedenting or whitespace normalisation", () => {
+      // Whatever whitespace is in the source literal, the tag returns it verbatim.
+      // We compare against the untagged version of the same literal so this test
+      // is resilient to any formatter reflowing the template.
+      const tagged = css`
+        button {
+          color: red;
+        }
+      `;
+      const plain = `
+        button {
+          color: red;
+        }
+      `;
+      expect(tagged).toBe(plain);
+    });
+
+    it("interpolates values as plain string concatenation", () => {
+      const color = "blue";
+      const size = 12;
+      const tagged = css`p { color: ${color}; font-size: ${size}px; }`;
+      const plain = `p { color: ${color}; font-size: ${size}px; }`;
+      expect(tagged).toBe(plain);
+    });
+
+    it("ilha.css is the builder method, not the passthrough tag", () => {
+      // The free-standing `css` export is the passthrough tag for tooling.
+      // `ilha.css` is the builder chain method, reached because IlhaBuilder
+      // has a .css() method. They are intentionally different callables.
+      expect(typeof ilha.css).toBe("function");
+      expect(ilha.css).not.toBe(css);
+    });
+
+    it("can be used as a plain string builder (non-tagged call)", () => {
+      // TS type allows TemplateStringsArray | string; runtime should accept both.
+      const s = (css as (v: string) => string)("p { margin: 0; }");
+      expect(s).toBe("p { margin: 0; }");
+    });
+  });
+
+  describe("dev-mode warnings", () => {
+    let warnSpy: ReturnType<typeof spyOn>;
+
+    beforeEach(() => {
+      warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it("warns when .css() is called more than once on the same chain", () => {
+      ilha
+        .css("p { color: red; }")
+        .css("p { color: blue; }")
+        .render(() => `<p>x</p>`);
+
+      expect(warnSpy).toHaveBeenCalled();
+      const msg: string = warnSpy.mock.calls[0]?.[0] ?? "";
+      expect(msg).toMatch(/ilha/i);
+      expect(msg).toMatch(/css/i);
+    });
+
+    it("uses the most recently supplied stylesheet when called twice", () => {
+      const island = ilha
+        .css("p { color: red; }")
+        .css("p { color: blue; }")
+        .render(() => `<p>x</p>`);
+
+      const out = island.toString();
+      expect(out).toContain("p { color: blue; }");
+      expect(out).not.toContain("p { color: red; }");
+    });
+
+    it("does NOT warn when .css() is called exactly once", () => {
+      ilha.css("p { color: red; }").render(() => `<p>x</p>`);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("client mount", () => {
+    it("inserts the <style> tag as the first child of the host", () => {
+      const island = ilha
+        .state("count", 0)
+        .css("p { color: red; }")
+        .render(({ state }) => `<p>${state.count()}</p>`);
+
+      const el = makeEl();
+      const unmount = island.mount(el);
+
+      const firstChild = el.firstElementChild;
+      expect(firstChild).not.toBeNull();
+      expect(firstChild!.tagName.toLowerCase()).toBe("style");
+      expect(firstChild!.hasAttribute("data-ilha-css")).toBe(true);
+
+      unmount();
+      cleanup(el);
+    });
+
+    it("preserves the <style> element across state-driven re-renders", () => {
+      let setCount!: (v: number) => void;
+
+      const island = ilha
+        .state("count", 0)
+        .css("p { color: red; }")
+        .render(({ state }) => {
+          setCount = state.count as unknown as (v: number) => void;
+          return `<p>${state.count()}</p>`;
+        });
+
+      const el = makeEl();
+      const unmount = island.mount(el);
+
+      const styleBefore = el.querySelector("style[data-ilha-css]");
+      expect(styleBefore).not.toBeNull();
+
+      // Trigger a re-render via state change
+      setCount(42);
+      expect(el.querySelector("p")!.textContent).toBe("42");
+
+      const styleAfter = el.querySelector("style[data-ilha-css]");
+      expect(styleAfter).not.toBeNull();
+      // Same node identity — morph should NOT have replaced it.
+      expect(styleAfter).toBe(styleBefore);
+      expect(el.querySelectorAll("style[data-ilha-css]").length).toBe(1);
+
+      unmount();
+      cleanup(el);
+    });
+
+    it("preserves <style> content across many re-renders", () => {
+      let setCount!: (v: number) => void;
+
+      const island = ilha
+        .state("count", 0)
+        .css(".value { color: red; }")
+        .render(({ state }) => {
+          setCount = state.count as unknown as (v: number) => void;
+          return `<p class="value">${state.count()}</p>`;
+        });
+
+      const el = makeEl();
+      const unmount = island.mount(el);
+
+      for (let i = 1; i <= 20; i++) setCount(i);
+
+      const style = el.querySelector("style[data-ilha-css]");
+      expect(style).not.toBeNull();
+      expect(style!.textContent).toContain(".value { color: red; }");
+      expect(el.querySelector("p")!.textContent).toBe("20");
+
+      unmount();
+      cleanup(el);
+    });
+  });
+
+  describe("hydration", () => {
+    it("does not duplicate the <style> tag when mounting over SSR output", async () => {
+      const island = ilha
+        .state("count", 0)
+        .css("p { color: red; }")
+        .render(({ state }) => `<p>${state.count()}</p>`);
+
+      const ssr = await island.hydratable({}, { name: "styled", snapshot: true });
+
+      document.body.innerHTML = ssr;
+      const wrapper = document.querySelector("[data-ilha='styled']")!;
+
+      const before = wrapper.querySelectorAll("style[data-ilha-css]").length;
+      expect(before).toBe(1);
+
+      const unmount = island.mount(wrapper);
+
+      const after = wrapper.querySelectorAll("style[data-ilha-css]").length;
+      expect(after).toBe(1);
+
+      unmount();
+      document.body.innerHTML = "";
+    });
+
+    it("keeps the same <style> element after hydration + first re-render", async () => {
+      let setCount!: (v: number) => void;
+
+      const island = ilha
+        .state("count", 0)
+        .css(".c { color: red; }")
+        .render(({ state }) => {
+          setCount = state.count as unknown as (v: number) => void;
+          return `<p class="c">${state.count()}</p>`;
+        });
+
+      const ssr = await island.hydratable({}, { name: "h", snapshot: true });
+      document.body.innerHTML = ssr;
+      const wrapper = document.querySelector("[data-ilha='h']")!;
+      const styleBefore = wrapper.querySelector("style[data-ilha-css]");
+
+      const unmount = island.mount(wrapper);
+      setCount(7);
+
+      const styleAfter = wrapper.querySelector("style[data-ilha-css]");
+      expect(styleAfter).not.toBeNull();
+      // After hydration the mount re-uses the SSR-emitted style node; subsequent
+      // morph passes should not replace it.
+      expect(styleAfter).toBe(styleBefore);
+
+      unmount();
+      document.body.innerHTML = "";
+    });
+  });
+
+  describe("interop with other builder features", () => {
+    it("works alongside .state / .on / .derived / events", async () => {
+      const island = ilha
+        .state("count", 1)
+        .derived("doubled", ({ state }) => state.count() * 2)
+        .css(".count { font-weight: 600; }")
+        .on("button@click", ({ state }) => state.count(state.count() + 1))
+        .render(
+          ({ state, derived }) =>
+            `<p class="count">${state.count()}/${derived.doubled.value ?? "?"}</p><button>+</button>`,
+        );
+
+      const el = makeEl();
+      const unmount = island.mount(el);
+
+      expect(el.querySelector("style[data-ilha-css]")).not.toBeNull();
+      expect(el.querySelector("p")!.textContent).toBe("1/2");
+
+      (el.querySelector("button") as HTMLButtonElement).click();
+      expect(el.querySelector("p")!.textContent).toBe("2/4");
+
+      // <style> must survive the re-render triggered by the click
+      expect(el.querySelectorAll("style[data-ilha-css]").length).toBe(1);
+
+      unmount();
+      cleanup(el);
+    });
+
+    it("child island in a slot emits its own <style> inside the slot, scoped by its own host", async () => {
+      const Inner = ilha.css("span { color: red; }").render(() => `<span>inner</span>`);
+
+      const Outer = ilha
+        .slot("inner", Inner)
+        .css("div { color: blue; }")
+        .render(({ slots }) => html`<div>${slots.inner()}</div>`);
+
+      const out = Outer.toString();
+
+      // Outer style present
+      expect(out).toContain("div { color: blue; }");
+      // Inner style present (emitted as part of the slot SSR string)
+      expect(out).toContain("span { color: red; }");
+      // Two separate @scope wrappers, one per island
+      const scopeCount = (out.match(/@scope \(:scope\) to \(\[data-ilha\]\)/g) ?? []).length;
+      expect(scopeCount).toBe(2);
+    });
+
+    it("does not interfere with .toString() synchronous contract when derived are async", () => {
+      const island = ilha
+        .state("count", 3)
+        .derived("slow", async () => {
+          await new Promise((r) => setTimeout(r, 50));
+          return "loaded";
+        })
+        .css("p { color: red; }")
+        .render(({ state, derived }) =>
+          derived.slow.loading ? `<p>loading ${state.count()}</p>` : `<p>${derived.slow.value}</p>`,
+        );
+
+      // Synchronous toString() still works and still contains the <style>
+      const out = island.toString();
+      expect(out).toContain("<style data-ilha-css>");
+      expect(out).toContain("loading 3");
+    });
   });
 });

--- a/packages/ilha/src/index.ts
+++ b/packages/ilha/src/index.ts
@@ -178,6 +178,26 @@ const SIGNAL_ACCESSOR = Symbol("ilha.signalAccessor");
 const SLOT_ATTR = "data-ilha-slot";
 const PROPS_ATTR = "data-ilha-props";
 const STATE_ATTR = "data-ilha-state";
+const CSS_ATTR = "data-ilha-css";
+
+// ---------------------------------------------
+// CSS scoping
+// ---------------------------------------------
+//
+// Wrap the user's CSS in an @scope rule bounded by the island host (upper) and
+// any nested island root (lower). This gives us:
+//   - Selectors resolved against the host's descendants only
+//   - Low-specificity selectors that don't win cascade wars with utilities
+//   - A donut hole at every `[data-ilha]` descendant so parent styles don't
+//     leak into child islands
+//
+// The resulting <style> element is emitted as the first child of the host on
+// every render. Because it's deterministically the same node on both `from`
+// and `to` sides of the morph, `morphChildren` sees a matching <style> and
+// leaves it alone — no flicker, no re-parse, no special-case code in the morph.
+function buildScopedStyle(css: string): string {
+  return `<style ${CSS_ATTR}>@scope (:scope) to ([data-ilha]){${css}}</style>`;
+}
 
 export interface RawHtml {
   [RAW]: true;
@@ -230,6 +250,21 @@ function isSignalAccessor(v: unknown): v is MarkedSignalAccessor<unknown> {
 
 function ilhaRaw(value: string): RawHtml {
   return { [RAW]: true, value };
+}
+
+// Plain passthrough tagged template for CSS. This exists purely for editor
+// tooling — it lets authors tag their stylesheets as `css\`…\`` so LSPs and
+// Prettier plugins can syntax-highlight and format the contents. No runtime
+// magic: the result is just the interpolated string, identical to what you'd
+// get from a plain template literal.
+function ilhaCss(strings: TemplateStringsArray | string, ...values: (string | number)[]): string {
+  if (typeof strings === "string") return strings;
+  let result = "";
+  for (let i = 0; i < strings.length; i++) {
+    result += strings[i];
+    if (i < values.length) result += String(values[i]);
+  }
+  return result;
 }
 
 // Resolves any interpolated value to an HTML string.
@@ -720,6 +755,7 @@ interface BuilderConfig<
   slots: Record<string, AnyIsland>;
   transition: TransitionOptions | null;
   binds: BindEntry<TStateMap>[];
+  css: string | null;
 }
 
 // ---------------------------------------------
@@ -762,6 +798,7 @@ class IlhaBuilder<
       slots: {},
       transition: null,
       binds: [],
+      css: null,
     });
   }
 
@@ -866,6 +903,36 @@ class IlhaBuilder<
     return new IlhaBuilder({ ...this._cfg, transition: opts });
   }
 
+  css(
+    strings: TemplateStringsArray | string,
+    ...values: (string | number)[]
+  ): IlhaBuilder<TInput, TStateMap, TDerivedMap, TSlots> {
+    // Accept both tagged-template form and plain-string form. The tagged form
+    // is the intended authoring style; plain-string keeps things flexible for
+    // users who want to compose CSS externally.
+    let source: string;
+    if (typeof strings === "string") {
+      source = strings;
+    } else {
+      let result = "";
+      for (let i = 0; i < strings.length; i++) {
+        result += strings[i];
+        if (i < values.length) result += String(values[i]);
+      }
+      source = result;
+    }
+
+    if (__DEV__ && this._cfg.css !== null) {
+      warn(
+        `css(): called more than once on the same builder chain. ` +
+          `The previous stylesheet has been discarded. ` +
+          `Compose styles into a single .css() call instead.`,
+      );
+    }
+
+    return new IlhaBuilder({ ...this._cfg, css: source });
+  }
+
   render(
     fn: (ctx: RenderContext<TInput, TStateMap, TDerivedMap, TSlots>) => string | RawHtml,
   ): Island<TInput, TStateMap> {
@@ -879,7 +946,10 @@ class IlhaBuilder<
       slots: slotDefs,
       transition,
       binds,
+      css: cssSource,
     } = this._cfg;
+
+    const stylePrefix = cssSource != null ? buildScopedStyle(cssSource) : "";
 
     function resolveInput(props?: Partial<TInput>): TInput {
       const value = props ?? {};
@@ -979,8 +1049,9 @@ class IlhaBuilder<
             derived[r.key] = { loading: false, value: r.result as unknown, error: undefined };
           }
         }
-        return unwrapHtml(
-          fn({ state, derived: derived as IslandDerived<TDerivedMap>, input, slots }),
+        return (
+          stylePrefix +
+          unwrapHtml(fn({ state, derived: derived as IslandDerived<TDerivedMap>, input, slots }))
         );
       }
 
@@ -1009,8 +1080,9 @@ class IlhaBuilder<
       ).then((resolved) => {
         const derived: Record<string, DerivedValue<unknown>> = {};
         for (const r of resolved) derived[r.key] = r.envelope;
-        return unwrapHtml(
-          fn({ state, derived: derived as IslandDerived<TDerivedMap>, input, slots }),
+        return (
+          stylePrefix +
+          unwrapHtml(fn({ state, derived: derived as IslandDerived<TDerivedMap>, input, slots }))
         );
       });
     }
@@ -1201,7 +1273,7 @@ class IlhaBuilder<
       // to the existing SSR content.
       const hasExistingContent = hydrated && host.childNodes.length > 0;
       if (!hasExistingContent) {
-        host.innerHTML = unwrapHtml(fn({ state, derived, input, slots }));
+        host.innerHTML = stylePrefix + unwrapHtml(fn({ state, derived, input, slots }));
       }
       attachListeners();
 
@@ -1226,7 +1298,7 @@ class IlhaBuilder<
 
       let initialized = false;
       const stopRender = effect(() => {
-        const html = unwrapHtml(fn({ state, derived, input, slots }));
+        const html = stylePrefix + unwrapHtml(fn({ state, derived, input, slots }));
         if (!initialized) {
           initialized = true;
           return;
@@ -1450,6 +1522,7 @@ const EMPTY_CFG: BuilderConfig<
   slots: {},
   transition: null,
   binds: [],
+  css: null,
 };
 
 const rootBuilder = new IlhaBuilder(EMPTY_CFG);
@@ -1480,6 +1553,7 @@ export function type<TInput, TOutput = TInput>(
 
 export const html = ilhaHtml;
 export const raw = ilhaRaw;
+export const css = ilhaCss;
 export const mount = mountAll;
 export const from = ilhaFrom;
 export const context = ilhaContext;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added .css() builder method and css tagged-template for island-scoped styling with automatic @scope wrapping; styles preserved across SSR, hydration, and reactive re-renders.
* **Documentation**
  * Added comprehensive CSS guide covering scoping, SSR/client integration, .hydratable() behavior, tooling passthrough, and constraint that multiple .css() calls are unsupported (dev warning; last wins).
* **Tests**
  * Added coverage for SSR/hydration, preservation of style nodes, nested islands, and dev-warning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->