### PR TITLE
fix(vite): fix layout island hydration in wrapLayout

### DIFF
--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -562,6 +562,8 @@ RouterLink.toString({ href: "/about", label: "About" });
 
 Wraps a page island with a layout handler. Used internally by the Vite plugin codegen — also available for manual composition.
 
+On client hydration, `wrapLayout` mounts the full layout island (layout child slots `p:*` and the keyed page slot `k:page`) from existing SSR DOM — it does not re-render layout markup from serialized props. Interactive components in `+layout.tsx` (state, event handlers, nested islands) hydrate the same way as the page.
+
 ```ts
 import { wrapLayout } from "@ilha/router";
 

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/router",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "A tiny SPA router for Ilha",
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",

--- a/packages/router/src/index.test.ts
+++ b/packages/router/src/index.test.ts
@@ -1793,6 +1793,52 @@ describe("wrapError / wrapLayout hydration", () => {
     unmount();
   });
 
+  it("wrapLayout hydrates interactive layout child slots (p:*) and page (k:page)", async () => {
+    const LayoutToggle = ilha
+      .state("on", false)
+      .on("[data-layout-toggle]@click", ({ state }) => {
+        state.on(!state.on());
+      })
+      .render(
+        ({ state }) => html`<button data-layout-toggle>${state.on() ? "on" : "off"}</button>`,
+      );
+
+    const Page = ilha
+      .state("count", 0)
+      .on("[data-page-inc]@click", ({ state }) => {
+        state.count(state.count() + 1);
+      })
+      .render(({ state }) => html`<button data-page-inc>${state.count()}</button>`);
+
+    const Layout = defineLayout((children) =>
+      ilha.render(
+        () => html`
+          <aside>${LayoutToggle()}</aside>
+          <main>${children()}</main>
+        `,
+      ),
+    );
+
+    const Wrapped = wrapLayout(Layout, Page);
+    const ssr = await Wrapped.hydratable({}, { name: "page", snapshot: true });
+
+    expect(ssr).toContain('data-ilha-slot="p:0"');
+    expect(ssr).toContain('data-ilha-slot="k:page"');
+
+    el = makeEl(`<div data-router-view>${ssr}</div>`);
+    const { unmount } = ilhaMount({ page: Wrapped }, { root: el });
+
+    el.querySelector<HTMLButtonElement>("[data-layout-toggle]")!.click();
+    await flushEffects();
+    expect(el.textContent).toContain("on");
+
+    el.querySelector<HTMLButtonElement>("[data-page-inc]")!.click();
+    await flushEffects();
+    expect(el.textContent).toContain("1");
+
+    unmount();
+  });
+
   it("wrapLayout mount wires page handlers through outer hydratable shell", async () => {
     const Page = ilha
       .state("count", 0)

--- a/packages/router/src/index.test.ts
+++ b/packages/router/src/index.test.ts
@@ -1839,6 +1839,34 @@ describe("wrapError / wrapLayout hydration", () => {
     unmount();
   });
 
+  it("wrapLayout layout onMount runs when outer snapshot has _skipOnMount", async () => {
+    const Layout = defineLayout((children) =>
+      ilha
+        .onMount(({ host }) => {
+          host.setAttribute("data-layout-mounted", "1");
+        })
+        .render(() => html`<nav>nav</nav><main>${children()}</main>`),
+    );
+
+    const Page = ilha.render(
+      () =>
+        html`
+          <p>page</p>
+        `,
+    );
+    const Wrapped = wrapLayout(Layout, Page);
+    const ssr = await Wrapped.hydratable({}, { name: "page", snapshot: true });
+
+    expect(ssr).toContain("_skipOnMount");
+
+    el = makeEl(`<div data-router-view>${ssr}</div>`);
+    const { unmount } = ilhaMount({ page: Wrapped }, { root: el });
+
+    expect(el.querySelector("[data-ilha]")?.getAttribute("data-layout-mounted")).toBe("1");
+
+    unmount();
+  });
+
   it("wrapLayout mount wires page handlers through outer hydratable shell", async () => {
     const Page = ilha
       .state("count", 0)

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -182,6 +182,9 @@ export function wrapLayout(layout: LayoutHandler, page: Island<any, any>): Islan
 
   function prepareLayoutMountHost(host: Element): void {
     preparePageMountHost(host, pageMountHost(host));
+    // Outer tag carries the page hydratable snapshot (incl. _skipOnMount); the
+    // layout root must not read it — state belongs on k:page only.
+    host.removeAttribute("data-ilha-state");
   }
 
   // Mount the full layout island so mountSlots wires layout child slots (p:*)

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -169,25 +169,38 @@ export function wrapLayout(layout: LayoutHandler, page: Island<any, any>): Islan
     }
   }
 
-  // Layout shells are SSR chrome — interactivity (state, binds, nested child
-  // islands) lives on the page. Same forwarding pattern as wrapError.
+  const layoutMount = Wrapped.mount.bind(Wrapped);
+  const layoutInternal = (Wrapped as unknown as Record<symbol, unknown>)[ISLAND_MOUNT_INTERNAL] as
+    | ((
+        host: Element,
+        props?: Record<string, unknown>,
+      ) => {
+        unmount: () => void | Promise<void>;
+        updateProps: (p?: Record<string, unknown>) => void;
+      })
+    | undefined;
+
+  function prepareLayoutMountHost(host: Element): void {
+    preparePageMountHost(host, pageMountHost(host));
+  }
+
+  // Mount the full layout island so mountSlots wires layout child slots (p:*)
+  // and the keyed page slot (k:page). preparePageMountHost copies outer SSR
+  // state onto k:page and clears _skipOnMount so the page onMount still runs.
   Wrapped.mount = (host: Element, props?: Record<string, unknown>) => {
-    const mountHost = pageMountHost(host);
-    preparePageMountHost(host, mountHost);
-    return page.mount(mountHost, props as never);
+    prepareLayoutMountHost(host);
+    return layoutMount(host, props as never);
   };
 
   (Wrapped as unknown as Record<symbol, unknown>)[ISLAND_MOUNT_INTERNAL] = (
     host: Element,
     props?: Record<string, unknown>,
   ) => {
-    const mountHost = pageMountHost(host);
-    preparePageMountHost(host, mountHost);
-    const pageInternal = (page as unknown as Record<symbol, unknown>)[ISLAND_MOUNT_INTERNAL];
-    if (typeof pageInternal === "function") {
-      return pageInternal(mountHost, props);
+    prepareLayoutMountHost(host);
+    if (typeof layoutInternal === "function") {
+      return layoutInternal(host, props);
     }
-    return { unmount: page.mount(mountHost, props as never), updateProps: () => {} };
+    return { unmount: layoutMount(host, props as never), updateProps: () => {} };
   };
 
   Wrapped.hydratable = async (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed layout hydration so interactive components in layout slots remain mounted and interactive alongside page content.

* **Documentation**
  * Clarified client hydration behavior: the full layout island mounts using existing server-rendered DOM during client init.

* **Tests**
  * Added tests covering interactive layout and page hydration and on-mount behavior.

* **Chores**
  * Package version bumped to 0.3.8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->