### PR TITLE
Add `browser` field to package.json

### DIFF
--- a/packages/ilha/package.json
+++ b/packages/ilha/package.json
@@ -18,6 +18,9 @@
       "import": "./dist/index.js"
     }
   },
+  "browser": {
+    "process": false,
+  },
   "scripts": {
     "build": "tsc && tsdown",
     "test": "bun test"

--- a/packages/ilha/package.json
+++ b/packages/ilha/package.json
@@ -12,14 +12,14 @@
     "dist"
   ],
   "type": "module",
+  "browser": {
+    "process": false
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
-  },
-  "browser": {
-    "process": false,
   },
   "scripts": {
     "build": "tsc && tsdown",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -12,6 +12,9 @@
     "dist"
   ],
   "type": "module",
+  "browser": {
+    "process": false
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -12,6 +12,9 @@
     "dist"
   ],
   "type": "module",
+  "browser": {
+    "process": false
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
this change gets rid of `https://esm.sh/node/process.mjs` dep when import ilha from esm.sh CDN.

ps, love this library 💚

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved browser compatibility in the Ilha, Router, and Store packages to reduce bundling/runtime issues and provide more consistent behavior in browser builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ilhajs/ilha/pull/35)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ilhajs/ilha/pull/35)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->