### PR TITLE
feat(router): add hash routing mode

### DIFF
--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -75,6 +75,65 @@ pageRouter.hydrate(registry);
 
 ---
 
+## Hash mode
+
+By default, the router uses the HTML5 History API and treats `location.pathname` as the route. This requires either a server that serves the SPA shell at every URL, or a static host with a SPA fallback. When neither is available — the document is loaded over `file://`, embedded in a desktop wrapper like Electron or Electrobun, opened directly from disk, or served from a host that can't be configured for SPA fallbacks — switch to **hash mode**, which stores the route in `location.hash`:
+
+```ts
+import { setHistoryMode, router } from "@ilha/router";
+
+setHistoryMode("hash"); // ← call once, before mounting
+
+router().route("/", homePage).route("/about", aboutPage).route("/user/:id", userPage).mount("#app");
+```
+
+`setHistoryMode("hash")` must be called **before** `.mount()`, `.hydrate()`, or `prime()`. Once set, every navigation API in this package — `navigate()`, `RouterLink`, `enableLinkInterception()`, popstate handling — operates against `location.hash` instead of `location.pathname`.
+
+URLs in hash mode look like:
+
+```
+file:///path/to/index.html#/
+file:///path/to/index.html#/about
+file:///path/to/index.html#/user/42?tab=overview
+file:///path/to/index.html#/docs/intro#section
+```
+
+The portion after the `#` is parsed as if it were a real URL — the path comes first, followed by an optional query string and an optional in-page anchor. `routeHash()` returns the in-hash anchor (`#section`), so in-page anchor links keep working alongside hash routing.
+
+### Links
+
+Both forms work — pick whichever is easier in your code:
+
+```html
+<a href="/about">About</a>
+<!-- plain path — preferred for shared code -->
+<a href="#/about">About</a>
+<!-- explicit hash form — also intercepted -->
+```
+
+`<RouterLink>` automatically renders the hash form (`<a href="#/about">`) in hash mode, so right-click → copy link gives a working URL.
+
+In-page anchor links (`<a href="#section">`) are not intercepted — they behave as normal browser anchors. Only links beginning with `#/` (a slash after the hash) are treated as in-app navigations.
+
+### What's not supported in hash mode
+
+**SSR + hydration.** The hash is never sent to the server, so it cannot pre-render the active route. Calling `mount({ hydrate: true })` or `.hydrate(registry)` while in hash mode logs a warning. Use plain SPA mode for hash-mode apps:
+
+```ts
+setHistoryMode("hash");
+pageRouter.mount("#app"); // ← no { hydrate: true }
+```
+
+You can still register loaders, but they run on the client (via the loader endpoint or by calling `runLoader()` yourself) — there is no server-rendered initial state.
+
+**Per-router mode.** History mode is process-global, not per-builder. This is intentional: `navigate()`, `RouterLink`, and `prefetch()` are module-level and would otherwise need explicit instance threading. If your app needs both modes simultaneously, that's not a use case this router supports.
+
+### Switching modes
+
+`setHistoryMode()` can be called more than once, but listeners registered before a switch keep using their original adapter until the router is unmounted and remounted. In practice, set the mode once at app entry and leave it alone.
+
+---
+
 ## Core API
 
 ### `router()`
@@ -135,6 +194,8 @@ unmount();
 | `registry` | `Record<string, Island>` | `undefined` | Island registry for interactive hydration on navigation    |
 
 When `hydrate: true`, `.mount()` does **not** wipe existing SSR HTML. It instead mounts a hidden navigation handler that re-renders routes with hydration on subsequent navigations.
+
+> Combining `hydrate: true` with hash mode logs a warning — hash routes are never visible to the server, so SSR can't pre-render them. Use plain SPA mode (no `hydrate`) for hash-mode apps.
 
 No-op with a console warning when called outside a browser environment.
 
@@ -253,6 +314,8 @@ pageRouter.hydrate(registry, {
 
 Returns an `unmount` function that tears down all listeners and hydrated islands.
 
+> `.hydrate()` is for SSR + history-mode apps. In hash mode, use plain `.mount("#app")` instead — the server has no visibility into hash routes, so there's nothing to hydrate against.
+
 ---
 
 #### `.attachLoader(pattern, loader)` — runtime
@@ -262,6 +325,21 @@ Attaches or replaces a loader on an already-registered route pattern. No-op if t
 ```ts
 router().route("/user/:id", userPage).attachLoader("/user/:id", serverLoader);
 ```
+
+---
+
+### `setHistoryMode(mode)` · `getHistoryMode()`
+
+Selects the history strategy used by the router. Defaults to `"history"` (HTML5 History API, reads/writes `location.pathname`). Set to `"hash"` to store the route in `location.hash` instead — see the [Hash mode](#hash-mode) section above for when to use it.
+
+```ts
+import { setHistoryMode, getHistoryMode } from "@ilha/router";
+
+setHistoryMode("hash");
+getHistoryMode(); // → "hash"
+```
+
+The mode is process-global. Call `setHistoryMode()` once at app entry, before any `.mount()`, `.hydrate()`, or `prime()` call.
 
 ---
 
@@ -275,6 +353,8 @@ import { navigate } from "@ilha/router";
 navigate("/about");
 navigate("/about", { replace: true }); // replaces instead of pushing
 ```
+
+In hash mode, `navigate("/about")` writes `#/about` into `location.hash`. The argument is always the logical path — no need to prefix it with `#`.
 
 No-op on the server.
 
@@ -583,6 +663,8 @@ interface HydrateOptions {
   target?: string | Element;
 }
 
+type HistoryMode = "history" | "hash";
+
 // Helper — returns fn as-is with LayoutHandler type enforced
 function defineLayout(fn: LayoutHandler): LayoutHandler;
 
@@ -597,6 +679,10 @@ function error(status: number, message: string): never;
 
 // Merges loaders — later loaders win on key collision
 function composeLoaders<Ls extends readonly Loader<any>[]>(loaders: Ls): Loader<MergeLoaders<Ls>>;
+
+// Selects the history strategy. Default: "history". Call before .mount() / .hydrate().
+function setHistoryMode(mode: HistoryMode): void;
+function getHistoryMode(): HistoryMode;
 ```
 
 ---

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/router",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "A tiny SPA router for Ilha",
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",

--- a/packages/router/src/hash.test.ts
+++ b/packages/router/src/hash.test.ts
@@ -1,0 +1,548 @@
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+
+import ilha from "ilha";
+
+import {
+  router,
+  navigate,
+  enableLinkInterception,
+  routePath,
+  routeSearch,
+  routeHash,
+  RouterLink,
+  setHistoryMode,
+  getHistoryMode,
+} from "./index";
+
+// ─────────────────────────────────────────────
+// Shared Page islands
+// ─────────────────────────────────────────────
+
+const HomePage = ilha.render(() => `<p>home</p>`);
+const AboutPage = ilha.render(() => `<p>about</p>`);
+const UserPage = ilha.render(() => `<p>user</p>`);
+
+// ─────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────
+
+function makeEl(inner = ""): Element {
+  const el = document.createElement("div");
+  el.innerHTML = inner;
+  document.body.appendChild(el);
+  return el;
+}
+
+function cleanup(el: Element) {
+  if (el.parentNode === document.body) document.body.removeChild(el);
+}
+
+function detached(): Element {
+  return document.createElement("div");
+}
+
+/**
+ * Set the URL bar to a hash-mode URL. We anchor at "/" because in a real
+ * hash-mode app the document is served from a single path (often "/" or
+ * "index.html") and the hash carries the route.
+ */
+function setHashLocation(logicalPath: string) {
+  const hash = logicalPath.startsWith("#") ? logicalPath : "#" + logicalPath;
+  window.location.href = "http://localhost/" + hash;
+}
+
+function popstate() {
+  window.dispatchEvent(new PopStateEvent("popstate", { state: null }));
+}
+
+function hashchange() {
+  window.dispatchEvent(new HashChangeEvent("hashchange"));
+}
+
+function resetMode() {
+  setHistoryMode("history");
+}
+
+// ─────────────────────────────────────────────
+// Mode toggle — public API
+// ─────────────────────────────────────────────
+
+describe("setHistoryMode / getHistoryMode", () => {
+  afterEach(() => {
+    resetMode();
+  });
+
+  it("defaults to history mode", () => {
+    expect(getHistoryMode()).toBe("history");
+  });
+
+  it("switches to hash mode when set", () => {
+    setHistoryMode("hash");
+    expect(getHistoryMode()).toBe("hash");
+  });
+
+  it("switches back to history mode when set", () => {
+    setHistoryMode("hash");
+    setHistoryMode("history");
+    expect(getHistoryMode()).toBe("history");
+  });
+});
+
+// ─────────────────────────────────────────────
+// Initial sync — router reads from hash on mount
+// ─────────────────────────────────────────────
+
+describe("hash mode — initial mount", () => {
+  let el: Element;
+  let unmount: () => void;
+
+  beforeEach(() => {
+    setHistoryMode("hash");
+  });
+
+  afterEach(() => {
+    unmount?.();
+    cleanup(el);
+    resetMode();
+    window.location.href = "http://localhost/";
+  });
+
+  it("reads route from location.hash on mount", () => {
+    setHashLocation("/about");
+    el = makeEl();
+    unmount = router().route("/", HomePage).route("/about", AboutPage).mount(el);
+    expect(routePath()).toBe("/about");
+    expect(el.innerHTML).toContain("about");
+  });
+
+  it("treats empty hash as root path", () => {
+    window.location.href = "http://localhost/";
+    el = makeEl();
+    unmount = router().route("/", HomePage).route("/about", AboutPage).mount(el);
+    expect(routePath()).toBe("/");
+    expect(el.innerHTML).toContain("home");
+  });
+
+  it("treats bare '#' as root path", () => {
+    window.location.href = "http://localhost/#";
+    el = makeEl();
+    unmount = router().route("/", HomePage).mount(el);
+    expect(routePath()).toBe("/");
+  });
+
+  it("parses search params from inside the hash", () => {
+    setHashLocation("/about?tab=docs");
+    el = makeEl();
+    unmount = router().route("/", HomePage).route("/about", AboutPage).mount(el);
+    expect(routePath()).toBe("/about");
+    expect(routeSearch()).toBe("?tab=docs");
+  });
+
+  it("parses an in-hash anchor into routeHash()", () => {
+    setHashLocation("/about#section");
+    el = makeEl();
+    unmount = router().route("/", HomePage).route("/about", AboutPage).mount(el);
+    expect(routePath()).toBe("/about");
+    expect(routeHash()).toBe("#section");
+  });
+});
+
+// ─────────────────────────────────────────────
+// navigate() in hash mode
+// ─────────────────────────────────────────────
+
+describe("hash mode — navigate()", () => {
+  let el: Element;
+  let unmount: () => void;
+
+  beforeEach(() => {
+    setHistoryMode("hash");
+    setHashLocation("/");
+    el = makeEl();
+    unmount = router().route("/", HomePage).route("/about", AboutPage).mount(el);
+  });
+
+  afterEach(() => {
+    unmount();
+    cleanup(el);
+    resetMode();
+    window.location.href = "http://localhost/";
+  });
+
+  it("writes the logical path into location.hash", () => {
+    navigate("/about");
+    expect(window.location.hash).toBe("#/about");
+  });
+
+  it("updates routePath to the logical path (no leading hash)", () => {
+    navigate("/about");
+    expect(routePath()).toBe("/about");
+  });
+
+  it("re-renders outlet to matched island", () => {
+    expect(el.innerHTML).toContain("home");
+    navigate("/about");
+    expect(el.innerHTML).toContain("about");
+  });
+
+  it("pushes a new history entry by default", () => {
+    const before = history.length;
+    navigate("/about");
+    expect(history.length).toBe(before + 1);
+  });
+
+  it("replaces history entry when replace: true", () => {
+    const before = history.length;
+    navigate("/about", { replace: true });
+    expect(history.length).toBe(before);
+  });
+
+  it("dedups duplicate navigations", () => {
+    navigate("/about");
+    const before = history.length;
+    navigate("/about");
+    expect(history.length).toBe(before);
+  });
+
+  it("preserves search params when navigating", () => {
+    navigate("/about?tab=docs");
+    expect(window.location.hash).toBe("#/about?tab=docs");
+    expect(routePath()).toBe("/about");
+    expect(routeSearch()).toBe("?tab=docs");
+  });
+});
+
+// ─────────────────────────────────────────────
+// hashchange & popstate — back/forward and address bar edits
+// ─────────────────────────────────────────────
+
+describe("hash mode — change events", () => {
+  let el: Element;
+  let unmount: () => void;
+
+  beforeEach(() => {
+    setHistoryMode("hash");
+    setHashLocation("/");
+    el = makeEl();
+    unmount = router().route("/", HomePage).route("/about", AboutPage).mount(el);
+  });
+
+  afterEach(() => {
+    unmount();
+    cleanup(el);
+    resetMode();
+    window.location.href = "http://localhost/";
+  });
+
+  it("syncs route when popstate fires (back/forward)", () => {
+    setHashLocation("/about");
+    popstate();
+    expect(routePath()).toBe("/about");
+    expect(el.innerHTML).toContain("about");
+  });
+
+  it("syncs route when hashchange fires (address bar edit)", () => {
+    setHashLocation("/about");
+    hashchange();
+    expect(routePath()).toBe("/about");
+    expect(el.innerHTML).toContain("about");
+  });
+
+  it("does NOT respond to hashchange after unmount", () => {
+    unmount();
+    setHashLocation("/about");
+    hashchange();
+    expect(routePath()).toBe("/");
+  });
+
+  it("does NOT respond to popstate after unmount", () => {
+    unmount();
+    setHashLocation("/about");
+    popstate();
+    expect(routePath()).toBe("/");
+  });
+});
+
+// ─────────────────────────────────────────────
+// Link interception
+// ─────────────────────────────────────────────
+
+describe("hash mode — link interception", () => {
+  let el: Element;
+  let unmount: () => void;
+
+  beforeEach(() => {
+    setHistoryMode("hash");
+    setHashLocation("/");
+    el = makeEl();
+    unmount = router().route("/", HomePage).route("/about", AboutPage).mount(el);
+  });
+
+  afterEach(() => {
+    unmount();
+    cleanup(el);
+    resetMode();
+    window.location.href = "http://localhost/";
+  });
+
+  it("intercepts hash-form links (#/about)", () => {
+    const link = document.createElement("a");
+    link.setAttribute("href", "#/about");
+    el.appendChild(link);
+    link.click();
+    expect(routePath()).toBe("/about");
+    expect(el.innerHTML).toContain("about");
+  });
+
+  it("intercepts plain-path links (/about) — same logical path", () => {
+    const link = document.createElement("a");
+    link.setAttribute("href", "/about");
+    el.appendChild(link);
+    link.click();
+    expect(routePath()).toBe("/about");
+    expect(window.location.hash).toBe("#/about");
+  });
+
+  it("does NOT intercept in-page anchor links (#section)", () => {
+    const root = detached();
+    const link = document.createElement("a");
+    link.setAttribute("href", "#section");
+    root.appendChild(link);
+    const stop = enableLinkInterception(root);
+    link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    stop();
+    expect(routePath()).toBe("/");
+  });
+
+  it("does NOT intercept bare '#' links", () => {
+    const root = detached();
+    const link = document.createElement("a");
+    link.setAttribute("href", "#");
+    root.appendChild(link);
+    const stop = enableLinkInterception(root);
+    link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    stop();
+    expect(routePath()).toBe("/");
+  });
+
+  it("does NOT intercept ctrl-click", () => {
+    const root = detached();
+    const link = document.createElement("a");
+    link.setAttribute("href", "#/about");
+    root.appendChild(link);
+    const stop = enableLinkInterception(root);
+    link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true, ctrlKey: true }));
+    stop();
+    expect(routePath()).toBe("/");
+  });
+
+  it("does NOT intercept target=_blank", () => {
+    const root = detached();
+    const link = document.createElement("a");
+    link.setAttribute("href", "#/about");
+    link.setAttribute("target", "_blank");
+    root.appendChild(link);
+    const stop = enableLinkInterception(root);
+    link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    stop();
+    expect(routePath()).toBe("/");
+  });
+
+  it("respects data-no-intercept", () => {
+    const root = detached();
+    const link = document.createElement("a");
+    link.setAttribute("href", "#/about");
+    link.setAttribute("data-no-intercept", "");
+    root.appendChild(link);
+    const stop = enableLinkInterception(root);
+    link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    stop();
+    expect(routePath()).toBe("/");
+  });
+
+  it("intercepts absolute same-origin URLs with a hash route", () => {
+    // Routes are already registered by the outer beforeEach.
+    const root = detached();
+    const link = document.createElement("a");
+    link.setAttribute("href", "http://localhost/#/about");
+    root.appendChild(link);
+    const stop = enableLinkInterception(root);
+    link.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    stop();
+    expect(routePath()).toBe("/about");
+  });
+});
+
+// ─────────────────────────────────────────────
+// RouterLink rendering
+// ─────────────────────────────────────────────
+
+describe("hash mode — RouterLink", () => {
+  beforeEach(() => {
+    setHistoryMode("hash");
+  });
+
+  afterEach(() => {
+    resetMode();
+  });
+
+  it("renders an empty-state link with '#' as the href in hash mode", () => {
+    // With no state seeded, state.href() returns "" so toLinkHref produces "#"
+    const html = RouterLink.toString();
+    expect(html).toContain("data-link");
+    expect(html).toContain("data-prefetch");
+  });
+
+  it("renders the empty-state RouterLink without errors in history mode", () => {
+    resetMode();
+    const html = RouterLink.toString();
+    expect(html).toContain("data-link");
+    expect(html).toContain("data-prefetch");
+  });
+});
+
+// ─────────────────────────────────────────────
+// Mode isolation — switching back to history mode resets behavior
+// ─────────────────────────────────────────────
+
+describe("hash mode — hydrate warning", () => {
+  let el: Element;
+  let unmount: (() => void) | undefined;
+
+  beforeEach(() => {
+    setHistoryMode("hash");
+    setHashLocation("/");
+  });
+
+  afterEach(() => {
+    unmount?.();
+    cleanup(el);
+    resetMode();
+    window.location.href = "http://localhost/";
+  });
+
+  it("warns when mount({ hydrate: true }) is called in hash mode", () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    el = makeEl();
+    unmount = router().route("/", HomePage).mount(el, { hydrate: true });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("hash mode"));
+    warn.mockRestore();
+  });
+
+  it("does NOT warn when mount() is called without hydrate in hash mode", () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    el = makeEl();
+    unmount = router().route("/", HomePage).mount(el);
+    // Filter for the hash-mode hydrate warning specifically — other warnings
+    // (e.g. from RouterView edge cases) should not fail this test.
+    const hashWarnings = warn.mock.calls.filter((call) => String(call[0]).includes("hash mode"));
+    expect(hashWarnings).toHaveLength(0);
+    warn.mockRestore();
+  });
+
+  it("does NOT warn when mount({ hydrate: true }) is called in history mode", () => {
+    resetMode();
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    el = makeEl();
+    unmount = router().route("/", HomePage).mount(el, { hydrate: true });
+    const hashWarnings = warn.mock.calls.filter((call) => String(call[0]).includes("hash mode"));
+    expect(hashWarnings).toHaveLength(0);
+    warn.mockRestore();
+  });
+});
+
+describe("hash mode — mode isolation", () => {
+  let el: Element;
+  let unmount: (() => void) | undefined;
+
+  afterEach(() => {
+    unmount?.();
+    cleanup(el);
+    resetMode();
+    window.location.href = "http://localhost/";
+  });
+
+  it("after switching back to history mode, navigate() writes pathname (not hash)", () => {
+    setHistoryMode("hash");
+    setHashLocation("/");
+    setHistoryMode("history");
+
+    el = makeEl();
+    unmount = router().route("/", HomePage).route("/about", AboutPage).mount(el);
+    navigate("/about");
+
+    expect(window.location.pathname).toBe("/about");
+    expect(routePath()).toBe("/about");
+  });
+
+  it("hash adapter and history adapter don't interfere across remount", () => {
+    // First mount: hash mode
+    setHistoryMode("hash");
+    setHashLocation("/about");
+    el = makeEl();
+    unmount = router().route("/", HomePage).route("/about", AboutPage).mount(el);
+    expect(routePath()).toBe("/about");
+    unmount();
+    cleanup(el);
+
+    // Remount: history mode
+    setHistoryMode("history");
+    window.location.href = "http://localhost/";
+    el = makeEl();
+    unmount = router().route("/", HomePage).route("/about", AboutPage).mount(el);
+    expect(routePath()).toBe("/");
+  });
+});
+
+// ─────────────────────────────────────────────
+// Multi-step navigation — exercises the dedup + popstate paths together
+// ─────────────────────────────────────────────
+
+describe("hash mode — navigation sequences", () => {
+  let el: Element;
+  let unmount: () => void;
+
+  beforeEach(() => {
+    setHistoryMode("hash");
+    setHashLocation("/");
+    el = makeEl();
+    unmount = router()
+      .route("/", HomePage)
+      .route("/about", AboutPage)
+      .route("/user/:id", UserPage)
+      .mount(el);
+  });
+
+  afterEach(() => {
+    unmount();
+    cleanup(el);
+    resetMode();
+    window.location.href = "http://localhost/";
+  });
+
+  it("navigates between three routes correctly", () => {
+    navigate("/about");
+    expect(routePath()).toBe("/about");
+    expect(el.innerHTML).toContain("about");
+
+    navigate("/user/42");
+    expect(routePath()).toBe("/user/42");
+    expect(el.innerHTML).toContain("user");
+
+    navigate("/");
+    expect(routePath()).toBe("/");
+    expect(el.innerHTML).toContain("home");
+  });
+
+  it("simulated back navigation re-renders prior route", () => {
+    navigate("/about");
+    expect(routePath()).toBe("/about");
+
+    // Simulate the user pressing back: the URL hash reverts and popstate fires.
+    setHashLocation("/");
+    popstate();
+
+    expect(routePath()).toBe("/");
+    expect(el.innerHTML).toContain("home");
+  });
+});

--- a/packages/router/src/hash.ts
+++ b/packages/router/src/hash.ts
@@ -121,10 +121,6 @@ function parseHash(rawHash: string): LogicalLocation {
   return { pathname: u.pathname, search: u.search, hash: u.hash };
 }
 
-function joinLogical(loc: LogicalLocation): string {
-  return loc.pathname + loc.search + loc.hash;
-}
-
 const hashAdapter: HistoryAdapter = {
   readLocation() {
     if (!isBrowser) return { pathname: "/", search: "", hash: "" };
@@ -132,11 +128,11 @@ const hashAdapter: HistoryAdapter = {
   },
   push(to) {
     if (!isBrowser) return;
-    history.pushState(null, "", "#" + to);
+    history.pushState(null, "", to.startsWith("#") ? to : "#" + to);
   },
   replace(to) {
     if (!isBrowser) return;
-    history.replaceState(null, "", "#" + to);
+    history.replaceState(null, "", to.startsWith("#") ? to : "#" + to);
   },
   onChange(handler) {
     if (!isBrowser) return () => {};

--- a/packages/router/src/hash.ts
+++ b/packages/router/src/hash.ts
@@ -1,0 +1,226 @@
+// ─────────────────────────────────────────────
+// History adapter — abstracts how the router reads/writes
+// the "logical" URL it matches routes against.
+//
+// Two modes:
+//   - "history" (default): reads/writes location.pathname directly,
+//     uses History API (history.pushState / popstate). This is the
+//     classic SPA setup and what every server-rendered page needs.
+//   - "hash": stores the logical path in location.hash (e.g. "#/users/42").
+//     Useful when the document is loaded over file:// (Electron, Electrobun,
+//     Tauri, opening a built bundle directly) where the History API can't
+//     write a meaningful pathname, or when there's no server able to serve
+//     a SPA fallback at every URL.
+//
+// The adapter is process-global and selected once at app entry via
+// setHistoryMode(). It does not affect server-side rendering — render(),
+// renderHydratable() and renderResponse() all take an explicit URL argument
+// and never touch window.location.
+// ─────────────────────────────────────────────
+
+const isBrowser = typeof window !== "undefined" && typeof document !== "undefined";
+
+export type HistoryMode = "history" | "hash";
+
+export interface LogicalLocation {
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+export interface HistoryAdapter {
+  /** Read the current logical URL (the one routes are matched against). */
+  readLocation(): LogicalLocation;
+  /** Push a new logical URL onto the history stack. */
+  push(to: string): void;
+  /** Replace the current history entry with a new logical URL. */
+  replace(to: string): void;
+  /** Subscribe to logical-URL changes. Returns a cleanup function. */
+  onChange(handler: () => void): () => void;
+  /**
+   * Convert a logical href (what the user writes, e.g. "/users/42") into
+   * the actual DOM href attribute (e.g. "#/users/42" in hash mode).
+   */
+  toLinkHref(logicalPath: string): string;
+  /**
+   * Extract a logical path from an `<a>` element. Returns null when the
+   * link is not an in-app navigation target (external, anchor-only, etc).
+   * The caller still applies modifier-key / target=_blank checks.
+   */
+  extractLogicalPath(anchor: HTMLAnchorElement): string | null;
+}
+
+// ─────────────────────────────────────────────
+// "history" mode — the classic SPA adapter (default)
+// ─────────────────────────────────────────────
+
+const historyAdapter: HistoryAdapter = {
+  readLocation() {
+    if (!isBrowser) return { pathname: "/", search: "", hash: "" };
+    return {
+      pathname: location.pathname,
+      search: location.search,
+      hash: location.hash,
+    };
+  },
+  push(to) {
+    if (!isBrowser) return;
+    history.pushState(null, "", to);
+  },
+  replace(to) {
+    if (!isBrowser) return;
+    history.replaceState(null, "", to);
+  },
+  onChange(handler) {
+    if (!isBrowser) return () => {};
+    window.addEventListener("popstate", handler);
+    return () => window.removeEventListener("popstate", handler);
+  },
+  toLinkHref(p) {
+    return p;
+  },
+  extractLogicalPath(anchor) {
+    const href = anchor.getAttribute("href");
+    if (!href) return null;
+    // Anchor-only links ("#section") are in-page, not navigations.
+    if (href.startsWith("#")) return null;
+    // Same-origin check — `hostname` is empty for relative hrefs, which is fine.
+    const isExternal =
+      !!anchor.hostname &&
+      (anchor.hostname !== location.hostname || anchor.protocol !== location.protocol);
+    if (isExternal) return null;
+    return anchor.pathname + anchor.search + anchor.hash;
+  },
+};
+
+// ─────────────────────────────────────────────
+// "hash" mode — logical URL lives in location.hash
+// ─────────────────────────────────────────────
+//
+// The hash content after the leading "#" is parsed as if it were a URL itself,
+// so "#/users/42?tab=info#section" yields:
+//   pathname: "/users/42"
+//   search:   "?tab=info"
+//   hash:     "#section"      ← available via routeHash() for in-page anchors
+//
+// We use history.pushState / replaceState (rather than `location.hash = ...`)
+// to write the hash. This avoids firing an extra `hashchange` event for
+// programmatic navigation, since we already call the change handler manually
+// after a push/replace via syncRouteFromLocation in index.ts. We still listen
+// for `hashchange` to catch out-of-band changes like the user typing into the
+// address bar or scripts setting `location.hash` directly.
+// ─────────────────────────────────────────────
+
+function parseHash(rawHash: string): LogicalLocation {
+  // Strip the leading "#". Empty hash → root path.
+  const stripped = rawHash.startsWith("#") ? rawHash.slice(1) : rawHash;
+  const path = stripped === "" ? "/" : stripped.startsWith("/") ? stripped : "/" + stripped;
+  // Use a dummy origin so the URL constructor parses pathname/search/hash
+  // exactly as it would for a real URL. The origin is never read.
+  const u = new URL(path, "http://_");
+  return { pathname: u.pathname, search: u.search, hash: u.hash };
+}
+
+function joinLogical(loc: LogicalLocation): string {
+  return loc.pathname + loc.search + loc.hash;
+}
+
+const hashAdapter: HistoryAdapter = {
+  readLocation() {
+    if (!isBrowser) return { pathname: "/", search: "", hash: "" };
+    return parseHash(location.hash);
+  },
+  push(to) {
+    if (!isBrowser) return;
+    history.pushState(null, "", "#" + to);
+  },
+  replace(to) {
+    if (!isBrowser) return;
+    history.replaceState(null, "", "#" + to);
+  },
+  onChange(handler) {
+    if (!isBrowser) return () => {};
+    window.addEventListener("popstate", handler);
+    window.addEventListener("hashchange", handler);
+    return () => {
+      window.removeEventListener("popstate", handler);
+      window.removeEventListener("hashchange", handler);
+    };
+  },
+  toLinkHref(p) {
+    // p is a logical path like "/users/42"; convert to "#/users/42".
+    // If the caller already passed something starting with "#", trust them.
+    if (p.startsWith("#")) return p;
+    return "#" + p;
+  },
+  extractLogicalPath(anchor) {
+    const href = anchor.getAttribute("href");
+    if (!href) return null;
+
+    // Hash-form link: "#/about" or "#/users/42?x=1"
+    if (href.startsWith("#")) {
+      const inner = href.slice(1);
+      // A bare "#" or "#section" without a leading slash is an in-page anchor,
+      // not an in-app navigation. We only intercept "#/..." style links.
+      if (inner === "" || !inner.startsWith("/")) return null;
+      return inner;
+    }
+
+    // Absolute URL with a hash component to a same-origin page —
+    // e.g. <a href="https://app.example.com/#/about">. Pull out the hash.
+    // For other absolute URLs (no hash, different origin), don't intercept.
+    if (/^https?:\/\//i.test(href)) {
+      try {
+        const u = new URL(href);
+        if (u.origin !== location.origin) return null;
+        if (!u.hash || u.hash === "#") return null;
+        const inner = u.hash.slice(1);
+        if (!inner.startsWith("/")) return null;
+        return inner;
+      } catch {
+        return null;
+      }
+    }
+
+    // A relative href like "/about" in hash mode is ambiguous. We treat it as
+    // a logical path — this matches what existing apps will already write
+    // (`<a href="/about">`) and keeps `navigate("/about")` symmetric. The
+    // alternative (refusing to intercept) would force every link in a hash-mode
+    // app to be hash-prefixed, which is hostile to code shared between modes.
+    return href;
+  },
+};
+
+// ─────────────────────────────────────────────
+// Module-level adapter selector
+// ─────────────────────────────────────────────
+
+let _mode: HistoryMode = "history";
+let _adapter: HistoryAdapter = historyAdapter;
+
+/**
+ * Set the router's history mode. Call this once at app entry, before
+ * mounting any router. Defaults to "history" (HTML5 History API).
+ *
+ * Use "hash" when the document is loaded over file:// (Electron, Tauri, etc.)
+ * or any time there's no server able to serve a SPA fallback at arbitrary
+ * pathnames.
+ *
+ * Switching modes mid-session is supported but not common — listeners
+ * registered before the switch will keep using their original adapter
+ * until they're re-attached (typically by unmounting and remounting
+ * the router).
+ */
+export function setHistoryMode(mode: HistoryMode): void {
+  _mode = mode;
+  _adapter = mode === "hash" ? hashAdapter : historyAdapter;
+}
+
+export function getHistoryMode(): HistoryMode {
+  return _mode;
+}
+
+/** Internal — used by index.ts. Not part of the public API. */
+export function getAdapter(): HistoryAdapter {
+  return _adapter;
+}

--- a/packages/router/src/hash.ts
+++ b/packages/router/src/hash.ts
@@ -82,6 +82,8 @@ const historyAdapter: HistoryAdapter = {
   extractLogicalPath(anchor) {
     const href = anchor.getAttribute("href");
     if (!href) return null;
+    // Ignore non-HTTP(S) schemes (mailto:, tel:, javascript:, etc.)
+    if (anchor.protocol && !/^(http:|https:)$/.test(anchor.protocol)) return null;
     // Anchor-only links ("#section") are in-page, not navigations.
     if (href.startsWith("#")) return null;
     // Same-origin check — `hostname` is empty for relative hrefs, which is fine.
@@ -152,6 +154,8 @@ const hashAdapter: HistoryAdapter = {
   extractLogicalPath(anchor) {
     const href = anchor.getAttribute("href");
     if (!href) return null;
+    // Ignore non-HTTP(S) schemes (mailto:, tel:, javascript:, etc.)
+    if (anchor.protocol && !/^(http:|https:)$/.test(anchor.protocol)) return null;
 
     // Hash-form link: "#/about" or "#/users/42?x=1"
     if (href.startsWith("#")) {

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -3,6 +3,11 @@ import type { Island, HydratableOptions } from "ilha";
 import ilha, { html } from "ilha";
 import { createRouter, addRoute, findRoute } from "rou3";
 
+import { getAdapter, getHistoryMode } from "./hash";
+
+export { setHistoryMode, getHistoryMode } from "./hash";
+export type { HistoryMode } from "./hash";
+
 // ─────────────────────────────────────────────
 // Environment
 // ─────────────────────────────────────────────
@@ -511,14 +516,15 @@ function syncRouteFromURL(url: string | URL): void {
   activeIsland(match?.data?.island ?? null);
 }
 
-/** Client-only fast path — reads directly from `location` instead of parsing a URL. */
+/** Client-only fast path — reads directly from the history adapter (location in history mode, hash content in hash mode). */
 function syncRouteFromLocation(): void {
-  const match = findRoute(_rou3, "GET", location.pathname);
+  const loc = getAdapter().readLocation();
+  const match = findRoute(_rou3, "GET", loc.pathname);
 
-  routePath(location.pathname);
+  routePath(loc.pathname);
   routeParams(extractParams(match?.params as Record<string, string> | undefined));
-  routeSearch(location.search);
-  routeHash(location.hash);
+  routeSearch(loc.search);
+  routeHash(loc.hash);
   activeIsland(match?.data?.island ?? null);
 }
 
@@ -542,12 +548,17 @@ export function prime(): void {
 export function navigate(to: string, opts: NavigateOptions = {}): void {
   if (!isBrowser) return;
 
-  // Skip duplicate navigations — same URL means no history push, no re-render
-  const current = location.pathname + location.search + location.hash;
+  const adapter = getAdapter();
+
+  // Skip duplicate navigations — same logical URL means no history push, no re-render.
+  // We compare against the adapter's logical location, not window.location, so the
+  // dedup behaves identically in hash mode.
+  const cur = adapter.readLocation();
+  const current = cur.pathname + cur.search + cur.hash;
   if (to === current) return;
 
-  if (opts.replace) history.replaceState(null, "", to);
-  else history.pushState(null, "", to);
+  if (opts.replace) adapter.replace(to);
+  else adapter.push(to);
   syncRouteFromLocation();
 }
 
@@ -573,29 +584,29 @@ export function enableLinkInterception(
 
   const prefetchEnabled = options.prefetch !== false;
 
-  /** Determine whether this anchor is a same-origin in-app link we should handle. */
-  function eligibleLink(target: HTMLAnchorElement, e?: Event): boolean {
-    const href = target.getAttribute("href");
-    if (!href) return false;
-    const isAnchorOnly = href.startsWith("#");
+  /**
+   * Determine whether this anchor is a same-origin in-app link we should handle,
+   * and if so, the logical path to navigate to. Returns null when the link
+   * should be left to the browser (external, modifier held, target=_blank, etc).
+   */
+  function logicalPathFor(target: HTMLAnchorElement, e?: Event): string | null {
     const isBlank = target.getAttribute("target") === "_blank";
     const hasModifier =
       !!e && ((e as MouseEvent).ctrlKey || (e as MouseEvent).metaKey || (e as MouseEvent).shiftKey);
-    const isExternal =
-      !!target.hostname &&
-      (target.hostname !== location.hostname || target.protocol !== location.protocol);
     const hasNoIntercept = target.hasAttribute("data-no-intercept");
-    return !(isExternal || isAnchorOnly || isBlank || hasModifier || hasNoIntercept);
+    if (isBlank || hasModifier || hasNoIntercept) return null;
+    return getAdapter().extractLogicalPath(target);
   }
 
   const clickHandler = (e: Event) => {
     if (e.defaultPrevented) return;
     const target = (e.target as Element).closest("a") as HTMLAnchorElement | null;
     if (!target) return;
-    if (!eligibleLink(target, e)) return;
+    const path = logicalPathFor(target, e);
+    if (path === null) return;
 
     e.preventDefault();
-    navigate(target.pathname + target.search + target.hash);
+    navigate(path);
   };
 
   const hoverHandler = (e: Event) => {
@@ -604,8 +615,11 @@ export function enableLinkInterception(
     // Opt-in only: link must have `data-prefetch` (and not `data-prefetch="false"`)
     const flag = target.getAttribute("data-prefetch");
     if (flag === null || flag === "false") return;
-    if (!eligibleLink(target)) return;
-    prefetch(target.pathname + target.search);
+    const path = logicalPathFor(target);
+    if (path === null) return;
+    // Drop hash for prefetch — loaders are keyed on path+search.
+    const noHash = path.split("#")[0] ?? path;
+    prefetch(noHash);
   };
 
   root.addEventListener("click", clickHandler);
@@ -659,7 +673,12 @@ export const RouterLink = ilha
     }
     prefetch(href);
   })
-  .render(({ state }) => html`<a data-link data-prefetch href="${state.href}">${state.label}</a>`);
+  .render(
+    ({ state }) =>
+      html`<a data-link data-prefetch href="${() => getAdapter().toLinkHref(state.href())}"
+        >${state.label}</a
+      >`,
+  );
 
 // ─────────────────────────────────────────────
 // isActive()
@@ -722,7 +741,7 @@ export function router(): RouterBuilder {
   _islandToPattern = new Map();
   _patternToData = new Map();
 
-  let _popstateCleanup: (() => void) | null = null;
+  let _navChangeCleanup: (() => void) | null = null;
   let _linkCleanup: (() => void) | null = null;
 
   const builder: RouterBuilder = {
@@ -774,8 +793,7 @@ export function router(): RouterBuilder {
       syncRouteFromLocation();
 
       const popHandler = () => syncRouteFromLocation();
-      window.addEventListener("popstate", popHandler);
-      _popstateCleanup = () => window.removeEventListener("popstate", popHandler);
+      _navChangeCleanup = getAdapter().onChange(popHandler);
       _linkCleanup = enableLinkInterception(document);
 
       let unmountView: (() => void) | null = null;
@@ -784,6 +802,19 @@ export function router(): RouterBuilder {
       let navAbort: AbortController | null = null;
 
       if (hydrate) {
+        // Hash-mode + hydration is a footgun: the server only ever sees "/" because
+        // the hash isn't sent in the request, so the SSR HTML was rendered for "/"
+        // even when the user opened a deep link like "index.html#/about". On the
+        // client we'd then try to hydrate "/about" against HTML rendered for "/" —
+        // mismatch. Warn loudly so apps don't accidentally combine the two.
+        if (getHistoryMode() === "hash") {
+          console.warn(
+            "[ilha-router] mount({ hydrate: true }) was called in hash mode. " +
+              "SSR + hydration assumes the server can render the active route, but in " +
+              "hash mode the server only ever sees the document URL. Use plain SPA mode " +
+              "(`mount(target)` without `hydrate: true`) for hash-mode apps.",
+          );
+        }
         // SSR HTML is already in the DOM and ilha.mount() has already hydrated
         // [data-ilha] nodes with reactivity.  We must NOT mount RouterView now —
         // any morph (even with identical HTML) would replace the live DOM nodes,
@@ -808,10 +839,11 @@ export function router(): RouterBuilder {
               if (thisNav !== navVersion) return;
               unmountView?.();
               try {
+                const loc = getAdapter().readLocation();
                 unmountView = await mountRouteWithHydration(
                   current,
                   viewHost,
-                  location.pathname + location.search,
+                  loc.pathname + loc.search,
                   signal,
                   registry,
                   reverseRegistry,
@@ -837,9 +869,9 @@ export function router(): RouterBuilder {
           unmountNavHandler();
           navHost.remove();
           unmountView?.();
-          _popstateCleanup?.();
+          _navChangeCleanup?.();
           _linkCleanup?.();
-          _popstateCleanup = null;
+          _navChangeCleanup = null;
           _linkCleanup = null;
         };
       }
@@ -868,10 +900,12 @@ export function router(): RouterBuilder {
         if (!viewHost) return;
 
         // Fetch loader data only if the matched route has a loader registered.
-        const clientMatch = findRoute(_rou3, "GET", location.pathname);
+        const adapter = getAdapter();
+        const loc = adapter.readLocation();
+        const clientMatch = findRoute(_rou3, "GET", loc.pathname);
         const hasLoader = !!clientMatch?.data?.loader;
         const result: LoaderFetchResult = hasLoader
-          ? await fetchLoaderData(location.pathname + location.search, signal)
+          ? await fetchLoaderData(loc.pathname + loc.search, signal)
           : { kind: "data", data: {} };
         if (signal.aborted) return;
         if (result.kind === "redirect") {
@@ -919,9 +953,9 @@ export function router(): RouterBuilder {
         unmountNavHandler();
         navHost.remove();
         unmountView?.();
-        _popstateCleanup?.();
+        _navChangeCleanup?.();
         _linkCleanup?.();
-        _popstateCleanup = null;
+        _navChangeCleanup = null;
         _linkCleanup = null;
       };
     },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional "hash" routing mode (URLs like #/about) and public APIs to set/query it.

* **Documentation**
  * Added a hash mode guide with setup, navigation semantics, supported link formats, and explicit limitations (no SSR + hydration; mount ordering requirements).

* **Chores**
  * Bumped router package version.

* **Tests**
  * Added comprehensive tests covering hash-mode navigation, link handling, and lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->