### PR TITLE
Fix/ilha make input reactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## `ilha`
 
+### 0.4.2 - 2026-05-11
+
+- Fixes .input() reactivity so child components can rerender when parent updates passed propes programatically.
+
 ### 0.4.1 - 2026-05-06
 
 - Fixes .derived() signal in child that caused unnecessary rerender of parent.
@@ -60,35 +64,11 @@ Initial release of **ilha** — a tiny, isomorphic island framework for building
 - Adds helpers and utilities: `raw(value)` — marks a string as trusted raw HTML, bypassing escaping inside `html`
 - Adds helpers and utilities: `type(coerce?)` — lightweight Standard Schema validator for `.input()` without a full validation library
 
-## `@ilha/form`
-
-### 0.2.1 - 2026-04-28
-
-- Deprecated the library in favor for handling form management with `@ilha/store` using `@ilha/store/form` helpers.
-
-### 0.2.0 - 2026-04-21
-
-- Adds `defaultValues` property to set initial form state
-- Adds Programmatic `form.setValue` API
-
-### 0.1.0 — 2026-04-14
-
-Initial release of **@ilha/form** — a tiny, typed form binding library for ilha islands. Binds a Standard Schema validator to a native `<form>` element; wires up typed submission, per-field error tracking, and dirty state using native DOM events only. No virtual DOM. No external runtime dependencies. Async schema validation is not supported.
-
-- Adds `createForm(options)` — creates a form binding instance; does not attach any listeners until `.mount()` is called; accepts `el`, `schema`, `onSubmit`, `onError`, and `validateOn`
-- Adds `createForm` option `onSubmit(values, event)` — called with fully typed schema output on valid submission; not called if validation fails
-- Adds `createForm` option `onError(issues, event)` — called with structured `StandardSchemaV1.Issue[]` on invalid submission
-- Adds `createForm` option `validateOn` — controls when live validation runs against field changes: `"submit"` (default, submission only), `"change"` (after a field loses focus with a new value), or `"input"` (every keystroke)
-- Adds `form.mount()` — attaches event listeners to the form; returns a cleanup function equivalent to calling `form.unmount()`
-- Adds `form.unmount()` — removes all event listeners; idempotent, safe to call multiple times
-- Adds `form.values` — reads and validates current form values synchronously against the schema; returns a discriminated union `{ ok: true, data }` or `{ ok: false, issues }`; never throws; can be called before mount
-- Adds `form.errors` — returns the per-field error map from the last validation run as `Record<string, string[]>`; keys are dot-separated field paths (e.g. `user.email`); empty object before first validation; returns a copy — mutations do not affect internal state
-- Adds `form.isDirty` — `true` if any field value has changed since mount was called (detected via `change` events); stays `true` after unmount
-- Adds `form.submit()` — programmatically triggers the validate / `onSubmit` / `onError` cycle; dispatches a real `SubmitEvent` when mounted, runs validation directly when not mounted
-- Adds exported helper `issuesToErrors(issues)` — converts a `StandardSchemaV1.Issue[]` array into a `FormErrors` map; useful for wiring `onError` into island state
-- Adds exported types: `FormResult<T>`, `FormErrors`, `ValidateOn`, `Form<S>`, `CreateFormOptions<S>`
-
 ## `@ilha/router`
+
+### 0.3.1 - 2026-05-11
+
+- Updates Ilha dependency to 0.4.2
 
 ### 0.2.5 - 2026-05-06
 
@@ -142,6 +122,10 @@ Initial release of **@ilha/router** — a lightweight, isomorphic router for ilh
 - Adds exported types: `RouteRecord`, `RouteSnapshot`, `AppError`, `LayoutHandler`, `ErrorHandler`, `NavigateOptions`, `MountOptions`, `HydrateOptions`, `HydratableRenderOptions`, `RouterBuilder`
 
 ## `@ilha/store`
+
+### 0.3.1 - 2026-05-11
+
+- Updates Ilha dependency to 0.4.2
 
 ### 0.3.0 - 2026-05-07
 

--- a/packages/ilha/package.json
+++ b/packages/ilha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ilha",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A tiny, framework-free island architecture library",
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",

--- a/packages/ilha/src/index.test.ts
+++ b/packages/ilha/src/index.test.ts
@@ -4895,3 +4895,228 @@ describe(".css()", () => {
     });
   });
 });
+
+// ---------------------------------------------
+// Regression: Child re-renders when parent state passed as prop changes
+// ---------------------------------------------
+//
+// Scenario: a Parent island has a state signal and renders a Child island,
+// passing the current state value as a Child input prop. The Parent's
+// onMount writes a new value to its state. The Child should re-render with
+// the updated prop value.
+//
+// This exercises the path where parent re-render produces a fresh slot map
+// with new props for an already-mounted child. If mountSlots skips re-
+// applying props to existing slots, the child will stay stuck on its
+// initial prop value.
+
+describe("regression: child receives updated props when parent state changes", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("Child re-renders after Parent.onMount writes new state passed as Child prop", async () => {
+    const Child = ilha
+      .input(z.object({ value: z.string() }))
+      .render(({ input }) => html`<span class="child">${input.value}</span>`);
+
+    const Parent = ilha
+      .state("msg", "initial")
+      .onMount(({ state }) => {
+        state.msg("updated");
+      })
+      .render(({ state }) => html`<div>${Child({ value: state.msg() })}</div>`);
+
+    const el = makeEl();
+    const unmount = Parent.mount(el);
+
+    // Let onMount's state write propagate. The write happens synchronously
+    // inside onMount, but the render effect that reacts to it may flush
+    // asynchronously — give it a microtask either way.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(el.querySelector(".child")!.textContent).toBe("updated");
+
+    unmount();
+    cleanup(el);
+  });
+
+  // The core "parent re-renders, child must follow" case. The previous
+  // test uses onMount to force the initial-effect-pass divergence path
+  // (state changed before the render effect was even registered). This
+  // test takes the *steady-state* path: parent is fully mounted, then
+  // a click fires that writes parent state, and we verify the child's
+  // DOM updates. If updateProps regresses to a no-op on the existing
+  // slot, this test will fail with "0" while the regression test above
+  // passes — they probe different code paths.
+  it("Child re-renders after click on Parent updates state passed as Child prop", () => {
+    const Child = ilha
+      .input(z.object({ count: z.number() }))
+      .render(({ input }) => html`<span class="child">${input.count}</span>`);
+
+    const Parent = ilha
+      .state("count", 0)
+      .on("button@click", ({ state }) => state.count(state.count() + 1))
+      .render(({ state }) => html`<div>${Child({ count: state.count() })}<button>+</button></div>`);
+
+    const el = makeEl();
+    const unmount = Parent.mount(el);
+
+    expect(el.querySelector(".child")!.textContent).toBe("0");
+
+    el.querySelector<HTMLButtonElement>("button")!.click();
+    expect(el.querySelector(".child")!.textContent).toBe("1");
+
+    el.querySelector<HTMLButtonElement>("button")!.click();
+    el.querySelector<HTMLButtonElement>("button")!.click();
+    expect(el.querySelector(".child")!.textContent).toBe("3");
+
+    unmount();
+    cleanup(el);
+  });
+
+  // The mounted Child element identity must be preserved when its props
+  // change. We're propagating props by writing into the existing child's
+  // input signal, NOT by tearing down and remounting — so its host
+  // element, internal state, and onMount cleanup should all survive.
+  it("Child element identity and state are preserved across prop updates", () => {
+    let childMountCount = 0;
+    let childUnmountCount = 0;
+
+    const Child = ilha
+      .input(z.object({ label: z.string() }))
+      .state("clicks", 0)
+      .on("[data-c]@click", ({ state }) => state.clicks(state.clicks() + 1))
+      .onMount(() => {
+        childMountCount++;
+        return () => {
+          childUnmountCount++;
+        };
+      })
+      .render(
+        ({ state, input }) =>
+          html`<span class="child" data-c>${input.label}:${state.clicks()}</span>`,
+      );
+
+    const Parent = ilha
+      .state("label", "a")
+      .on("button@click", ({ state }) => state.label(state.label() + "+"))
+      .render(
+        ({ state }) => html`<div>${Child({ label: state.label() })}<button>edit</button></div>`,
+      );
+
+    const el = makeEl();
+    const unmount = Parent.mount(el);
+
+    expect(childMountCount).toBe(1);
+    const childElBefore = el.querySelector(".child");
+
+    // Bump child internal state via a click on the child.
+    el.querySelector<HTMLSpanElement>(".child")!.click();
+    expect(el.querySelector(".child")!.textContent).toBe("a:1");
+
+    // Trigger a parent re-render that pushes new props to the child.
+    el.querySelector<HTMLButtonElement>("button")!.click();
+    expect(el.querySelector(".child")!.textContent).toBe("a+:1");
+
+    // Same DOM element — child was NOT remounted.
+    expect(el.querySelector(".child")).toBe(childElBefore);
+    expect(childMountCount).toBe(1);
+    expect(childUnmountCount).toBe(0);
+
+    // Child's internal state survived; another click still increments.
+    el.querySelector<HTMLSpanElement>(".child")!.click();
+    expect(el.querySelector(".child")!.textContent).toBe("a+:2");
+
+    unmount();
+    cleanup(el);
+  });
+
+  // Parent re-renders that don't change child props should not cause the
+  // child's render effect to run again. The shallowEqualInput short-circuit
+  // in updateProps is what guarantees this — without it, every parent
+  // re-render would churn the child's input signal and re-run its
+  // render/derived/effect scopes pointlessly.
+  it("Child does NOT re-render when parent re-renders with shallow-equal props", () => {
+    let childRenders = 0;
+
+    const Child = ilha.input(z.object({ value: z.string() })).render(({ input }) => {
+      childRenders++;
+      return html`<span class="child">${input.value}</span>`;
+    });
+
+    const Parent = ilha
+      .state("count", 0)
+      .state("label", "hello")
+      .on("button@click", ({ state }) => state.count(state.count() + 1))
+      .render(
+        ({ state }) =>
+          html`<div>
+            <p>${state.count()}</p>
+            ${Child({ value: state.label() })}
+            <button>+</button>
+          </div>`,
+      );
+
+    const el = makeEl();
+    const unmount = Parent.mount(el);
+
+    const initialChildRenders = childRenders;
+
+    // Parent state changes drive parent re-renders, but child props
+    // (state.label) are unchanged, so child should not re-run.
+    el.querySelector<HTMLButtonElement>("button")!.click();
+    el.querySelector<HTMLButtonElement>("button")!.click();
+    el.querySelector<HTMLButtonElement>("button")!.click();
+
+    expect(el.querySelector("p")!.textContent).toBe("3");
+    expect(el.querySelector(".child")!.textContent).toBe("hello");
+    expect(childRenders).toBe(initialChildRenders);
+
+    unmount();
+    cleanup(el);
+  });
+
+  // Mixed: one prop changes, another stays the same. Because we use a
+  // single input signal per child, ANY prop change triggers a re-render
+  // (coarse-grained reactivity by design — granular per-key signals would
+  // be a much bigger change). Documenting this so the granularity choice
+  // is intentional and tested.
+  it("Child re-renders when ANY prop changes (whole-input granularity)", () => {
+    let childRenders = 0;
+
+    const Child = ilha.input(z.object({ a: z.string(), b: z.string() })).render(({ input }) => {
+      childRenders++;
+      return html`<span class="child">${input.a}-${input.b}</span>`;
+    });
+
+    const Parent = ilha
+      .state("a", "x")
+      .state("b", "y")
+      .on("[data-a]@click", ({ state }) => state.a(state.a() + "!"))
+      .on("[data-b]@click", ({ state }) => state.b(state.b() + "?"))
+      .render(
+        ({ state }) =>
+          html`<div>
+            ${Child({ a: state.a(), b: state.b() })}
+            <button data-a>A</button>
+            <button data-b>B</button>
+          </div>`,
+      );
+
+    const el = makeEl();
+    const unmount = Parent.mount(el);
+    const baseline = childRenders;
+
+    el.querySelector<HTMLButtonElement>("[data-a]")!.click();
+    expect(el.querySelector(".child")!.textContent).toBe("x!-y");
+    expect(childRenders).toBe(baseline + 1);
+
+    el.querySelector<HTMLButtonElement>("[data-b]")!.click();
+    expect(el.querySelector(".child")!.textContent).toBe("x!-y?");
+    expect(childRenders).toBe(baseline + 2);
+
+    unmount();
+    cleanup(el);
+  });
+});

--- a/packages/ilha/src/index.ts
+++ b/packages/ilha/src/index.ts
@@ -49,6 +49,26 @@ function warn(msg: string): void {
   if (__DEV__) console.warn(`[ilha] ${msg}`);
 }
 
+// Shallow equality on two resolved-input objects. Used to short-circuit
+// updateProps when a parent re-renders with the same props — avoids
+// unnecessary signal churn (and therefore unnecessary child re-renders).
+// Objects only; both arguments are always plain objects produced by
+// resolveInput. Uses Object.is so NaN compares equal to itself.
+function shallowEqualInput(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== "object" || a === null || typeof b !== "object" || b === null) return false;
+  const ak = Object.keys(a as object);
+  const bk = Object.keys(b as object);
+  if (ak.length !== bk.length) return false;
+  for (const k of ak) {
+    if (!Object.prototype.hasOwnProperty.call(b, k)) return false;
+    if (!Object.is((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // ---------------------------------------------
 // Simplified morph engine
 // ---------------------------------------------
@@ -175,6 +195,10 @@ const RAW = Symbol("ilha.raw");
 const SIGNAL_ACCESSOR = Symbol("ilha.signalAccessor");
 const ISLAND = Symbol("ilha.island");
 const ISLAND_CALL = Symbol("ilha.islandCall");
+// Internal hook used by a parent's mountSlots to mount a child island and
+// retain a handle to push updated props into it on subsequent parent
+// re-renders. Not part of the public surface.
+const ISLAND_MOUNT_INTERNAL = Symbol("ilha.islandMountInternal");
 
 const SLOT_ATTR = "data-ilha-slot";
 const PROPS_ATTR = "data-ilha-props";
@@ -1447,7 +1471,24 @@ class IlhaBuilder<
       });
     }
 
+    type MountHandle = {
+      unmount: () => void;
+      // Push new props into an already-mounted island. Used by parent
+      // mountSlots when a parent re-render produces new props for an
+      // already-mounted child slot. The new props are resolved (and
+      // validated against the schema, if any) and written into the input
+      // signal — reactive scopes (render, derived, effect) that read input
+      // keys re-run automatically.
+      updateProps: (props?: Partial<TInput>) => void;
+    };
+
     function mountIsland(host: Element, props?: Partial<TInput>): () => void {
+      return mountIslandInternal(host, props).unmount;
+    }
+
+    function mountIslandInternal(host: Element, props?: Partial<TInput>): MountHandle {
+      const noop: MountHandle = { unmount: () => {}, updateProps: () => {} };
+
       if (__DEV__ && _mountedHosts) {
         if (_mountedHosts.has(host)) {
           warn(
@@ -1455,7 +1496,7 @@ class IlhaBuilder<
               `memory leaks and duplicate event listeners.\n` +
               `Element: ${host.outerHTML.slice(0, 120)}`,
           );
-          return () => {};
+          return noop;
         }
         _mountedHosts.add(host);
       }
@@ -1471,7 +1512,38 @@ class IlhaBuilder<
         }
       }
 
-      const input = resolveInput(props);
+      // Input is reactive: stored in a signal whose value is the resolved
+      // input object, and exposed to user code via a Proxy whose getters
+      // read the signal. This lets child islands re-render when a parent
+      // passes them updated state via `Child({ value: state.x() })` and
+      // the parent's render effect re-runs — see updateProps below.
+      const inputSignal = signal(resolveInput(props));
+      const input = new Proxy({} as TInput, {
+        get(_t, key) {
+          return (inputSignal() as Record<PropertyKey, unknown>)[key];
+        },
+        has(_t, key) {
+          return key in (inputSignal() as object);
+        },
+        ownKeys() {
+          // ownKeys is invoked outside a tracking scope (e.g. Object.keys);
+          // peek without subscribing to avoid surprises.
+          const prevSub = setActiveSub(undefined);
+          try {
+            return Reflect.ownKeys(inputSignal() as object);
+          } finally {
+            setActiveSub(prevSub);
+          }
+        },
+        getOwnPropertyDescriptor(_t, key) {
+          const prevSub = setActiveSub(undefined);
+          try {
+            return Reflect.getOwnPropertyDescriptor(inputSignal() as object, key);
+          } finally {
+            setActiveSub(prevSub);
+          }
+        },
+      });
 
       let snapshotRaw: Record<string, unknown> | undefined;
       const rawState = host.getAttribute(STATE_ATTR);
@@ -1547,12 +1619,17 @@ class IlhaBuilder<
         }
       }
 
-      // Tracks slots currently mounted into the host: id -> { element, unmount }.
+      // Tracks slots currently mounted into the host: id -> { element, unmount, updateProps }.
       // mountSlots reconciles this against the fresh slot map from each render.
       // Preservation of identity across re-renders happens in the render effect
-      // (detach-before-morph, rehome-after-morph). This function's job is
-      // purely: unmount removed slots, mount newly-added ones.
-      const mountedSlots = new Map<string, { el: Element; unmount: () => void }>();
+      // (detach-before-morph, rehome-after-morph). This function's job is:
+      // unmount removed slots, mount newly-added ones, and push fresh props
+      // into slots that were already mounted (so children re-render when the
+      // parent passes them updated state as input).
+      const mountedSlots = new Map<
+        string,
+        { el: Element; unmount: () => void; updateProps: (props?: Record<string, unknown>) => void }
+      >();
 
       function findSlot(id: string): Element | null {
         // Use CSS.escape when available (DOM environments always have it); fall
@@ -1582,9 +1659,17 @@ class IlhaBuilder<
           }
         }
 
-        // Mount new slot ids that aren't yet mounted.
+        // Mount new slot ids that aren't yet mounted; push updated props
+        // into slots that are.
         for (const [id, { island: childIsland, props }] of slotMap) {
-          if (mountedSlots.has(id)) continue;
+          const existing = mountedSlots.get(id);
+          if (existing) {
+            // Already mounted — propagate fresh props so the child can
+            // re-render. Short-circuit happens inside updateProps when the
+            // resolved input is shallow-equal to the previous one.
+            existing.updateProps(props);
+            continue;
+          }
 
           const slotEl = findSlot(id);
           if (!slotEl) continue;
@@ -1612,13 +1697,25 @@ class IlhaBuilder<
           // parent to child-internal state and preventing the child's own
           // render effect from receiving updates.
           const prevSub = setActiveSub(undefined);
-          let unmount: () => void;
+          let handle: { unmount: () => void; updateProps: (p?: Record<string, unknown>) => void };
           try {
-            unmount = childIsland.mount(slotEl, slotProps);
+            // Use the internal mount path so we get a handle that can push
+            // new props on subsequent parent re-renders, not just unmount.
+            const internal = (childIsland as unknown as Record<symbol, unknown>)[
+              ISLAND_MOUNT_INTERNAL
+            ] as
+              | ((
+                  host: Element,
+                  props?: Record<string, unknown>,
+                ) => { unmount: () => void; updateProps: (p?: Record<string, unknown>) => void })
+              | undefined;
+            handle = internal
+              ? internal(slotEl, slotProps)
+              : { unmount: childIsland.mount(slotEl, slotProps), updateProps: () => {} };
           } finally {
             setActiveSub(prevSub);
           }
-          mountedSlots.set(id, { el: slotEl, unmount });
+          mountedSlots.set(id, { el: slotEl, ...handle });
         }
       }
 
@@ -1770,6 +1867,12 @@ class IlhaBuilder<
       }
 
       let initialized = false;
+      // Track the rendered HTML from the initial sync render so the first
+      // effect pass can detect whether state writes during onMount or
+      // synchronous effect setup have produced a divergence that needs a
+      // re-paint. Without this, the DOM stays stuck on the initial-render
+      // value because the effect's first run short-circuits.
+      const initialRenderedHtml = initial.html;
       const stopRender = effect(() => {
         // Re-render produces empty stubs for every child island site (see
         // emitIslandSlot). The full strategy for preserving mounted children
@@ -1795,9 +1898,22 @@ class IlhaBuilder<
           host,
         );
         const html = stylePrefix + rendered;
+
         if (!initialized) {
           initialized = true;
-          return;
+          // Fast path: render output matches the eager initial render. DOM
+          // and slot map are already in sync — nothing more to do here. The
+          // typical case: no onMount has run yet, or onMount hasn't written
+          // any state.
+          if (rendered === initialRenderedHtml) {
+            return;
+          }
+          // Divergence: a state write between the eager initial render and
+          // the first effect pass (typically inside onMount) changed what
+          // the render fn produces. Fall through to do a full morph + slot
+          // reconcile so the DOM and mounted children catch up. The child
+          // islands that were already mounted by the eager mountSlots get
+          // their new props pushed via updateProps.
         }
 
         detachListeners();
@@ -1887,7 +2003,7 @@ class IlhaBuilder<
       }
 
       let tornDown = false;
-      return () => {
+      const unmount = (): void => {
         if (tornDown) return;
         tornDown = true;
         if (__DEV__ && _mountedHosts) _mountedHosts.delete(host);
@@ -1900,6 +2016,20 @@ class IlhaBuilder<
         }
         cleanups.forEach((c) => c());
       };
+
+      const updateProps = (nextProps?: Partial<TInput>): void => {
+        if (tornDown) return;
+        const next = resolveInput(nextProps);
+        const prev = inputSignal();
+        // Shallow-equal short-circuit: don't churn reactive subscribers when
+        // the resolved input hasn't actually changed. We compare own keys
+        // and values with Object.is. This keeps repeated parent re-renders
+        // with identical props free of work.
+        if (shallowEqualInput(prev, next)) return;
+        inputSignal(next);
+      };
+
+      return { unmount, updateProps };
     }
 
     /**
@@ -1929,6 +2059,14 @@ class IlhaBuilder<
 
     island.mount = (host: Element, props?: Partial<TInput>): (() => void) =>
       mountIsland(host, props);
+
+    // Internal hook for parent mountSlots — returns { unmount, updateProps }
+    // so parent re-renders can push new props into already-mounted child
+    // islands. Not exported as part of the public Island interface.
+    (island as unknown as Record<symbol, unknown>)[ISLAND_MOUNT_INTERNAL] = (
+      host: Element,
+      props?: Partial<TInput>,
+    ): MountHandle => mountIslandInternal(host, props);
 
     // Create a keyed invocation for stable slot identity across re-renders
     // (useful in reorderable lists). Returns a callable that, when given

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/router",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A tiny SPA router for Ilha",
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",
@@ -27,7 +27,7 @@
     "test": "bun test"
   },
   "dependencies": {
-    "ilha": "0.4.1",
+    "ilha": "0.4.2",
     "rou3": "0.8.1"
   },
   "devDependencies": {

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/store",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Typed store.",
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "alien-signals": "3.1.2",
-    "ilha": "0.4.1"
+    "ilha": "0.4.2"
   },
   "devDependencies": {
     "zod": "^4.4.3"

--- a/templates/electrobun/package.json
+++ b/templates/electrobun/package.json
@@ -10,9 +10,9 @@
     "build:canary": "vite build && electrobun build --env=canary"
   },
   "dependencies": {
-    "@ilha/router": "^0.2.5",
+    "@ilha/router": "^0.3.1",
     "electrobun": "1.16.0",
-    "ilha": "^0.4.1"
+    "ilha": "^0.4.2"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/templates/elysia/package.json
+++ b/templates/elysia/package.json
@@ -11,9 +11,9 @@
   "dependencies": {
     "@elysiajs/html": "^1.4.2",
     "@elysiajs/static": "^1.4.10",
-    "@ilha/router": "^0.2.5",
+    "@ilha/router": "^0.3.1",
     "elysia": "^1.4.28",
-    "ilha": "^0.4.1"
+    "ilha": "^0.4.2"
   },
   "devDependencies": {
     "bun-types": "latest",

--- a/templates/hono/package.json
+++ b/templates/hono/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.1",
-    "@ilha/router": "^0.2.5",
+    "@ilha/router": "^0.3.1",
     "hono": "^4.12.16",
-    "ilha": "^0.4.1"
+    "ilha": "^0.4.2"
   },
   "devDependencies": {
     "@types/node": "^24",

--- a/templates/nitro/package.json
+++ b/templates/nitro/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.2.5",
-    "ilha": "^0.4.1",
+    "@ilha/router": "^0.3.1",
+    "ilha": "^0.4.2",
     "nitro": "^3.0.260429-beta"
   },
   "devDependencies": {

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.2.5",
-    "ilha": "^0.4.1"
+    "@ilha/router": "^0.3.1",
+    "ilha": "^0.4.2"
   },
   "devDependencies": {
     "typescript": "^6.0.3",


### PR DESCRIPTION
Child islands stayed stuck on their initial props because `mountSlots` skipped already-mounted slots on parent re-renders — fixed by making each child's `input` a reactive signal-backed proxy and having `mountSlots` push new props into existing children via an `updateProps` call (with a shallow-equality short-circuit to avoid churn).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `.input()` reactivity issue preventing child Island components from updating when parent state changes were passed programmatically. Child components now properly observe and rerender in response to parent updates, maintaining stable DOM elements and preserving internal state across prop synchronization events. This improves parent-child component communication and enables more reliable reactive patterns.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ilhajs/ilha/pull/32)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->