### PR TITLE
fix(router): follow FS loader redirects in SPA mode

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/geist-mono": "^5.2.7",
-    "@ilha/router": "0.4.1",
+    "@ilha/router": "0.4.3",
     "@rspress/core": "^2.0.11",
     "@rspress/plugin-llms": "^2.0.11",
     "@rspress/plugin-sitemap": "^2.0.11",

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
       "devDependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource-variable/geist-mono": "^5.2.7",
-        "@ilha/router": "0.4.1",
+        "@ilha/router": "0.4.3",
         "@rspress/core": "^2.0.11",
         "@rspress/plugin-llms": "^2.0.11",
         "@rspress/plugin-sitemap": "^2.0.11",
@@ -56,7 +56,7 @@
     },
     "packages/router": {
       "name": "@ilha/router",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "ilha": "0.7.0",
         "rou3": "0.8.1",
@@ -1050,8 +1050,6 @@
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "vite/rolldown": ["rolldown@1.0.2", "", { "dependencies": { "@oxc-project/types": "=0.132.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.2", "@rolldown/binding-darwin-arm64": "1.0.2", "@rolldown/binding-darwin-x64": "1.0.2", "@rolldown/binding-freebsd-x64": "1.0.2", "@rolldown/binding-linux-arm-gnueabihf": "1.0.2", "@rolldown/binding-linux-arm64-gnu": "1.0.2", "@rolldown/binding-linux-arm64-musl": "1.0.2", "@rolldown/binding-linux-ppc64-gnu": "1.0.2", "@rolldown/binding-linux-s390x-gnu": "1.0.2", "@rolldown/binding-linux-x64-gnu": "1.0.2", "@rolldown/binding-linux-x64-musl": "1.0.2", "@rolldown/binding-openharmony-arm64": "1.0.2", "@rolldown/binding-wasm32-wasi": "1.0.2", "@rolldown/binding-win32-arm64-msvc": "1.0.2", "@rolldown/binding-win32-x64-msvc": "1.0.2" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g=="],
-
-    "website/@ilha/router": ["@ilha/router@0.4.1", "", { "dependencies": { "ilha": "0.7.0", "rou3": "0.8.1", "unplugin": "3.0.0" } }, "sha512-VA4JnxT20pYWmdsoBhjHQPCIFYPUIJCSbcxXaqmgX2gBYu8BUYnV1l2VCTrQI5cfw+7G43S2lezQL4UlAlMmMQ=="],
 
     "@tailwindcss/postcss/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/router",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A tiny SPA router for Ilha",
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",

--- a/packages/router/src/codegen.test.ts
+++ b/packages/router/src/codegen.test.ts
@@ -777,13 +777,14 @@ describe("codegen — loader detection", () => {
     expect(errorImport!).toContain("?client");
   });
 
-  it("routes.ts does not reference loaders", async () => {
+  it("routes.ts marks routes that have loaders without importing loader code", async () => {
     await writePage(
       pagesDir,
       "index.ts",
       `export const load = async () => ({}); export default null;`,
     );
     const { routes } = await runCodegen();
+    expect(routes).toContain(`.route("/", _wrapped0).markLoader("/")`);
     expect(routes).not.toContain("attachLoader");
     expect(routes).not.toContain("composeLoaders");
     expect(routes).not.toContain("import { load");

--- a/packages/router/src/codegen.test.ts
+++ b/packages/router/src/codegen.test.ts
@@ -788,6 +788,18 @@ describe("codegen — loader detection", () => {
     expect(routes).not.toContain("attachLoader");
     expect(routes).not.toContain("composeLoaders");
     expect(routes).not.toContain("import { load");
+
+    await writePage(pagesDir, "index.ts", `export default null;`);
+    await writePage(
+      pagesDir,
+      "+layout.ts",
+      `export const load = async () => ({}); export default null;`,
+    );
+    const layoutOnly = await runCodegen();
+    expect(layoutOnly.routes).toContain(`.markLoader("/")`);
+    expect(layoutOnly.routes).not.toContain("attachLoader");
+    expect(layoutOnly.routes).not.toContain("composeLoaders");
+    expect(layoutOnly.routes).not.toContain("import { load");
   });
 
   // ── loaders.ts — written only when needed ──────────────────────────────

--- a/packages/router/src/codegen.ts
+++ b/packages/router/src/codegen.ts
@@ -327,7 +327,12 @@ export async function generate(
     registryLines.push(
       `  ${JSON.stringify(entry.name)}: ${wrappedId}` + (i < entries.length - 1 ? "," : ""),
     );
-    routeLines.push(`  .route(${JSON.stringify(entry.pattern)}, ${wrappedId})`);
+    routeLines.push(
+      `  .route(${JSON.stringify(entry.pattern)}, ${wrappedId})` +
+        (entry.hasLoader || entry.loaderLayouts.length > 0
+          ? `.markLoader(${JSON.stringify(entry.pattern)})`
+          : ""),
+    );
   }
 
   const code = [

--- a/packages/router/src/index.test.ts
+++ b/packages/router/src/index.test.ts
@@ -522,12 +522,10 @@ describe("router() isolation", () => {
   });
 
   it("SPA mode follows redirects returned by a marked FS loader", async () => {
-    const fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => {
-      return new Response(JSON.stringify({ kind: "redirect", to: "/login", status: 302 }), {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      });
-    });
+    const fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => ({
+      ok: true,
+      json: async () => ({ kind: "redirect", to: "/login", status: 302 }),
+    }));
 
     setLocation("/protected");
     const el = makeEl();
@@ -537,16 +535,20 @@ describe("router() isolation", () => {
       .route("/login", HomePage)
       .mount(el);
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    try {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
-    expect(routePath()).toBe("/login");
-    expect(el.innerHTML).toContain("home");
-
-    unmount();
-    cleanup(el);
-    fetchSpy.mockRestore();
-    setLocation("/");
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(routePath()).toBe("/login");
+      expect(el.innerHTML).toContain("home");
+    } finally {
+      unmount();
+      cleanup(el);
+      fetchSpy.mockRestore();
+      setLocation("/");
+    }
   });
 });
 

--- a/packages/router/src/index.test.ts
+++ b/packages/router/src/index.test.ts
@@ -520,6 +520,34 @@ describe("router() isolation", () => {
     cleanup(el);
     setLocation("/");
   });
+
+  it("SPA mode follows redirects returned by a marked FS loader", async () => {
+    const fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => {
+      return new Response(JSON.stringify({ kind: "redirect", to: "/login", status: 302 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    setLocation("/protected");
+    const el = makeEl();
+    const unmount = router()
+      .route("/protected", UserPage)
+      .markLoader("/protected")
+      .route("/login", HomePage)
+      .mount(el);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(routePath()).toBe("/login");
+    expect(el.innerHTML).toContain("home");
+
+    unmount();
+    cleanup(el);
+    fetchSpy.mockRestore();
+    setLocation("/");
+  });
 });
 
 // ─────────────────────────────────────────────

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -889,8 +889,9 @@ export function router(options: RouterOptions = {}): RouterBuilder {
 
   const builder: RouterBuilder = {
     route(pattern: string, island: Island<any, any>, loader?: Loader<any>): RouterBuilder {
-      const data: RouteData = { island, loader, hasLoader: !!loader };
-      _records.push({ pattern, island, loader });
+      const hasLoader = !!loader;
+      const data: RouteData = { island, loader, hasLoader };
+      _records.push({ pattern, island, loader, hasLoader });
       addRoute(_rou3, "GET", pattern, data);
       _patternToData.set(pattern, data);
       // First pattern registered for an island wins (most specific due to sort order)

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -23,6 +23,8 @@ export interface RouteRecord {
   island: Island<any, any>;
   /** Merged loader chain (layouts outer→inner, then page) — `undefined` if no loaders. */
   loader?: Loader<any>;
+  /** True when the route has a server-side loader, even if the client only has a marker. */
+  hasLoader?: boolean;
 }
 
 export interface RouteSnapshot {
@@ -355,6 +357,12 @@ export interface RouterBuilder {
    */
   attachLoader(pattern: string, loader: Loader<any>): RouterBuilder;
   /**
+   * Mark an already-registered route as having a server-side loader without
+   * importing that loader into the client bundle. Used by FS-routing codegen
+   * so SPA navigation knows to call the loader endpoint.
+   */
+  markLoader(pattern: string): RouterBuilder;
+  /**
    * Return a snapshot of every registered route in match order. Useful for
    * prerenderers that need to discover the filesystem routes exposed by
    * `pageRouter` without reaching into router internals.
@@ -482,7 +490,7 @@ export function prefetch(pathWithSearch: string): void {
   // Don't prefetch routes that have no loader — nothing to fetch.
   const pathOnly = pathWithSearch.split("?")[0] ?? "";
   const match = findRoute(_rou3, "GET", pathOnly);
-  if (!match?.data?.loader) return;
+  if (!match?.data?.hasLoader) return;
   const promise = fetchLoaderData(pathWithSearch).catch((e) => {
     return { kind: "error", status: 0, message: e?.message ?? "prefetch failed" } as const;
   });
@@ -515,7 +523,7 @@ async function mountRouteWithHydration(
   // Routes registered client-side have `loader: undefined` when the Vite
   // plugin emits server-only loader imports behind `import.meta.env.SSR`.
   const clientMatch = findRoute(_rou3, "GET", pathWithSearch.split("?")[0] ?? "");
-  const hasLoader = !!clientMatch?.data?.loader;
+  const hasLoader = !!clientMatch?.data?.hasLoader;
 
   let props: Record<string, unknown> = {};
   const loaderResult: LoaderFetchResult = hasLoader
@@ -600,6 +608,7 @@ const activeIsland = context<Island<any, any> | null>("router.active", null);
 interface RouteData {
   island: Island<any, any>;
   loader?: Loader<any>;
+  hasLoader?: boolean;
 }
 
 let _records: RouteRecord[] = [];
@@ -880,7 +889,7 @@ export function router(options: RouterOptions = {}): RouterBuilder {
 
   const builder: RouterBuilder = {
     route(pattern: string, island: Island<any, any>, loader?: Loader<any>): RouterBuilder {
-      const data: RouteData = { island, loader };
+      const data: RouteData = { island, loader, hasLoader: !!loader };
       _records.push({ pattern, island, loader });
       addRoute(_rou3, "GET", pattern, data);
       _patternToData.set(pattern, data);
@@ -901,9 +910,28 @@ export function router(options: RouterOptions = {}): RouterBuilder {
         return builder;
       }
       data.loader = loader;
+      data.hasLoader = true;
       // Keep _records in sync for consumers that read it directly
       const rec = _records.find((r) => r.pattern === pattern);
-      if (rec) rec.loader = loader;
+      if (rec) {
+        rec.loader = loader;
+        rec.hasLoader = true;
+      }
+      return builder;
+    },
+
+    markLoader(pattern: string): RouterBuilder {
+      const data = _patternToData.get(pattern);
+      if (!data) {
+        console.warn(
+          `[ilha-router] markLoader("${pattern}"): pattern was never registered via .route(). ` +
+            `The loader marker will be ignored.`,
+        );
+        return builder;
+      }
+      data.hasLoader = true;
+      const rec = _records.find((r) => r.pattern === pattern);
+      if (rec) rec.hasLoader = true;
       return builder;
     },
 
@@ -1041,7 +1069,7 @@ export function router(options: RouterOptions = {}): RouterBuilder {
         const adapter = getAdapter();
         const loc = adapter.readLocation();
         const clientMatch = findRoute(_rou3, "GET", loc.pathname);
-        const hasLoader = !!clientMatch?.data?.loader;
+        const hasLoader = !!clientMatch?.data?.hasLoader;
         const result: LoaderFetchResult = hasLoader
           ? await fetchLoaderData(loc.pathname + loc.search, signal)
           : { kind: "data", data: {} };

--- a/templates/elysia/package.json
+++ b/templates/elysia/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@elysiajs/html": "^1.4.2",
     "@elysiajs/static": "^1.4.10",
-    "@ilha/router": "^0.4.2",
+    "@ilha/router": "^0.4.3",
     "areia": "^0.1.6",
     "elysia": "^1.4.28",
     "ilha": "^0.7.0",

--- a/templates/hono/package.json
+++ b/templates/hono/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.2",
-    "@ilha/router": "^0.4.2",
+    "@ilha/router": "^0.4.3",
     "areia": "^0.1.6",
     "hono": "^4.12.18",
     "ilha": "^0.7.0",

--- a/templates/nitro/package.json
+++ b/templates/nitro/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.4.2",
+    "@ilha/router": "^0.4.3",
     "areia": "^0.1.6",
     "ilha": "^0.7.0",
     "nitro": "^3.0.260522-beta",

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.4.2",
+    "@ilha/router": "^0.4.3",
     "areia": "^0.1.6",
     "ilha": "^0.7.0",
     "quando": "^0.1.6"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New API to mark routes as having server-side loaders without bundling loader code into the client.
  * Automatic detection of loaders from page and layout files to mark routes accordingly.

* **Bug Fixes**
  * Improved SPA behavior for loader-driven redirects and fetch gating during navigation/hydration.

* **Chores**
  * Updated router dependency to v0.4.3 across site and templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->