### PR TITLE
feat(store): add select method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,10 @@ Initial release of **@ilha/router** — a lightweight, isomorphic router for ilh
 
 ## `@ilha/store`
 
+### 0.3.0 - 2026-05-07
+
+- Adds `select` method that projects a slice of state into a signal-shaped accessor.
+
 ### 0.2.2 - 2026-05-06
 
 - Updates Ilha dependency to 0.4.1

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -38,6 +38,8 @@ store.setState({ count: 1 });
 store.getState(); // → { count: 1 }
 ```
 
+For consuming a store inside an island, jump to [Usage with Ilha Islands](#usage-with-ilha-islands).
+
 ---
 
 ## API
@@ -87,7 +89,7 @@ store.setState((s) => ({ count: s.count + 1 }));
 
 ### `store.getState()`
 
-Returns the current state snapshot.
+Returns the current state snapshot. Non-reactive — use `select` for reactive reads inside an island.
 
 ```ts
 store.getState(); // → { count: 5 }
@@ -105,9 +107,32 @@ store.getInitialState(); // → { count: 0 }
 
 ---
 
+### `store.select(selector)` — reactive accessor
+
+Projects a slice of state into a **signal-shaped accessor**: a `() => S` function that reads the current value when called, and tracks reactivity automatically inside any ilha tracking scope (`.render()`, `.derived()`, `.effect()`).
+
+```ts
+const store = createStore({ count: 0, name: "Ada" });
+
+const count = store.select((s) => s.count);
+const name = store.select((s) => s.name);
+
+count(); // → 0    (read)
+store.setState({ count: 5 });
+count(); // → 5    (reflects the change)
+```
+
+The returned accessor has the same shape as `signal()` and `context()` from `ilha` core, so it composes naturally with `html\`\``interpolation and`.bind()`. See [Usage with Ilha Islands](#usage-with-ilha-islands) below for the full pattern.
+
+The slice is memoized — accessors only notify dependents when the selected value changes (compared with `Object.is`). Setting `count` to its current value, or mutating an unrelated field, does not trigger downstream re-runs.
+
+> **Hoist `select` calls out of render functions.** Each call allocates a fresh `computed`. Define selectors at module scope or inside an island's closure setup — not inside the `.render()` callback itself.
+
+---
+
 ### `store.subscribe(listener)`
 
-Subscribes to all state changes. The listener receives the next and previous state. Returns an unsubscribe function.
+Subscribes to all state changes. The listener receives the next and previous state. Returns an unsubscribe function. Use this for **imperative** subscriptions outside an island scope (e.g. a WebSocket handler, `localStorage` sync); inside an island, prefer `select`.
 
 ```ts
 const unsub = store.subscribe((state, prev) => {
@@ -161,13 +186,13 @@ store.bind(
 
 ## Usage with Ilha Islands
 
-The most common pattern is reading the store inside an island's `.effect()` and calling `store.subscribe()` to drive reactive re-renders:
+`select` returns the same `() => T` accessor shape as `signal()` and `context()` from `ilha` core. That means store-backed state composes with islands the same way context signals do — read it inside `html\`\``and the surrounding render scope subscribes automatically. No`.effect()`plumbing, no manual`subscribe` wiring.
 
 ```ts
 import { createStore } from "@ilha/store";
 import ilha, { html } from "ilha";
 
-export const cartStore = createStore({ items: [] as string[] }, (set, get) => ({
+const cartStore = createStore({ items: [] as string[] }, (set, get) => ({
   add(item: string) {
     set({ items: [...get().items, item] });
   },
@@ -176,22 +201,52 @@ export const cartStore = createStore({ items: [] as string[] }, (set, get) => ({
   },
 }));
 
-export const CartIsland = ilha
-  .state("items", cartStore.getState().items)
-  .effect(({ state }) => {
-    return cartStore.subscribe(
-      (s) => s.items,
-      (items) => state.items(items),
-    );
-  })
-  .render(
-    ({ state }) => html`
-      <ul>
-        ${state.items().map((item) => html`<li>${item}</li>`)}
-      </ul>
-    `,
-  );
+const items = cartStore.select((s) => s.items);
+const itemCount = cartStore.select((s) => s.items.length);
+
+export const CartBadge = ilha.render(() => html`<span>${itemCount()}</span>`);
+
+export const CartList = ilha.render(
+  () => html`
+    <ul>
+      ${items().map((item) => html`<li>${item}</li>`)}
+    </ul>
+  `,
+);
 ```
+
+Both islands stay in sync automatically. `CartBadge` only re-renders when `items.length` changes; `CartList` only re-renders when the array itself changes.
+
+### Inside `.derived()` and `.effect()`
+
+`select` accessors work in any tracking scope — the same dependency tracking that powers `.state()` reads applies:
+
+```ts
+const userStore = createStore({ id: 1, name: "Ada" });
+const userId = userStore.select((s) => s.id);
+
+const Profile = ilha
+  .derived("user", async ({ signal }) => {
+    const res = await fetch(`/api/users/${userId()}`, { signal });
+    return res.json();
+  })
+  .effect(() => {
+    document.title = `User: ${userStore.select((s) => s.name)()}`;
+    //                ^ inline is fine here — `.effect()` runs once per dep change,
+    //                  not on every render. For hot paths, hoist the `select`.
+  })
+  .render(({ derived }) => html`<p>${derived.user.value?.name ?? "…"}</p>`);
+```
+
+When `userId()` changes, the derived re-fetches automatically.
+
+### When to use `select` vs `subscribe`
+
+| Use `select`                                          | Use `subscribe`                                        |
+| ----------------------------------------------------- | ------------------------------------------------------ |
+| Reading store state inside an island                  | Imperative side effects outside an island              |
+| Driving `.derived()` or `.effect()` dependencies      | Syncing to `localStorage`, WebSockets, analytics       |
+| Anywhere you'd reach for `context()` from `ilha` core | Anywhere you'd reach for `effect()` from alien-signals |
 
 ---
 
@@ -271,37 +326,38 @@ const formStore = createStore({ errors: {} as FormErrors }, (set) => ({
   },
 }));
 
+const errors = formStore.select((s) => s.errors);
+
 export default ilha
   .on("form@submit", ({ event }) => {
     event.preventDefault();
     formStore.getState().submit(event);
   })
-  .render(() => {
-    const errors = formStore.getState().errors;
-    return html`
+  .render(
+    () => html`
       <form>
         <label>
           Name
           <input name="name" />
-          ${errors.name ? html`<p role="alert">${errors.name.join(", ")}</p>` : ""}
+          ${errors().name ? html`<p role="alert">${errors().name.join(", ")}</p>` : ""}
         </label>
         <label>
           Email
           <input name="email" type="email" />
-          ${errors.email ? html`<p role="alert">${errors.email.join(", ")}</p>` : ""}
+          ${errors().email ? html`<p role="alert">${errors().email.join(", ")}</p>` : ""}
         </label>
         <label>
           Message
           <textarea name="message"></textarea>
-          ${errors.message ? html`<p role="alert">${errors.message.join(", ")}</p>` : ""}
+          ${errors().message ? html`<p role="alert">${errors().message.join(", ")}</p>` : ""}
         </label>
         <button type="submit">Send</button>
       </form>
-    `;
-  });
+    `,
+  );
 ```
 
-The store holds errors, the schema drives types, and `extractFormData` + `validateWithSchema` + `issuesToErrors` form a straight pipeline from DOM to error state.
+The store holds errors, the schema drives types, and `extractFormData` + `validateWithSchema` + `issuesToErrors` form a straight pipeline from DOM to error state. The `errors` accessor is reactive — when `submit` writes new errors, the island re-renders automatically.
 
 ---
 

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/store",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Typed store.",
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",

--- a/packages/store/src/index.test.ts
+++ b/packages/store/src/index.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 
+import { effect } from "alien-signals";
 import { html, raw } from "ilha";
 
 import { createStore, effectScope } from "./index";
@@ -18,6 +19,17 @@ function fixture(markup: string): HTMLElement {
   el.innerHTML = markup;
   document.body.appendChild(el);
   return el;
+}
+
+function makeEl(inner = ""): Element {
+  const el = document.createElement("div");
+  el.innerHTML = inner;
+  document.body.appendChild(el);
+  return el;
+}
+
+function cleanup(el: Element) {
+  if (el.parentNode) el.parentNode.removeChild(el);
 }
 
 beforeEach(() => {
@@ -427,7 +439,13 @@ describe("bind() — RawHtml render", () => {
     const store = createStore({ items: ["a", "b", "c"] });
     const el = fixture("<div id='t'></div>");
     const target = el.querySelector("#t")!;
-    store.bind(target, (s) => html`<ul>${s.items.map((i) => html`<li>${i}</li>`)}</ul>`);
+    store.bind(
+      target,
+      (s) =>
+        html`<ul>
+          ${s.items.map((i) => html`<li>${i}</li>`)}
+        </ul>`,
+    );
     expect(target.querySelectorAll("li").length).toBe(3);
     expect(target.innerHTML).not.toContain(",");
   });
@@ -436,7 +454,13 @@ describe("bind() — RawHtml render", () => {
     const store = createStore({ items: ["a"] });
     const el = fixture("<div id='t'></div>");
     const target = el.querySelector("#t")!;
-    store.bind(target, (s) => html`<ul>${s.items.map((i) => html`<li>${i}</li>`)}</ul>`);
+    store.bind(
+      target,
+      (s) =>
+        html`<ul>
+          ${s.items.map((i) => html`<li>${i}</li>`)}
+        </ul>`,
+    );
     store.setState({ items: ["a", "b", "c"] });
     expect(target.querySelectorAll("li").length).toBe(3);
   });
@@ -744,5 +768,292 @@ describe("integration", () => {
     store.setState({ count: 2 });
     expect(a.innerHTML).toBe("1"); // frozen after unsub
     expect(b.innerHTML).toBe("2"); // still live
+  });
+});
+
+describe("store.select() — reads", () => {
+  it("returns the current selected slice on call", () => {
+    const store = createStore({ count: 7, name: "Ada" });
+    const count = store.select((s) => s.count);
+    expect(count()).toBe(7);
+  });
+
+  it("reflects subsequent state changes when called again", () => {
+    const store = createStore({ count: 0 });
+    const count = store.select((s) => s.count);
+    expect(count()).toBe(0);
+    store.setState({ count: 5 });
+    expect(count()).toBe(5);
+    store.setState({ count: 9 });
+    expect(count()).toBe(9);
+  });
+
+  it("supports projections that compute derived values", () => {
+    const store = createStore({ items: [1, 2, 3] as number[] });
+    const total = store.select((s) => s.items.reduce((a, b) => a + b, 0));
+    expect(total()).toBe(6);
+    store.setState({ items: [10, 20] });
+    expect(total()).toBe(30);
+  });
+
+  it("supports projections that return objects/arrays", () => {
+    const store = createStore({ user: { name: "Ada", age: 30 } });
+    const user = store.select((s) => s.user);
+    expect(user()).toEqual({ name: "Ada", age: 30 });
+    store.setState({ user: { name: "Grace", age: 40 } });
+    expect(user()).toEqual({ name: "Grace", age: 40 });
+  });
+
+  it("works with stores that have actions", () => {
+    const store = createStore({ count: 0 }, (set, get) => ({
+      increment: () => set({ count: get().count + 1 }),
+    }));
+    const count = store.select((s) => s.count);
+    expect(count()).toBe(0);
+    store.getState().increment();
+    expect(count()).toBe(1);
+    store.getState().increment();
+    expect(count()).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// .select() — reactivity
+// ---------------------------------------------------------------------------
+
+describe("store.select() — reactivity", () => {
+  it("re-runs an enclosing effect when the selected slice changes", () => {
+    const store = createStore({ count: 0 });
+    const count = store.select((s) => s.count);
+
+    const seen: number[] = [];
+    const stop = effect(() => {
+      seen.push(count());
+    });
+
+    expect(seen).toEqual([0]);
+
+    store.setState({ count: 1 });
+    store.setState({ count: 2 });
+    store.setState({ count: 3 });
+
+    expect(seen).toEqual([0, 1, 2, 3]);
+    stop();
+  });
+
+  it("does NOT re-run an enclosing effect when an unrelated slice changes", () => {
+    const store = createStore({ count: 0, label: "hi" });
+    const count = store.select((s) => s.count);
+
+    const seen: number[] = [];
+    const stop = effect(() => {
+      seen.push(count());
+    });
+
+    expect(seen).toEqual([0]);
+
+    // Mutating an unrelated field should not cause `count` slice to fire.
+    store.setState({ label: "bye" });
+    store.setState({ label: "again" });
+
+    expect(seen).toEqual([0]);
+
+    // But a relevant change still does.
+    store.setState({ count: 5 });
+    expect(seen).toEqual([0, 5]);
+
+    stop();
+  });
+
+  it("does NOT re-run an enclosing effect when the slice value is unchanged", () => {
+    // setState always replaces the top-level state object, but the computed
+    // memoizes on Object.is, so derived effects should only see real changes.
+    const store = createStore({ count: 0, label: "hi" });
+    const count = store.select((s) => s.count);
+
+    const seen: number[] = [];
+    const stop = effect(() => {
+      seen.push(count());
+    });
+
+    expect(seen).toEqual([0]);
+
+    // Re-set count to the same value — top-level state object changes, but
+    // count slice does not.
+    store.setState({ count: 0 });
+    store.setState({ count: 0 });
+
+    expect(seen).toEqual([0]);
+    stop();
+  });
+
+  it("returns stable identity for object slices when state is shallow-merged unchanged", () => {
+    const initial = { user: { name: "Ada" } };
+    const store = createStore(initial);
+    const user = store.select((s) => s.user);
+
+    const a = user();
+    // Touching another field doesn't reallocate the inner object.
+    store.setState({} as Partial<typeof initial>);
+    const b = user();
+    expect(a).toBe(b);
+  });
+
+  it("supports multiple independent selectors over the same store", () => {
+    const store = createStore({ a: 1, b: 10 });
+    const aSel = store.select((s) => s.a);
+    const bSel = store.select((s) => s.b);
+
+    const aSeen: number[] = [];
+    const bSeen: number[] = [];
+    const stopA = effect(() => aSeen.push(aSel()));
+    const stopB = effect(() => bSeen.push(bSel()));
+
+    expect(aSeen).toEqual([1]);
+    expect(bSeen).toEqual([10]);
+
+    store.setState({ a: 2 });
+    expect(aSeen).toEqual([1, 2]);
+    expect(bSeen).toEqual([10]); // b untouched
+
+    store.setState({ b: 20 });
+    expect(aSeen).toEqual([1, 2]); // a untouched
+    expect(bSeen).toEqual([10, 20]);
+
+    stopA();
+    stopB();
+  });
+
+  it("each .select() call returns a fresh accessor (no global caching by selector identity)", () => {
+    const store = createStore({ count: 0 });
+    const sel = (s: { count: number }) => s.count;
+    const a = store.select(sel);
+    const b = store.select(sel);
+    // Different accessor instances...
+    expect(a).not.toBe(b);
+    // ...but observing the same underlying value.
+    expect(a()).toBe(b());
+    store.setState({ count: 42 });
+    expect(a()).toBe(42);
+    expect(b()).toBe(42);
+  });
+
+  it("composes — a selector can read another selector's output", () => {
+    const store = createStore({ items: [1, 2, 3] as number[] });
+    const items = store.select((s) => s.items);
+    // Outer selector reads through the inner accessor; the inner closes over
+    // `store` directly, so the outer just composes pure JS functions.
+    const count = store.select((s) => s.items.length);
+
+    const seen: number[] = [];
+    const stop = effect(() => {
+      seen.push(count());
+    });
+
+    expect(seen).toEqual([3]);
+    store.setState({ items: [...items(), 4] });
+    expect(seen).toEqual([3, 4]);
+    stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// .select() — interplay with bind() refactor
+// ---------------------------------------------------------------------------
+
+describe("store.bind() (post-refactor)", () => {
+  it("two-arg form still updates the element when slice changes", () => {
+    const el = makeEl();
+    const store = createStore({ name: "Ada" });
+    const stop = store.bind(
+      el,
+      (s) => s.name,
+      (name) => `<p>${name}</p>`,
+    );
+    expect(el.innerHTML).toBe("<p>Ada</p>");
+    store.setState({ name: "Grace" });
+    expect(el.innerHTML).toBe("<p>Grace</p>");
+    stop();
+    cleanup(el);
+  });
+
+  it("two-arg form does NOT re-render when an unrelated field changes", () => {
+    const el = makeEl();
+    const store = createStore({ name: "Ada", count: 0 });
+
+    let renders = 0;
+    const stop = store.bind(
+      el,
+      (s) => s.name,
+      (name) => {
+        renders++;
+        return `<p>${name}</p>`;
+      },
+    );
+    expect(renders).toBe(1);
+
+    store.setState({ count: 1 });
+    store.setState({ count: 2 });
+    expect(renders).toBe(1);
+
+    store.setState({ name: "Grace" });
+    expect(renders).toBe(2);
+
+    stop();
+    cleanup(el);
+  });
+
+  it("one-arg form is unaffected and re-renders on any state change", () => {
+    const el = makeEl();
+    const store = createStore({ a: 1, b: 2 });
+
+    let renders = 0;
+    const stop = store.bind(el, (s) => {
+      renders++;
+      return `<p>${s.a}-${s.b}</p>`;
+    });
+    expect(renders).toBe(1);
+    expect(el.innerHTML).toBe("<p>1-2</p>");
+
+    store.setState({ a: 10 });
+    expect(renders).toBe(2);
+    store.setState({ b: 20 });
+    expect(renders).toBe(3);
+    expect(el.innerHTML).toBe("<p>10-20</p>");
+
+    stop();
+    cleanup(el);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// .select() — type-level checks (compile-time, exercised at runtime)
+// ---------------------------------------------------------------------------
+
+describe("store.select() — type inference", () => {
+  it("infers the selected value type from the projection", () => {
+    const store = createStore({ count: 0, name: "Ada" });
+
+    const count = store.select((s) => s.count);
+    const name = store.select((s) => s.name);
+    const upper = store.select((s) => s.name.toUpperCase());
+
+    // These calls must satisfy the inferred return type at compile time.
+    const c: number = count();
+    const n: string = name();
+    const u: string = upper();
+
+    expect(c).toBe(0);
+    expect(n).toBe("Ada");
+    expect(u).toBe("ADA");
+  });
+
+  it("includes action keys in the state shape passed to the selector", () => {
+    const store = createStore({ count: 0 }, (set) => ({
+      reset: () => set({ count: 0 }),
+    }));
+    // Selector sees both state and action keys — `reset` is a function.
+    const reset = store.select((s) => s.reset);
+    expect(typeof reset()).toBe("function");
   });
 });

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -30,6 +30,31 @@ export interface StoreApi<T extends object> {
   subscribe<S>(selector: (state: T) => S, listener: SliceListener<T, S>): Unsub;
   bind(el: Element, render: (state: T) => RenderResult): Unsub;
   bind<S>(el: Element, selector: (state: T) => S, render: (slice: S) => RenderResult): Unsub;
+  /**
+   * Project a reactive slice of state into a signal-shaped accessor.
+   *
+   * The returned function reads the current value when called. When called
+   * inside an ilha tracking scope (`.render()`, `.derived()`, `.effect()`)
+   * or any other alien-signals reactive context, that scope subscribes to
+   * the slice and re-runs whenever the selector's output changes.
+   *
+   * Hoist the call out of render functions — each `.select()` allocates
+   * a fresh `computed`, so calling it inside a render that re-runs leaks
+   * one per render until the scope is collected. Define selectors at
+   * module scope or in `.onMount()`/closure setup.
+   *
+   * @example
+   * const cartStore = createStore({ items: [] as Item[], total: 0 });
+   * const itemCount = cartStore.select(s => s.items.length);
+   *
+   * const Badge = ilha.render(() => html`<span>${itemCount()}</span>`);
+   *
+   * @example
+   * // Stable identity for downstream comparisons:
+   * const items = cartStore.select(s => s.items);
+   * cartStore.setState({ total: 99 }); // items() returns the same array
+   */
+  select<S>(selector: (state: T) => S): () => S;
 }
 
 // ---------------------------------------------------------------------------
@@ -118,6 +143,11 @@ export function createStore<TState extends object, TActions extends object = Rec
     });
   }
 
+  function select<S>(selector: (state: T) => S): () => S {
+    const sliceComputed = computed(() => selector(stateSignal()));
+    return () => sliceComputed();
+  }
+
   function bind(el: Element, render: (state: T) => RenderResult): Unsub;
   function bind<S>(
     el: Element,
@@ -134,9 +164,9 @@ export function createStore<TState extends object, TActions extends object = Rec
         el.innerHTML = unwrap((renderOrSelector as (state: T) => RenderResult)(stateSignal()));
       });
     }
-    const sliceComputed = computed(() => (renderOrSelector as (state: T) => S)(stateSignal()));
+    const slice = select(renderOrSelector as (state: T) => S);
     return effect(() => {
-      el.innerHTML = unwrap(maybeRender(sliceComputed()));
+      el.innerHTML = unwrap(maybeRender(slice()));
     });
   }
 
@@ -148,6 +178,7 @@ export function createStore<TState extends object, TActions extends object = Rec
     getInitialState: () => resolvedInitialState,
     subscribe,
     bind,
+    select,
   };
 
   const resolvedActions = actionsCreator


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes: @ilha/store v0.3.0

* **New Features**
  * Added `select` method to the store API, returning a signal-shaped accessor for reactive state projection in tracking scopes with automatic memoization.

* **Documentation**
  * Expanded README with comprehensive usage examples and best practices for the new `select` method.
  * Added version 0.3.0 release entry to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->