### PR TITLE
fix(jsx): improve interpolation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
       "devDependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource-variable/geist-mono": "^5.2.7",
-        "@ilha/router": "0.4.3",
+        "@ilha/router": "0.5.0",
         "@rspress/core": "^2.0.11",
         "@rspress/plugin-llms": "^2.0.11",
         "@rspress/plugin-sitemap": "^2.0.11",
@@ -46,7 +46,7 @@
     },
     "packages/ilha": {
       "name": "ilha",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "alien-signals": "3.2.1",
       },
@@ -56,9 +56,9 @@
     },
     "packages/router": {
       "name": "@ilha/router",
-      "version": "0.4.3",
+      "version": "0.5.1",
       "dependencies": {
-        "ilha": "0.7.0",
+        "ilha": "0.7.1",
         "rou3": "0.8.1",
         "unplugin": "3.0.0",
       },
@@ -68,7 +68,7 @@
     },
     "packages/store": {
       "name": "@ilha/store",
-      "version": "0.3.7",
+      "version": "0.3.8",
       "dependencies": {
         "alien-signals": "3.2.1",
         "ilha": "0.5.0",
@@ -81,7 +81,7 @@
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
-    "@areia/slots": ["@areia/slots@0.1.3", "", {}, "sha512-8bMYEwoFt1vIKMDCVtBBkKaH+7DU+zdU1kyP0NlS0neaA0FaxFjz2aE1lIbh40Wc4DomYyznyWD6kN4yHOndYg=="],
+    "@areia/slots": ["@areia/slots@0.1.4", "", {}, "sha512-1CJDsSMd7Liu498GYX+bEiYU1+8XquVGfapq3vOC4ecg3c0HtcXt7GJ40Y5vrSJenr5oTaRtIZzJ/RwpLEGOew=="],
 
     "@babel/generator": ["@babel/generator@8.0.0-rc.3", "", { "dependencies": { "@babel/parser": "^8.0.0-rc.3", "@babel/types": "^8.0.0-rc.3", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-em37/13/nR320G4jab/nIIHZgc2Wz2y/D39lxnTyxB4/D/omPQncl/lSdlnJY1OhQcRGugTSIF2l/69o31C9dA=="],
 
@@ -435,7 +435,7 @@
 
     "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
 
-    "areia": ["areia@0.1.6", "", { "dependencies": { "@areia/slots": "0.1.3", "clsx": "2.1.1", "date-fns": "4.2.1", "tailwind-merge": "3.6.0" }, "peerDependencies": { "ilha": "^0.7.0", "sonner": "^2.0.7", "tailwindcss": ">=4.0.0" }, "optionalPeers": ["tailwindcss"] }, "sha512-HG4PG6q3Mi/HwaJSDAtSM6Wkdfq/j8zIvQXzu7m/tZ7yEZ/sgI3evOigsWIkuKdMPF6hsrbte0Dx9+HyzJ11/Q=="],
+    "areia": ["areia@0.1.16", "", { "dependencies": { "@areia/slots": "0.1.4", "clsx": "2.1.1", "date-fns": "4.2.1", "tailwind-merge": "3.6.0" }, "peerDependencies": { "ilha": "^0.7.0", "sonner": "^2.0.7", "tailwindcss": ">=4.0.0" }, "optionalPeers": ["tailwindcss"] }, "sha512-Jq+sIfVcF4SjTjYv2UQ4xkXdVb20AdIIoe42VJD2h4YEtCHf23GUbbYLhtmCQCMswsLcllxltEuz0Ub1S7MFPw=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -1050,6 +1050,10 @@
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "vite/rolldown": ["rolldown@1.0.2", "", { "dependencies": { "@oxc-project/types": "=0.132.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.2", "@rolldown/binding-darwin-arm64": "1.0.2", "@rolldown/binding-darwin-x64": "1.0.2", "@rolldown/binding-freebsd-x64": "1.0.2", "@rolldown/binding-linux-arm-gnueabihf": "1.0.2", "@rolldown/binding-linux-arm64-gnu": "1.0.2", "@rolldown/binding-linux-arm64-musl": "1.0.2", "@rolldown/binding-linux-ppc64-gnu": "1.0.2", "@rolldown/binding-linux-s390x-gnu": "1.0.2", "@rolldown/binding-linux-x64-gnu": "1.0.2", "@rolldown/binding-linux-x64-musl": "1.0.2", "@rolldown/binding-openharmony-arm64": "1.0.2", "@rolldown/binding-wasm32-wasi": "1.0.2", "@rolldown/binding-win32-arm64-msvc": "1.0.2", "@rolldown/binding-win32-x64-msvc": "1.0.2" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g=="],
+
+    "website/@ilha/router": ["@ilha/router@0.5.0", "", { "dependencies": { "ilha": "0.7.0", "rou3": "0.8.1", "unplugin": "3.0.0" } }, "sha512-988ct3A/uaR9SJuZSK/wcQpLFuyp+jWmaeC7d/lnM9SIu2SBy4L36ajSW5BbrSkigGDwNNN/jCkRPo3ZdG5n7A=="],
+
+    "website/ilha": ["ilha@0.7.0", "", { "dependencies": { "alien-signals": "3.2.1" } }, "sha512-ospMnQ9Faw66dVyTE1kNkcmvBilNbEzp7ppmR10xs1AuYAoyw8eHmupUkYOHQKo2Fg38FeHdf/KyNRG+yu6MMQ=="],
 
     "@tailwindcss/postcss/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 

--- a/packages/ilha/package.json
+++ b/packages/ilha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ilha",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A tiny, framework-free island architecture library",
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",

--- a/packages/ilha/src/index.ts
+++ b/packages/ilha/src/index.ts
@@ -870,6 +870,18 @@ function ilhaJsx(
       return ilhaRaw(emitIslandSlot(type as AnyIsland, componentProps, slotKey));
     }
     if (typeof out === "string") return ilhaHtml`${out}`;
+    // Plain object with a custom toString (e.g. Areia compound-component parts
+    // like ResizablePanel that return { __areiaResizablePart, toString() { ... } }).
+    // Treat the toString() result as raw HTML — the object is a renderable part
+    // intended for parent consumption, not an opaque value to be escaped.
+    if (
+      typeof out === "object" &&
+      out !== null &&
+      Object.getPrototypeOf(out) === Object.prototype &&
+      Object.prototype.hasOwnProperty.call(out, "toString")
+    ) {
+      return ilhaRaw((out as object).toString());
+    }
     return ilhaHtml`${out}`;
   }
 

--- a/packages/ilha/src/index.ts
+++ b/packages/ilha/src/index.ts
@@ -870,15 +870,15 @@ function ilhaJsx(
       return ilhaRaw(emitIslandSlot(type as AnyIsland, componentProps, slotKey));
     }
     if (typeof out === "string") return ilhaHtml`${out}`;
-    // Plain object with a custom toString (e.g. Areia compound-component parts
-    // like ResizablePanel that return { __areiaResizablePart, toString() { ... } }).
-    // Treat the toString() result as raw HTML — the object is a renderable part
-    // intended for parent consumption, not an opaque value to be escaped.
+    // Plain object explicitly marked as a renderable part (e.g. Areia compound-component
+    // parts like ResizablePanel). The marker Symbol.for("ilha.renderPart") must be set
+    // on the object, and toString must be a callable that produces safe HTML.
     if (
       typeof out === "object" &&
       out !== null &&
       Object.getPrototypeOf(out) === Object.prototype &&
-      Object.prototype.hasOwnProperty.call(out, "toString")
+      (out as Record<symbol, unknown>)[Symbol.for("ilha.renderPart")] === true &&
+      typeof (out as any).toString === "function"
     ) {
       return ilhaRaw((out as object).toString());
     }

--- a/packages/ilha/src/jsx-runtime.test.tsx
+++ b/packages/ilha/src/jsx-runtime.test.tsx
@@ -1071,12 +1071,13 @@ describe("ilha JSX runtime", () => {
 
 describe("ilha JSX runtime — compound component children", () => {
   it("plain object children with custom toString are rendered as raw HTML inside parent", () => {
+    const RENDER_PART = Symbol.for("ilha.renderPart");
     function Root(props: { children?: any }) {
       const kids: any[] = Array.isArray(props.children) ? props.children : [props.children];
       return html`<root>${kids}</root>`;
     }
     Root.Part = function Part(props: { label: string }) {
-      const part: any = { __part: true };
+      const part: any = { [RENDER_PART]: true };
       Object.defineProperty(part, "toString", {
         value: () => `<part>${props.label}</part>`,
         enumerable: false,
@@ -1094,13 +1095,13 @@ describe("ilha JSX runtime — compound component children", () => {
   });
 
   it("plain object children do not appear as escaped [object Object]", () => {
-    function Wrapper(_props: { children?: any }) {
-      return html`
-        <wrap></wrap>
-      `;
+    const RENDER_PART = Symbol.for("ilha.renderPart");
+    function Wrapper(props: { children?: any }) {
+      const kids: any[] = Array.isArray(props.children) ? props.children : [props.children];
+      return html`<wrap>${kids}</wrap>`;
     }
     (Wrapper as any).Slot = function Slot(_props: {}) {
-      const part: any = {};
+      const part: any = { [RENDER_PART]: true };
       Object.defineProperty(part, "toString", {
         value: () => "<slot/>",
         enumerable: false,
@@ -1114,13 +1115,14 @@ describe("ilha JSX runtime — compound component children", () => {
       </W>
     );
     expect(result.value).not.toContain("[object Object]");
-    expect(result.value).toBe("<wrap></wrap>");
+    expect(result.value).toBe("<wrap><slot/></wrap>");
   });
 
   it("Areia-like Resizable: panels and handle rendered inside root, not as siblings", () => {
     const PART = "__resizablePart";
+    const RENDER_PART = Symbol.for("ilha.renderPart");
     function createPart(type: string, input: any) {
-      const part: any = { [PART]: type, input };
+      const part: any = { [PART]: type, input, [RENDER_PART]: true };
       Object.defineProperty(part, "toString", {
         value: () => {
           const r = renderPart(part);

--- a/packages/ilha/src/jsx-runtime.test.tsx
+++ b/packages/ilha/src/jsx-runtime.test.tsx
@@ -1068,3 +1068,111 @@ describe("ilha JSX runtime", () => {
     }
   });
 });
+
+describe("ilha JSX runtime — compound component children", () => {
+  it("plain object children with custom toString are rendered as raw HTML inside parent", () => {
+    function Root(props: { children?: any }) {
+      const kids: any[] = Array.isArray(props.children) ? props.children : [props.children];
+      return html`<root>${kids}</root>`;
+    }
+    Root.Part = function Part(props: { label: string }) {
+      const part: any = { __part: true };
+      Object.defineProperty(part, "toString", {
+        value: () => `<part>${props.label}</part>`,
+        enumerable: false,
+      });
+      return part;
+    };
+
+    const result = (
+      <Root>
+        <Root.Part label="A" />
+        <Root.Part label="B" />
+      </Root>
+    );
+    expect(result.value).toBe("<root><part>A</part><part>B</part></root>");
+  });
+
+  it("plain object children do not appear as escaped [object Object]", () => {
+    function Wrapper(_props: { children?: any }) {
+      return html`
+        <wrap></wrap>
+      `;
+    }
+    (Wrapper as any).Slot = function Slot(_props: {}) {
+      const part: any = {};
+      Object.defineProperty(part, "toString", {
+        value: () => "<slot/>",
+        enumerable: false,
+      });
+      return part;
+    };
+    const W = Wrapper as any;
+    const result = (
+      <W>
+        <W.Slot />
+      </W>
+    );
+    expect(result.value).not.toContain("[object Object]");
+    expect(result.value).toBe("<wrap></wrap>");
+  });
+
+  it("Areia-like Resizable: panels and handle rendered inside root, not as siblings", () => {
+    const PART = "__resizablePart";
+    function createPart(type: string, input: any) {
+      const part: any = { [PART]: type, input };
+      Object.defineProperty(part, "toString", {
+        value: () => {
+          const r = renderPart(part);
+          return typeof r === "object" && r !== null && "value" in r ? (r as any).value : String(r);
+        },
+        enumerable: false,
+      });
+      return part;
+    }
+    function renderPart(part: any) {
+      if (part[PART] === "panel")
+        return html`<div data-slot="resizable-panel">${part.input.children ?? ""}</div>`;
+      return html`
+        <div data-slot="resizable-handle"></div>
+      `;
+    }
+    function renderChildren(v: any): any {
+      if (v == null) return "";
+      if (Array.isArray(v)) return v.map(renderChildren);
+      if (typeof v === "object" && PART in v) return renderPart(v);
+      if (typeof v === "object" && "value" in v && typeof v.value === "string") return raw(v.value);
+      return v;
+    }
+    function ResizablePanel(input: any) {
+      return createPart("panel", input);
+    }
+    function ResizableHandle(input: any) {
+      return createPart("handle", input);
+    }
+    function Resizable(input: any) {
+      const kids = Array.isArray(input.children) ? input.children : [input.children];
+      return html`<div data-slot="resizable">${renderChildren(kids)}</div>`;
+    }
+    (Resizable as any).Panel = ResizablePanel;
+    (Resizable as any).Handle = ResizableHandle;
+    const R = Resizable as any;
+
+    const result = (
+      <R>
+        <R.Panel>content A</R.Panel>
+        <R.Handle />
+        <R.Panel>content B</R.Panel>
+      </R>
+    );
+
+    expect(result.value).toContain('data-slot="resizable"');
+    expect(result.value).toContain('data-slot="resizable-panel"');
+    expect(result.value).toContain('data-slot="resizable-handle"');
+    expect(result.value).not.toContain("[object Object]");
+    // panels must be inside the root, not siblings
+    const rootIdx = result.value.indexOf('data-slot="resizable"');
+    const panelIdx = result.value.indexOf('data-slot="resizable-panel"');
+    expect(panelIdx).toBeGreaterThan(rootIdx);
+  });
+});

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/router",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A tiny SPA router for Ilha",
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",
@@ -38,7 +38,7 @@
     "test": "bun test"
   },
   "dependencies": {
-    "ilha": "0.7.0",
+    "ilha": "0.7.1",
     "rou3": "0.8.1",
     "unplugin": "3.0.0"
   },

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/store",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Typed store.",
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "alien-signals": "3.2.1",
-    "ilha": "0.7.0"
+    "ilha": "0.7.1"
   },
   "devDependencies": {
     "zod": "^4.4.3"

--- a/templates/elysia/package.json
+++ b/templates/elysia/package.json
@@ -11,10 +11,10 @@
   "dependencies": {
     "@elysiajs/html": "^1.4.2",
     "@elysiajs/static": "^1.4.10",
-    "@ilha/router": "^0.5.0",
+    "@ilha/router": "^0.5.1",
     "areia": "^0.1.15",
     "elysia": "^1.4.28",
-    "ilha": "^0.7.0",
+    "ilha": "^0.7.1",
     "quando": "^0.1.6"
   },
   "devDependencies": {

--- a/templates/hono/package.json
+++ b/templates/hono/package.json
@@ -8,10 +8,10 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.2",
-    "@ilha/router": "^0.5.0",
+    "@ilha/router": "^0.5.1",
     "areia": "^0.1.15",
     "hono": "^4.12.18",
-    "ilha": "^0.7.0",
+    "ilha": "^0.7.1",
     "quando": "^0.1.6"
   },
   "devDependencies": {

--- a/templates/nitro/package.json
+++ b/templates/nitro/package.json
@@ -9,9 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.5.0",
+    "@ilha/router": "^0.5.1",
     "areia": "^0.1.15",
-    "ilha": "^0.7.0",
+    "ilha": "^0.7.1",
     "nitro": "^3.0.260522-beta",
     "quando": "^0.1.6"
   },

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -9,9 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.5.0",
+    "@ilha/router": "^0.5.1",
     "areia": "^0.1.15",
-    "ilha": "^0.7.0",
+    "ilha": "^0.7.1",
     "quando": "^0.1.6"
   },
   "devDependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Components returning plain objects with custom toString now render as unescaped HTML.

* **Tests**
  * Added test coverage for compound component children using custom serialization.

* **Chores**
  * Bumped package versions: ilha → 0.7.1, `@ilha/router` → 0.5.1, store → 0.3.8; updated templates and dependency references accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->