### PR TITLE
fix(ilha): fix child derived rerender signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## `ilha`
 
+### 0.4.1 - 2026-05-06
+
+- Fixes .derived() signal in child that caused unnecessary rerender of parent.
+
 ### 0.4.0 - 2026-05-01
 
 - added `:abortable` modifier for `.on()`.
@@ -86,6 +90,10 @@ Initial release of **@ilha/form** — a tiny, typed form binding library for ilh
 
 ## `@ilha/router`
 
+### 0.2.5 - 2026-05-06
+
+- Updates Ilha dependency to 0.4.1
+
 ### 0.2.4 - 2026-05-01
 
 - Updates Ilha dependency to 0.4.0
@@ -134,6 +142,10 @@ Initial release of **@ilha/router** — a lightweight, isomorphic router for ilh
 - Adds exported types: `RouteRecord`, `RouteSnapshot`, `AppError`, `LayoutHandler`, `ErrorHandler`, `NavigateOptions`, `MountOptions`, `HydrateOptions`, `HydratableRenderOptions`, `RouterBuilder`
 
 ## `@ilha/store`
+
+### 0.2.2 - 2026-05-06
+
+- Updates Ilha dependency to 0.4.1
 
 ### 0.2.1 - 2026-05-01
 

--- a/bun.lock
+++ b/bun.lock
@@ -44,17 +44,17 @@
     },
     "packages/ilha": {
       "name": "ilha",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "alien-signals": "3.1.2",
       },
       "devDependencies": {
-        "zod": "^4.4.1",
+        "zod": "^4.4.3",
       },
     },
     "packages/router": {
       "name": "@ilha/router",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "ilha": "0.4.0",
         "rou3": "0.8.1",
@@ -65,13 +65,13 @@
     },
     "packages/store": {
       "name": "@ilha/store",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "alien-signals": "3.1.2",
-        "ilha": "0.4.0",
+        "ilha": "0.4.1",
       },
       "devDependencies": {
-        "zod": "^4.4.1",
+        "zod": "^4.4.3",
       },
     },
   },
@@ -1004,7 +1004,7 @@
 
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
-    "zod": ["zod@4.4.1", "", {}, "sha512-a6ENMBBGZBsnlSebQ/eKCguSBeGKSf4O7BPnqVPmYGtpBYI7VSqoVqw+QcB7kPRjbqPwhYTpFbVj/RqNz/CT0Q=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 

--- a/packages/ilha/package.json
+++ b/packages/ilha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ilha",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A tiny, framework-free island architecture library",
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",
@@ -26,6 +26,6 @@
     "alien-signals": "3.1.2"
   },
   "devDependencies": {
-    "zod": "^4.4.1"
+    "zod": "^4.4.3"
   }
 }

--- a/packages/ilha/src/index.test.ts
+++ b/packages/ilha/src/index.test.ts
@@ -1878,6 +1878,161 @@ describe("Island mount", () => {
       });
     });
   });
+
+  describe("BUG: subscription leak via island.toString() inside parent render effect", () => {
+    it("CASE I (suspected bug): parent calls child.toString() in its render — child's derived leaks subscription to parent", () => {
+      // Mirrors what `RouterView` does in @ilha/router:
+      //   ilha.render(() => `<div>${island.toString()}</div>`)
+      //
+      // The child island has a .derived() that reads an external signal.
+      // When the parent's render effect runs island.toString(), the child's
+      // derived fn is invoked with the parent's render effect as the active
+      // subscriber → parent gets subscribed to the external signal.
+
+      const params = signal({ path: "/initial.md" });
+
+      let parentRenders = 0;
+      let childMounts = 0;
+
+      const Topbar = ilha
+        .derived("filename", () => {
+          const p = params();
+          return (p.path ?? "").split("/").pop() || "untitled.md";
+        })
+        .render(({ derived }) => html`<div data-tb>${derived.filename.value}</div>`);
+
+      // Mirror RouterView pattern: parent calls child.toString() (NOT interpolation).
+      const ParentView = ilha.render(() => {
+        parentRenders++;
+        // Note the .toString() call — this is what RouterView does.
+        return html`<section>${Topbar.toString() as unknown as { value: string }}</section>` as any;
+      });
+
+      // Hmm, .toString returns a string, but html`` would escape it. Use raw:
+      // Actually let's just use the same pattern as RouterView — concat strings.
+      const ParentView2 = ilha.render(() => {
+        parentRenders++;
+        return `<section>${Topbar.toString()}</section>`;
+      });
+
+      const el = makeEl();
+      const unmount = ParentView2.mount(el);
+      void Topbar; // silence unused
+      void ParentView; // silence unused
+      void childMounts; // silence unused
+
+      const p0 = parentRenders;
+      // Change params — should NOT re-render the parent if there's no leak.
+      params({ path: "/foo/bar.md" });
+
+      expect({
+        parentDelta: parentRenders - p0,
+      }).toEqual({
+        parentDelta: 0, // if this is 1, the leak is confirmed
+      });
+
+      unmount();
+      cleanup(el);
+    });
+
+    it("CASE J (control): same as above but child uses .state + .effect — no leak", () => {
+      const params = signal({ path: "/initial.md" });
+
+      let parentRenders = 0;
+
+      const Topbar = ilha
+        .state("filename", "untitled.md")
+        .effect(({ state }) => {
+          const p = params();
+          state.filename((p.path ?? "").split("/").pop() || "untitled.md");
+        })
+        .render(({ state }) => html`<div data-tb>${state.filename()}</div>`);
+
+      const ParentView = ilha.render(() => {
+        parentRenders++;
+        return `<section>${Topbar.toString()}</section>`;
+      });
+
+      const el = makeEl();
+      const unmount = ParentView.mount(el);
+
+      const p0 = parentRenders;
+      params({ path: "/foo/bar.md" });
+
+      expect({
+        parentDelta: parentRenders - p0,
+      }).toEqual({
+        parentDelta: 0,
+      });
+
+      unmount();
+      cleanup(el);
+    });
+
+    it("CASE K (direct repro of router shape): parent reads activeIsland(), calls activeIsland().toString()", () => {
+      // Even closer to RouterView's actual shape.
+      const params = signal({ path: "/initial.md" });
+
+      let parentRenders = 0;
+
+      const PageA = ilha
+        .derived("filename", () => {
+          const p = params();
+          return (p.path ?? "").split("/").pop() || "untitled.md";
+        })
+        .render(({ derived }) => html`<div data-page="A">${derived.filename.value}</div>`);
+
+      const activeIsland = signal<typeof PageA | null>(PageA);
+
+      const RouterView = ilha.render(() => {
+        parentRenders++;
+        const island = activeIsland();
+        if (!island) return `<div data-empty></div>`;
+        return `<div data-view>${island.toString()}</div>`;
+      });
+
+      const el = makeEl();
+      const unmount = RouterView.mount(el);
+
+      const p0 = parentRenders;
+      // Only change params — activeIsland stays the same.
+      // RouterView SHOULD NOT re-render. If it does, leak confirmed.
+      params({ path: "/foo/bar.md" });
+
+      expect({
+        parentDelta: parentRenders - p0,
+      }).toEqual({
+        parentDelta: 0,
+      });
+
+      unmount();
+      cleanup(el);
+    });
+
+    it("CASE L: parent reads signal directly in child's .render() during toString from reactive scope", () => {
+      const params = signal({ path: "/initial.md" });
+      let parentRenders = 0;
+
+      const Page = ilha.render(() => {
+        // Reads params directly in render — no derived, no state
+        const p = params();
+        return html`<div>${(p.path ?? "").split("/").pop()}</div>`;
+      });
+
+      const RouterView = ilha.render(() => {
+        parentRenders++;
+        return `<div>${Page.toString()}</div>`;
+      });
+
+      const el = makeEl();
+      const unmount = RouterView.mount(el);
+      const p0 = parentRenders;
+      params({ path: "/foo/bar.md" });
+      expect(parentRenders - p0).toBe(0);
+      unmount();
+      cleanup(el);
+    });
+  });
 });
 
 // ---------------------------------------------

--- a/packages/ilha/src/index.test.ts
+++ b/packages/ilha/src/index.test.ts
@@ -1877,6 +1877,27 @@ describe("Island mount", () => {
         expect(() => mount({ Counter })).not.toThrow();
       });
     });
+
+    it("hydratable() records sync-throwing derived as error entry, doesn't reject", async () => {
+      const Island = ilha
+        .derived("bad", () => {
+          throw new Error("kaboom");
+        })
+        .render(() => `<p>x</p>`);
+
+      const html = await Island.hydratable({}, { name: "test", snapshot: true });
+      expect(html).toContain("data-ilha-state");
+      // Pull out and parse the snapshot
+      const match = html.match(/data-ilha-state='([^']+)'/);
+      expect(match).toBeTruthy();
+      const decoded = match![1]!.replace(/&quot;/g, '"').replace(/&#39;/g, "'");
+      const snapshot = JSON.parse(decoded);
+      expect(snapshot._derived.bad).toEqual({
+        loading: false,
+        value: undefined,
+        error: "kaboom",
+      });
+    });
   });
 
   describe("BUG: subscription leak via island.toString() inside parent render effect", () => {

--- a/packages/ilha/src/index.ts
+++ b/packages/ilha/src/index.ts
@@ -1369,6 +1369,7 @@ class IlhaBuilder<
       const state = buildPlainState(input);
 
       const results = deriveds.map((entry) => {
+        const prevSub = setActiveSub(undefined);
         try {
           return {
             key: entry.key,
@@ -1380,6 +1381,8 @@ class IlhaBuilder<
           };
         } catch (err) {
           return { key: entry.key, result: Promise.reject(err) };
+        } finally {
+          setActiveSub(prevSub);
         }
       });
 
@@ -1394,10 +1397,15 @@ class IlhaBuilder<
             derived[r.key] = { loading: false, value: r.result as unknown, error: undefined };
           }
         }
-        const { html } = renderWithCtx(() =>
-          fn({ state, derived: derived as IslandDerived<TDerivedMap>, input }),
-        );
-        return stylePrefix + html;
+        const prevSub = setActiveSub(undefined);
+        try {
+          const { html } = renderWithCtx(() =>
+            fn({ state, derived: derived as IslandDerived<TDerivedMap>, input }),
+          );
+          return stylePrefix + html;
+        } finally {
+          setActiveSub(prevSub);
+        }
       }
 
       return Promise.all(
@@ -1425,12 +1433,17 @@ class IlhaBuilder<
       ).then(async (resolved) => {
         const derived: Record<string, DerivedValue<unknown>> = {};
         for (const r of resolved) derived[r.key] = r.envelope;
-        const { html } = await renderWithCtx(
-          () => fn({ state, derived: derived as IslandDerived<TDerivedMap>, input }),
-          undefined,
-          true,
-        );
-        return stylePrefix + html;
+        const prevSub = setActiveSub(undefined);
+        try {
+          const { html } = await renderWithCtx(
+            () => fn({ state, derived: derived as IslandDerived<TDerivedMap>, input }),
+            undefined,
+            true,
+          );
+          return stylePrefix + html;
+        } finally {
+          setActiveSub(prevSub);
+        }
       });
     }
 
@@ -1972,14 +1985,19 @@ class IlhaBuilder<
         if (doDerived) {
           const derivedResults: Record<string, unknown> = {};
           for (const entry of deriveds) {
+            const prevSub = setActiveSub(undefined);
+            let resultPromise: unknown;
             try {
-              const result = await Promise.resolve(
-                entry.fn({
-                  state: plainState as never,
-                  input,
-                  signal: new AbortController().signal,
-                }),
-              );
+              resultPromise = entry.fn({
+                state: plainState as never,
+                input,
+                signal: new AbortController().signal,
+              });
+            } finally {
+              setActiveSub(prevSub);
+            }
+            try {
+              const result = await Promise.resolve(resultPromise);
               derivedResults[entry.key] = { loading: false, value: result, error: undefined };
             } catch (err) {
               derivedResults[entry.key] = {

--- a/packages/ilha/src/index.ts
+++ b/packages/ilha/src/index.ts
@@ -1987,15 +1987,30 @@ class IlhaBuilder<
           for (const entry of deriveds) {
             const prevSub = setActiveSub(undefined);
             let resultPromise: unknown;
+            let syncError: unknown;
+            let threw = false;
             try {
               resultPromise = entry.fn({
                 state: plainState as never,
                 input,
                 signal: new AbortController().signal,
               });
+            } catch (err) {
+              threw = true;
+              syncError = err;
             } finally {
               setActiveSub(prevSub);
             }
+
+            if (threw) {
+              derivedResults[entry.key] = {
+                loading: false,
+                value: undefined,
+                error: syncError instanceof Error ? syncError.message : String(syncError),
+              };
+              continue;
+            }
+
             try {
               const result = await Promise.resolve(resultPromise);
               derivedResults[entry.key] = { loading: false, value: result, error: undefined };

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/router",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "A tiny SPA router for Ilha",
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",
@@ -27,7 +27,7 @@
     "test": "bun test"
   },
   "dependencies": {
-    "ilha": "0.4.0",
+    "ilha": "0.4.1",
     "rou3": "0.8.1"
   },
   "devDependencies": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/store",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Typed store.",
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",
@@ -29,9 +29,9 @@
   },
   "dependencies": {
     "alien-signals": "3.1.2",
-    "ilha": "0.4.0"
+    "ilha": "0.4.1"
   },
   "devDependencies": {
-    "zod": "^4.4.1"
+    "zod": "^4.4.3"
   }
 }

--- a/templates/electrobun/package.json
+++ b/templates/electrobun/package.json
@@ -10,9 +10,9 @@
     "build:canary": "vite build && electrobun build --env=canary"
   },
   "dependencies": {
-    "@ilha/router": "^0.2.4",
+    "@ilha/router": "^0.2.5",
     "electrobun": "1.16.0",
-    "ilha": "^0.4.0"
+    "ilha": "^0.4.1"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/templates/elysia/package.json
+++ b/templates/elysia/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "@elysiajs/html": "^1.4.2",
     "@elysiajs/static": "^1.4.10",
-    "@ilha/router": "^0.2.4",
+    "@ilha/router": "^0.2.5",
     "elysia": "^1.4.28",
-    "ilha": "^0.4.0"
+    "ilha": "^0.4.1"
   },
   "devDependencies": {
     "bun-types": "latest",

--- a/templates/hono/package.json
+++ b/templates/hono/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.1",
-    "@ilha/router": "^0.2.4",
+    "@ilha/router": "^0.2.5",
     "hono": "^4.12.16",
-    "ilha": "^0.4.0"
+    "ilha": "^0.4.1"
   },
   "devDependencies": {
     "@types/node": "^24",

--- a/templates/nitro/package.json
+++ b/templates/nitro/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.2.4",
-    "ilha": "^0.4.0",
+    "@ilha/router": "^0.2.5",
+    "ilha": "^0.4.1",
     "nitro": "^3.0.260429-beta"
   },
   "devDependencies": {

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.2.4",
-    "ilha": "^0.4.0"
+    "@ilha/router": "^0.2.5",
+    "ilha": "^0.4.1"
   },
   "devDependencies": {
     "typescript": "^6.0.3",


### PR DESCRIPTION
Fixes issue where child .derived() caused unnecessary parent rerender.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where derived signals were causing unnecessary parent component rerenders.

* **Chores**
  * Updated Ilha to 0.4.1, router to 0.2.5, and store to 0.2.2.
  * Updated template dependencies to use latest package versions.
  * Updated zod dependency to 4.4.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->