### PR TITLE
Fix CSS asset links in Nitro template

### DIFF
--- a/templates/nitro/src/entry-server.ts
+++ b/templates/nitro/src/entry-server.ts
@@ -13,7 +13,7 @@ async function handler(request: Request): Promise<Response> {
 
   const assets = clientAssets.merge(serverAssets);
   const entryPath = assets.entry ?? "/entry-client.js";
-  const styles = assets.css.map((asset) => stylesheetTag(asset)).join("\n  ");
+  const styles = (assets.css ?? []).map((asset) => stylesheetTag(asset)).join("\n  ");
 
   return new Response(htmlTemplate(body, entryPath, styles), {
     headers: { "content-type": "text/html;charset=utf-8" },

--- a/templates/nitro/src/entry-server.ts
+++ b/templates/nitro/src/entry-server.ts
@@ -3,6 +3,7 @@ import { pageRouter } from "ilha:pages";
 import { registry } from "ilha:registry";
 
 import clientAssets from "./entry-client.ts?assets=client";
+import serverAssets from "./entry-server.ts?assets=ssr";
 
 async function handler(request: Request): Promise<Response> {
   const url = new URL(request.url);
@@ -10,13 +11,22 @@ async function handler(request: Request): Promise<Response> {
 
   const body = await pageRouter.renderHydratable(href, registry);
 
-  const entryPath = clientAssets.entry ?? "/entry-client.js";
-  return new Response(htmlTemplate(body, entryPath), {
+  const assets = clientAssets.merge(serverAssets);
+  const entryPath = assets.entry ?? "/entry-client.js";
+  const styles = assets.css.map((asset) => stylesheetTag(asset)).join("\n  ");
+
+  return new Response(htmlTemplate(body, entryPath, styles), {
     headers: { "content-type": "text/html;charset=utf-8" },
   });
 }
 
-function htmlTemplate(body: string, clientEntry: string): string {
+function stylesheetTag(attrs: { href: string; "data-vite-dev-id"?: string }): string {
+  const devId = attrs["data-vite-dev-id"] ? ` data-vite-dev-id="${attrs["data-vite-dev-id"]}"` : "";
+
+  return `<link rel="stylesheet" href="${attrs.href}"${devId} />`;
+}
+
+function htmlTemplate(body: string, clientEntry: string, styles: string): string {
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -24,6 +34,7 @@ function htmlTemplate(body: string, clientEntry: string): string {
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ilha + Nitro</title>
   <link rel="icon" href="/favicon.svg" />
+  ${styles}
 </head>
 <body>
   <div id="app">${body}</div>


### PR DESCRIPTION
## Summary
- merge client and SSR asset manifests in the Nitro template server entry
- render generated CSS assets as stylesheet links in the document head
- keep the client entry script fallback behavior unchanged

## Why
The Nitro template imports app.css, but the generated HTML only includes the client script. Since CSS assets are not linked in the head, SSR pages can flash unstyled content before the client entry loads styles.

This follows Nitro's documented Vite SSR pattern of using ?assets manifests and rendering assets.css in the head.

## Validation
- bunx oxfmt --check templates/nitro/src/entry-server.ts
- bunx oxlint templates/nitro/src/entry-server.ts

Note: full template dependency install hung in my local environment, so I kept validation focused to the changed file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Server-rendered pages now include merged CSS stylesheet links in the HTML head, ensuring initial styles load correctly.
  * SSR asset handling improved so the correct client entry is referenced in responses while preserving HTML content-type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->