### PR TITLE
chore(router): introduce a clean split between client and server modes

### DIFF
--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -53,9 +53,9 @@ export default defineEventHandler((event) => {
 ### SSR + Client Hydration (recommended)
 
 ```ts
-// routes/[...].ts — Nitro handler
-import { pageRouter } from "ilha:pages";
-import { registry } from "ilha:registry";
+// routes/[...].ts — Nitro handler (SSR/prerender)
+import { pageRouter, registry } from "ilha:pages/server";
+import "ilha:loaders"; // ← wire server-only loaders
 
 export default defineEventHandler(async (event) => {
   const html = await pageRouter.renderHydratable(event.node.req.url ?? "/", registry);
@@ -67,8 +67,7 @@ export default defineEventHandler(async (event) => {
 
 ```ts
 // src/client.ts — browser entry
-import { pageRouter } from "ilha:pages";
-import { registry } from "ilha:registry";
+import { pageRouter, registry } from "ilha:pages/client";
 
 pageRouter.hydrate(registry);
 ```
@@ -916,18 +915,19 @@ export default ((error, route) =>
 
 ### Virtual modules
 
-The plugin exposes three virtual modules:
+The plugin exposes separate server and client virtual modules. **Always use the explicit `/server` or `/client` path** — they resolve to different generated files with different import strategies.
 
-| Module          | Export       | Description                                  |
-| --------------- | ------------ | -------------------------------------------- |
-| `ilha:pages`    | `pageRouter` | A `RouterBuilder` with all routes registered |
-| `ilha:registry` | `registry`   | `Record<string, Island>` for hydration       |
-| `ilha:loaders`  | —            | Side-effect import that wires server loaders |
+| Module              | Exports                  | Use for                                |
+| ------------------- | ------------------------ | -------------------------------------- |
+| `ilha:pages/server` | `pageRouter`, `registry` | SSR, prerender, Nitro handlers         |
+| `ilha:pages/client` | `pageRouter`, `registry` | Browser hydration entry                |
+| `ilha:loaders`      | —                        | Server-only side-effect: wires loaders |
+
+The server module imports page/layout/error modules **without** `?client` — raw imports so SSR sees full JSX including compound component render parts. The client module imports with `?client` which strips server-only `load` exports from the browser bundle.
 
 ```ts
-// routes/[...].ts — Nitro catch-all handler
-import { pageRouter } from "ilha:pages";
-import { registry } from "ilha:registry";
+// routes/[...].ts — SSR/prerender
+import { pageRouter, registry } from "ilha:pages/server";
 import "ilha:loaders"; // ← wire server loaders
 
 export default defineEventHandler(async (event) => {
@@ -940,10 +940,18 @@ export default defineEventHandler(async (event) => {
 
 ```ts
 // src/client.ts — browser entry
-import { pageRouter } from "ilha:pages";
-import { registry } from "ilha:registry";
+import { pageRouter, registry } from "ilha:pages/client";
 
 pageRouter.hydrate(registry);
+```
+
+For `static` MPA mode:
+
+```ts
+// src/entry-client.ts — static/SSG browser entry
+import { pageRouter, registry } from "ilha:pages/client";
+
+pageRouter.hydrateStatic(registry);
 ```
 
 ### Plugin options
@@ -951,7 +959,7 @@ pageRouter.hydrate(registry);
 ```ts
 pages({
   dir: "src/pages", // pages directory (default: "src/pages")
-  generated: ".ilha/routes.ts", // generated file output (default: ".ilha/routes.ts")
+  outDir: ".ilha", // output directory for generated files (default: ".ilha")
   mode: "spa", // "spa" | "static" (default: "spa")
   interceptLinks: true, // only meaningful in spa mode (default: true)
 });

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/router",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "A tiny SPA router for Ilha",
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",

--- a/packages/router/src/codegen.test.ts
+++ b/packages/router/src/codegen.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 
-import { generate } from "./codegen";
+import { generate, resolveGeneratedPaths } from "./codegen";
 import { makeDir, writePage, removeDir } from "./test-helpers";
 
 // ─────────────────────────────────────────────
@@ -11,13 +11,13 @@ import { makeDir, writePage, removeDir } from "./test-helpers";
 
 describe("codegen — generated file", () => {
   let pagesDir: string;
-  let outFile: string;
+  let outDir: string;
   let root: string;
 
   beforeEach(async () => {
     root = await makeDir("root");
     pagesDir = join(root, "src/pages");
-    outFile = join(root, "src/generated/Page-routes.ts");
+    outDir = join(root, "src/generated");
     await mkdir(pagesDir, { recursive: true });
   });
 
@@ -26,8 +26,8 @@ describe("codegen — generated file", () => {
   });
 
   async function runCodegen() {
-    await generate(pagesDir, outFile);
-    return readFile(outFile, "utf8");
+    await generate(pagesDir, outDir);
+    return readFile(resolveGeneratedPaths(outDir).serverFile, "utf8");
   }
 
   it("generates a file with the @generated header", async () => {
@@ -151,8 +151,8 @@ describe("codegen — generated file", () => {
 
   it("can generate a no-intercept SPA pageRouter", async () => {
     await writePage(pagesDir, "index.ts", `export default null;`);
-    await generate(pagesDir, outFile, { interceptLinks: false });
-    expect(await readFile(outFile, "utf8")).toContain(
+    await generate(pagesDir, outDir, { interceptLinks: false });
+    expect(await readFile(resolveGeneratedPaths(outDir).clientFile, "utf8")).toContain(
       `export const pageRouter = router({ interceptLinks: false })`,
     );
   });
@@ -291,13 +291,13 @@ describe("codegen — generated file", () => {
 
 describe("codegen — registry", () => {
   let pagesDir: string;
-  let outFile: string;
+  let outDir: string;
   let root: string;
 
   beforeEach(async () => {
     root = await makeDir("registry");
     pagesDir = join(root, "src/pages");
-    outFile = join(root, ".ilha/routes.ts");
+    outDir = join(root, ".ilha");
     await mkdir(pagesDir, { recursive: true });
   });
 
@@ -306,8 +306,8 @@ describe("codegen — registry", () => {
   });
 
   async function runCodegen() {
-    await generate(pagesDir, outFile);
-    return readFile(outFile, "utf8");
+    await generate(pagesDir, outDir);
+    return readFile(resolveGeneratedPaths(outDir).serverFile, "utf8");
   }
 
   it("generates export const registry", async () => {
@@ -402,14 +402,14 @@ describe("codegen — registry", () => {
 
 describe("codegen — registry name collision", () => {
   let pagesDir: string;
-  let outFile: string;
+  let outDir: string;
   let root: string;
   let warnings: string[];
 
   beforeEach(async () => {
     root = await makeDir("namecol");
     pagesDir = join(root, "src/pages");
-    outFile = join(root, ".ilha/routes.ts");
+    outDir = join(root, ".ilha");
     await mkdir(pagesDir, { recursive: true });
     warnings = [];
     console.warn = (...args: any[]) => warnings.push(args.join(" "));
@@ -420,8 +420,8 @@ describe("codegen — registry name collision", () => {
   });
 
   async function runCodegen() {
-    await generate(pagesDir, outFile);
-    return readFile(outFile, "utf8");
+    await generate(pagesDir, outDir);
+    return readFile(resolveGeneratedPaths(outDir).serverFile, "utf8");
   }
 
   it("warns on registry name collision", async () => {
@@ -459,13 +459,13 @@ describe("codegen — registry name collision", () => {
 
 describe("codegen — route sorting", () => {
   let pagesDir: string;
-  let outFile: string;
+  let outDir: string;
   let root: string;
 
   beforeEach(async () => {
     root = await makeDir("sort");
     pagesDir = join(root, "src/pages");
-    outFile = join(root, "src/generated/Page-routes.ts");
+    outDir = join(root, "src/generated");
     await mkdir(pagesDir, { recursive: true });
   });
 
@@ -474,8 +474,8 @@ describe("codegen — route sorting", () => {
   });
 
   async function runCodegen() {
-    await generate(pagesDir, outFile);
-    return readFile(outFile, "utf8");
+    await generate(pagesDir, outDir);
+    return readFile(resolveGeneratedPaths(outDir).serverFile, "utf8");
   }
 
   it("static routes appear before param routes", async () => {
@@ -541,14 +541,14 @@ describe("codegen — route sorting", () => {
 
 describe("codegen — duplicate pattern detection", () => {
   let pagesDir: string;
-  let outFile: string;
+  let outDir: string;
   let root: string;
   let warnings: string[];
 
   beforeEach(async () => {
     root = await makeDir("dup");
     pagesDir = join(root, "src/pages");
-    outFile = join(root, "src/generated/Page-routes.ts");
+    outDir = join(root, "src/generated");
     await mkdir(pagesDir, { recursive: true });
     warnings = [];
     console.warn = (...args: any[]) => warnings.push(args.join(" "));
@@ -559,8 +559,8 @@ describe("codegen — duplicate pattern detection", () => {
   });
 
   async function runCodegen() {
-    await generate(pagesDir, outFile);
-    return readFile(outFile, "utf8");
+    await generate(pagesDir, outDir);
+    return readFile(resolveGeneratedPaths(outDir).serverFile, "utf8");
   }
 
   it("warns when two files produce the same pattern", async () => {
@@ -599,14 +599,14 @@ describe("codegen — duplicate pattern detection", () => {
 
 describe("codegen — empty pages dir warning", () => {
   let pagesDir: string;
-  let outFile: string;
+  let outDir: string;
   let root: string;
   let warnings: string[];
 
   beforeEach(async () => {
     root = await makeDir("empty");
     pagesDir = join(root, "src/pages");
-    outFile = join(root, "src/generated/Page-routes.ts");
+    outDir = join(root, "src/generated");
     await mkdir(pagesDir, { recursive: true });
     warnings = [];
     console.warn = (...args: any[]) => warnings.push(args.join(" "));
@@ -617,8 +617,8 @@ describe("codegen — empty pages dir warning", () => {
   });
 
   async function runCodegen() {
-    await generate(pagesDir, outFile);
-    return readFile(outFile, "utf8");
+    await generate(pagesDir, outDir);
+    return readFile(resolveGeneratedPaths(outDir).serverFile, "utf8");
   }
 
   it("warns when pages dir is empty", async () => {
@@ -651,13 +651,13 @@ describe("codegen — empty pages dir warning", () => {
 
 describe("codegen — relative imports", () => {
   let pagesDir: string;
-  let outFile: string;
+  let outDir: string;
   let root: string;
 
   beforeEach(async () => {
     root = await makeDir("rel");
     pagesDir = join(root, "src/pages");
-    outFile = join(root, ".ilha/routes.ts");
+    outDir = join(root, ".ilha");
     await mkdir(pagesDir, { recursive: true });
   });
 
@@ -666,8 +666,8 @@ describe("codegen — relative imports", () => {
   });
 
   async function runCodegen() {
-    await generate(pagesDir, outFile);
-    return readFile(outFile, "utf8");
+    await generate(pagesDir, outDir);
+    return readFile(resolveGeneratedPaths(outDir).serverFile, "utf8");
   }
 
   it("Page imports start with . or ..", async () => {
@@ -719,14 +719,14 @@ describe("codegen — relative imports", () => {
 
 describe("codegen — loader detection", () => {
   let pagesDir: string;
-  let outFile: string;
+  let outDir: string;
   let loadersFile: string;
   let root: string;
 
   beforeEach(async () => {
     root = await makeDir("loaders");
     pagesDir = join(root, "src/pages");
-    outFile = join(root, ".ilha/routes.ts");
+    outDir = join(root, ".ilha");
     loadersFile = join(root, ".ilha/loaders.ts");
     await mkdir(pagesDir, { recursive: true });
   });
@@ -736,9 +736,9 @@ describe("codegen — loader detection", () => {
   });
 
   async function runCodegen() {
-    await generate(pagesDir, outFile);
+    await generate(pagesDir, outDir);
     return {
-      routes: await readFile(outFile, "utf8"),
+      routes: await readFile(resolveGeneratedPaths(outDir).serverFile, "utf8"),
       loaders: await readFile(loadersFile, "utf8").catch(() => ""),
     };
   }
@@ -748,18 +748,26 @@ describe("codegen — loader detection", () => {
   it("Page imports in routes.ts use the ?client suffix", async () => {
     await writePage(pagesDir, "index.ts", `export default null;`);
     const { routes } = await runCodegen();
-    const PageImport = routes
+    const clientCode = await readFile(resolveGeneratedPaths(outDir).clientFile, "utf8");
+    const PageImport = clientCode
       .split("\n")
       .find((l) => l.startsWith("import") && l.includes("_page0"));
     expect(PageImport).toBeDefined();
     expect(PageImport!).toContain("?client");
+    // server file must NOT have ?client
+    const serverImport = routes
+      .split("\n")
+      .find((l) => l.startsWith("import") && l.includes("_page0"));
+    expect(serverImport).toBeDefined();
+    expect(serverImport!).not.toContain("?client");
   });
 
   it("layout imports in routes.ts use the ?client suffix", async () => {
     await writePage(pagesDir, "index.ts", `export default null;`);
     await writePage(pagesDir, "+layout.ts", `export default null;`);
-    const { routes } = await runCodegen();
-    const layoutImport = routes
+    await runCodegen();
+    const clientCode = await readFile(resolveGeneratedPaths(outDir).clientFile, "utf8");
+    const layoutImport = clientCode
       .split("\n")
       .find((l) => l.startsWith("import") && l.includes("+layout"));
     expect(layoutImport).toBeDefined();
@@ -769,8 +777,9 @@ describe("codegen — loader detection", () => {
   it("error imports in routes.ts use the ?client suffix", async () => {
     await writePage(pagesDir, "index.ts", `export default null;`);
     await writePage(pagesDir, "+error.ts", `export default null;`);
-    const { routes } = await runCodegen();
-    const errorImport = routes
+    await runCodegen();
+    const clientCode = await readFile(resolveGeneratedPaths(outDir).clientFile, "utf8");
+    const errorImport = clientCode
       .split("\n")
       .find((l) => l.startsWith("import") && l.includes("+error"));
     expect(errorImport).toBeDefined();
@@ -987,14 +996,14 @@ describe("codegen — loader detection", () => {
 
 describe("codegen — loaders.ts file", () => {
   let pagesDir: string;
-  let outFile: string;
+  let outDir: string;
   let loadersFile: string;
   let root: string;
 
   beforeEach(async () => {
     root = await makeDir("loaders-struct");
     pagesDir = join(root, "src/pages");
-    outFile = join(root, ".ilha/routes.ts");
+    outDir = join(root, ".ilha");
     loadersFile = join(root, ".ilha/loaders.ts");
     await mkdir(pagesDir, { recursive: true });
   });
@@ -1004,7 +1013,7 @@ describe("codegen — loaders.ts file", () => {
   });
 
   async function runCodegen() {
-    await generate(pagesDir, outFile);
+    await generate(pagesDir, outDir);
     return readFile(loadersFile, "utf8");
   }
 
@@ -1028,19 +1037,19 @@ describe("codegen — loaders.ts file", () => {
       "+layout.ts",
       `export const load = async () => ({}); export default null;`,
     );
-    const code = await runCodegen();
-    expect(code).toContain(`import { composeLoaders } from "@ilha/router"`);
+    const loaders = await runCodegen();
+    expect(loaders).toContain(`import { composeLoaders } from "@ilha/router"`);
   });
 
-  it("imports pageRouter from the routes file", async () => {
+  it("imports pageRouter from the server routes file", async () => {
     await writePage(
       pagesDir,
       "index.ts",
       `export const load = async () => ({}); export default null;`,
     );
-    const code = await runCodegen();
-    expect(code).toContain(`import { pageRouter } from`);
-    expect(code).toContain("routes");
+    const loaders = await runCodegen();
+    expect(loaders).toContain(`import { pageRouter } from`);
+    expect(loaders).toContain("pages.server");
   });
 
   it("all imports are relative (no absolute paths)", async () => {
@@ -1096,13 +1105,13 @@ describe("codegen — loaders.ts file", () => {
 
 describe("codegen — static mode", () => {
   let pagesDir: string;
-  let outFile: string;
+  let outDir: string;
   let root: string;
 
   beforeEach(async () => {
     root = await makeDir("static");
     pagesDir = join(root, "src/pages");
-    outFile = join(root, ".ilha/routes.ts");
+    outDir = join(root, ".ilha");
     await mkdir(pagesDir, { recursive: true });
   });
 
@@ -1111,8 +1120,8 @@ describe("codegen — static mode", () => {
   });
 
   async function runStatic() {
-    await generate(pagesDir, outFile, { mode: "static" });
-    return readFile(outFile, "utf8");
+    await generate(pagesDir, outDir, { mode: "static" });
+    return readFile(resolveGeneratedPaths(outDir).clientFile, "utf8");
   }
 
   it("emits static mode router stub", async () => {
@@ -1179,5 +1188,80 @@ describe("codegen — static mode", () => {
     expect(code).not.toContain(".route(");
     expect(code).not.toContain("load");
     expect(code).not.toContain("attachLoader");
+  });
+});
+
+// ─────────────────────────────────────────────
+// codegen — server/client split correctness
+// ─────────────────────────────────────────────
+
+describe("codegen — server/client split", () => {
+  let pagesDir: string;
+  let outDir: string;
+  let root: string;
+
+  beforeEach(async () => {
+    root = await makeDir("split");
+    pagesDir = join(root, "src/pages");
+    outDir = join(root, ".ilha");
+    await mkdir(pagesDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await removeDir(root);
+  });
+
+  it("server file does not contain ?client imports", async () => {
+    await writePage(pagesDir, "index.ts", `export default null;`);
+    await writePage(pagesDir, "+layout.ts", `export default null;`);
+    await generate(pagesDir, outDir);
+    const server = await readFile(resolveGeneratedPaths(outDir).serverFile, "utf8");
+    expect(server).not.toContain("?client");
+  });
+
+  it("client file uses ?client imports for all page/layout/error modules", async () => {
+    await writePage(pagesDir, "index.ts", `export default null;`);
+    await writePage(pagesDir, "+layout.ts", `export default null;`);
+    await writePage(pagesDir, "+error.ts", `export default null;`);
+    await generate(pagesDir, outDir);
+    const client = await readFile(resolveGeneratedPaths(outDir).clientFile, "utf8");
+    const importLines = client
+      .split("\n")
+      .filter((l) => l.startsWith("import") && l.includes("src/pages"));
+    expect(importLines.length).toBeGreaterThan(0);
+    expect(importLines.every((l) => l.includes("?client"))).toBe(true);
+  });
+
+  it("server file has full route graph (wrapLayout, .route calls)", async () => {
+    await writePage(pagesDir, "index.ts", `export default null;`);
+    await writePage(pagesDir, "+layout.ts", `export default null;`);
+    await generate(pagesDir, outDir);
+    const server = await readFile(resolveGeneratedPaths(outDir).serverFile, "utf8");
+    expect(server).toContain("wrapLayout");
+    expect(server).toContain(".route(");
+  });
+
+  it("static mode: client file has no route graph, server file still has full graph", async () => {
+    await writePage(pagesDir, "index.ts", `export default null;`);
+    await writePage(pagesDir, "+layout.ts", `export default null;`);
+    await generate(pagesDir, outDir, { mode: "static" });
+    const client = await readFile(resolveGeneratedPaths(outDir).clientFile, "utf8");
+    const server = await readFile(resolveGeneratedPaths(outDir).serverFile, "utf8");
+    expect(client).not.toContain(".route(");
+    expect(client).not.toContain("wrapLayout");
+    expect(server).toContain(".route(");
+    expect(server).toContain("wrapLayout");
+  });
+
+  it("loaders.ts imports pageRouter from pages.server, not pages.client", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const load = async () => ({}); export default null;`,
+    );
+    await generate(pagesDir, outDir);
+    const loaders = await readFile(resolveGeneratedPaths(outDir).loadersFile, "utf8");
+    expect(loaders).toContain("pages.server");
+    expect(loaders).not.toContain("pages.client");
   });
 });

--- a/packages/router/src/codegen.ts
+++ b/packages/router/src/codegen.ts
@@ -112,10 +112,8 @@ function sortEntries(entries: PageEntry[]): PageEntry[] {
   return [...entries].sort((a, b) => {
     const specDiff = specificityScore(b.pattern) - specificityScore(a.pattern);
     if (specDiff !== 0) return specDiff;
-    // Within the same specificity tier, more segments = more specific
     const segDiff = b.pattern.split("/").length - a.pattern.split("/").length;
     if (segDiff !== 0) return segDiff;
-    // Final tiebreaker: alphabetical for determinism across filesystems
     return a.pattern.localeCompare(b.pattern);
   });
 }
@@ -181,9 +179,6 @@ async function scanPages(pagesDir: string): Promise<PageEntry[]> {
   const allSet = new Set(all);
   const pages = all.filter((f) => !basename(f).startsWith("+"));
 
-  // Detect loader exports on pages and on +layout.ts files in parallel. Error
-  // sentinels don't carry loaders so we skip them. Cache layout results since
-  // the same layout can apply to many pages.
   const layoutLoaderCache = new Map<string, Promise<boolean>>();
   const getLayoutHasLoader = (file: string): Promise<boolean> => {
     let cached = layoutLoaderCache.get(file);
@@ -258,13 +253,13 @@ function validateEntries(entries: PageEntry[], pagesDir: string): void {
 }
 
 // ─────────────────────────────────────────────
-// Codegen — emit generated file
+// Codegen — emit generated files
 // ─────────────────────────────────────────────
 
 export type PagesMode = "spa" | "static";
 
 export interface GenerateOptions {
-  /** Generated page router navigation mode. Default: `spa`. */
+  /** Client navigation mode. Default: `spa`. */
   mode?: PagesMode;
   /**
    * Whether to install client-side link interception. Only meaningful in `spa`
@@ -273,9 +268,27 @@ export interface GenerateOptions {
   interceptLinks?: boolean;
 }
 
+/** Paths for all generated files derived from the base output directory. */
+export interface GeneratedPaths {
+  /** Server module: raw imports, full route graph. `ilha:pages/server` */
+  serverFile: string;
+  /** Client module: ?client imports, browser-optimised. `ilha:pages/client` */
+  clientFile: string;
+  /** Server-only loaders side-effect module. `ilha:loaders` */
+  loadersFile: string;
+}
+
+export function resolveGeneratedPaths(outDir: string): GeneratedPaths {
+  return {
+    serverFile: join(outDir, "pages.server.ts"),
+    clientFile: join(outDir, "pages.client.ts"),
+    loadersFile: join(outDir, "loaders.ts"),
+  };
+}
+
 export async function generate(
   pagesDir: string,
-  outFile: string,
+  outDir: string,
   options: GenerateOptions = {},
 ): Promise<void> {
   const mode = options.mode ?? "spa";
@@ -286,14 +299,110 @@ export async function generate(
 
   validateEntries(entries, pagesDir);
 
+  await mkdir(outDir, { recursive: true });
+
+  const { serverFile, clientFile, loadersFile } = resolveGeneratedPaths(outDir);
+
+  // ─── Server file: raw imports, full route graph ──────────────────────────
+  const serverCode = buildServerFile(entries, serverFile);
+  const serverChanged = await writeIfChanged(serverFile, serverCode);
+
+  // ─── Client file: ?client imports, browser bundle ───────────────────────
+  const clientCode = buildClientFile(entries, clientFile, { isStatic, interceptLinks });
+  const clientChanged = await writeIfChanged(clientFile, clientCode);
+
+  // ─── Loaders file (server-only, skipped in static mode) ─────────────────
+  if (!isStatic) {
+    const loadersCode = buildLoadersFile(entries, loadersFile, serverFile);
+    await writeIfChanged(loadersFile, loadersCode);
+  }
+
+  if (serverChanged || clientChanged) {
+    await generateTypes(outDir);
+  }
+}
+
+// ─────────────────────────────────────────────
+// Codegen — server file
+// ─────────────────────────────────────────────
+
+function buildServerFile(entries: PageEntry[], serverFile: string): string {
   const rel = (abs: string) => {
-    const r = toPosix(relative(dirname(outFile), abs));
+    const r = toPosix(relative(dirname(serverFile), abs));
     return r.startsWith(".") ? r : `./${r}`;
   };
 
-  // ─── Client-safe routes file ────────────────────────────────────────────
+  const imports: string[] = [
+    `import { router, wrapLayout, wrapError } from "@ilha/router";`,
+    `import type { Island } from "ilha";`,
+  ];
+  const wrappedIslandLines: string[] = [];
+  const registryLines: string[] = [];
+  const routeLines: string[] = [];
+
+  for (const [i, entry] of entries.entries()) {
+    // Raw imports — no ?client — so SSR sees the full module including JSX
+    imports.push(`import { default as _page${i} } from ${JSON.stringify(rel(entry.file))};`);
+    for (const [j, l] of entry.layouts.entries())
+      imports.push(`import { default as _layout${i}_${j} } from ${JSON.stringify(rel(l))};`);
+    for (const [j, e] of entry.errors.entries())
+      imports.push(`import { default as _error${i}_${j} } from ${JSON.stringify(rel(e))};`);
+
+    let expr = `_page${i}`;
+    for (let j = entry.errors.length - 1; j >= 0; j--) expr = `wrapError(_error${i}_${j}, ${expr})`;
+    for (let j = entry.layouts.length - 1; j >= 0; j--)
+      expr = `wrapLayout(_layout${i}_${j}, ${expr})`;
+
+    const wrappedId = `_wrapped${i}`;
+    wrappedIslandLines.push(`const ${wrappedId} = ${expr};`);
+    registryLines.push(
+      `  ${JSON.stringify(entry.name)}: ${wrappedId}` + (i < entries.length - 1 ? "," : ""),
+    );
+    routeLines.push(
+      `  .route(${JSON.stringify(entry.pattern)}, ${wrappedId})` +
+        (entry.hasLoader || entry.loaderLayouts.length > 0
+          ? `.markLoader(${JSON.stringify(entry.pattern)})`
+          : ""),
+    );
+  }
+
+  return [
+    `// @generated by @ilha/router — do not edit`,
+    `// Server module. Use for SSR and SSG/prerender.`,
+    `// Import via: import { pageRouter, registry } from "ilha:pages/server";`,
+    ``,
+    ...imports,
+    ``,
+    ...wrappedIslandLines,
+    ``,
+    `export const registry: Record<string, Island<any, any>> = {`,
+    ...registryLines,
+    `};`,
+    ``,
+    `export const pageRouter = router()`,
+    ...routeLines,
+    `  ;`,
+  ].join("\n");
+}
+
+// ─────────────────────────────────────────────
+// Codegen — client file
+// ─────────────────────────────────────────────
+
+function buildClientFile(
+  entries: PageEntry[],
+  clientFile: string,
+  opts: { isStatic: boolean; interceptLinks?: boolean },
+): string {
+  const { isStatic, interceptLinks } = opts;
+  const rel = (abs: string) => {
+    const r = toPosix(relative(dirname(clientFile), abs));
+    return r.startsWith(".") ? r : `./${r}`;
+  };
+  const clientImport = (abs: string) => `${rel(abs)}?client`;
+
   const imports: string[] = isStatic
-    ? [`import type { Island } from "ilha";`]
+    ? [`import { router as _router } from "@ilha/router";`, `import type { Island } from "ilha";`]
     : [
         `import { router, wrapLayout, wrapError } from "@ilha/router";`,
         `import type { Island } from "ilha";`,
@@ -303,30 +412,22 @@ export async function generate(
   const registryLines: string[] = [];
   const routeLines: string[] = [];
 
-  // The `?client` query suffix resolves (via the plugin) to a virtual module
-  // that re-exports only the default. This strips `load` and any symbol only
-  // reachable from `load`, keeping server-only code out of the client bundle.
-  const clientImport = (abs: string) => `${rel(abs)}?client`;
-
   for (const [i, entry] of entries.entries()) {
-    const pageId = `_page${i}`;
     imports.push(
-      `import { default as ${pageId} } from ${JSON.stringify(clientImport(entry.file))};`,
+      `import { default as _page${i} } from ${JSON.stringify(clientImport(entry.file))};`,
     );
-
     if (!isStatic) {
       for (const [j, l] of entry.layouts.entries())
         imports.push(
           `import { default as _layout${i}_${j} } from ${JSON.stringify(clientImport(l))};`,
         );
-
       for (const [j, e] of entry.errors.entries())
         imports.push(
           `import { default as _error${i}_${j} } from ${JSON.stringify(clientImport(e))};`,
         );
     }
 
-    let expr = pageId;
+    let expr = `_page${i}`;
     if (!isStatic) {
       for (let j = entry.errors.length - 1; j >= 0; j--)
         expr = `wrapError(_error${i}_${j}, ${expr})`;
@@ -334,8 +435,6 @@ export async function generate(
         expr = `wrapLayout(_layout${i}_${j}, ${expr})`;
     }
 
-    // Store wrapped island in a variable so registry and route use the SAME instance
-    // This is required for renderHydratable to find the island by identity
     const wrappedId = `_wrapped${i}`;
     wrappedIslandLines.push(`const ${wrappedId} = ${expr};`);
     registryLines.push(
@@ -351,70 +450,44 @@ export async function generate(
     }
   }
 
-  const code = isStatic
-    ? [
-        `// @generated by @ilha/router — do not edit`,
-        `// static mode: no route graph, no client navigation.`,
-        `// Import registry to hydrate islands; use pageRouter.hydrateStatic(registry).`,
-        ``,
-        `import { router as _router } from "@ilha/router";`,
-        ...imports,
-        ``,
-        ...wrappedIslandLines,
-        ``,
-        `export const registry: Record<string, Island<any, any>> = {`,
-        ...registryLines,
-        `};`,
-        ``,
-        `export const pageRouter = _router({ mode: "static" });`,
-      ].join("\n")
-    : [
-        `// @generated by @ilha/router — do not edit`,
-        ``,
-        ...imports,
-        ``,
-        ...wrappedIslandLines,
-        ``,
-        `export const registry: Record<string, Island<any, any>> = {`,
-        ...registryLines,
-        `};`,
-        ``,
-        `export const pageRouter = router(${interceptLinks === false ? `{ interceptLinks: false }` : ""})`,
-        ...routeLines,
-        `  ;`,
-      ].join("\n");
+  const routerExpr = isStatic
+    ? `_router({ mode: "static" })`
+    : `router(${interceptLinks === false ? `{ interceptLinks: false }` : ""})`;
 
-  // Only write if content actually changed — avoids unnecessary HMR invalidation
-  await mkdir(dirname(outFile), { recursive: true });
-  const routesChanged = await writeIfChanged(outFile, code);
+  const lines = [
+    `// @generated by @ilha/router — do not edit`,
+    `// Client module. Use for browser hydration.`,
+    `// Import via: import { pageRouter, registry } from "ilha:pages/client";`,
+    ``,
+    ...imports,
+    ``,
+    ...wrappedIslandLines,
+    ``,
+    `export const registry: Record<string, Island<any, any>> = {`,
+    ...registryLines,
+    `};`,
+    ``,
+  ];
 
-  // ─── Server-only loaders file ───────────────────────────────────────────
-  // Static mode has no route graph so attachLoader is never called; skip.
   if (isStatic) {
-    if (routesChanged) await generateTypes(outFile);
-    return;
+    lines.push(`export const pageRouter = ${routerExpr};`);
+  } else {
+    lines.push(`export const pageRouter = ${routerExpr}`, ...routeLines, `  ;`);
   }
-  const loadersFile = join(dirname(outFile), "loaders.ts");
-  const loadersCode = buildLoadersFile(entries, loadersFile, outFile);
-  const loadersChanged = await writeIfChanged(loadersFile, loadersCode);
 
-  if (routesChanged || loadersChanged) {
-    await generateTypes(outFile);
-  }
+  return lines.join("\n");
 }
 
 // ─────────────────────────────────────────────
-// Codegen — build the server-only loaders file
+// Codegen — server-only loaders file
 // ─────────────────────────────────────────────
 
-function buildLoadersFile(entries: PageEntry[], loadersFile: string, routesFile: string): string {
+function buildLoadersFile(entries: PageEntry[], loadersFile: string, serverFile: string): string {
   const relFromLoaders = (abs: string) => {
     const r = toPosix(relative(dirname(loadersFile), abs));
     return r.startsWith(".") ? r : `./${r}`;
   };
 
-  // Only include pages that have at least one loader in their chain (page or
-  // any layout). Pages without any loaders don't need an attachLoader call.
   const withLoaders = entries.filter((e) => e.hasLoader || e.loaderLayouts.length > 0);
 
   if (withLoaders.length === 0) {
@@ -427,42 +500,30 @@ function buildLoadersFile(entries: PageEntry[], loadersFile: string, routesFile:
     ].join("\n");
   }
 
-  const routesRel = relFromLoaders(routesFile).replace(/\.tsx?$/, "");
-
-  const imports: string[] = [`import { pageRouter } from ${JSON.stringify(routesRel)};`];
+  const serverRel = relFromLoaders(serverFile).replace(/\.tsx?$/, "");
+  const imports: string[] = [`import { pageRouter } from ${JSON.stringify(serverRel)};`];
   let needsComposeLoaders = false;
-
   const attachLines: string[] = [];
 
   for (const [i, entry] of withLoaders.entries()) {
-    // Unique local names per page index to avoid collisions when the same
-    // layout file is imported by many pages (we import it once per page for
-    // clarity — Vite dedupes the underlying module anyway).
     const loaderIds: string[] = [];
-
     for (const [j, layout] of entry.loaderLayouts.entries()) {
       const id = `_p${i}_l${j}`;
       imports.push(`import { load as ${id} } from ${JSON.stringify(relFromLoaders(layout))};`);
       loaderIds.push(id);
     }
-
     if (entry.hasLoader) {
       const id = `_p${i}`;
       imports.push(`import { load as ${id} } from ${JSON.stringify(relFromLoaders(entry.file))};`);
       loaderIds.push(id);
     }
-
     const loadersExpr =
       loaderIds.length === 1 ? loaderIds[0] : `composeLoaders([${loaderIds.join(", ")}])`;
     if (loaderIds.length > 1) needsComposeLoaders = true;
-
     attachLines.push(`pageRouter.attachLoader(${JSON.stringify(entry.pattern)}, ${loadersExpr});`);
   }
 
-  // Only import composeLoaders if at least one page needs it (multiple loaders)
-  if (needsComposeLoaders) {
-    imports.unshift(`import { composeLoaders } from "@ilha/router";`);
-  }
+  if (needsComposeLoaders) imports.unshift(`import { composeLoaders } from "@ilha/router";`);
 
   return [
     `// @generated by @ilha/router — do not edit`,
@@ -486,7 +547,7 @@ async function writeIfChanged(file: string, content: string): Promise<boolean> {
     const existing = await readFile(file, "utf8");
     if (existing === content) return false;
   } catch {
-    // File doesn't exist yet — that's fine, proceed to write
+    // File doesn't exist yet — proceed to write
   }
   await writeFile(file, content, "utf8");
   return true;
@@ -496,19 +557,23 @@ async function writeIfChanged(file: string, content: string): Promise<boolean> {
 // Type declarations for virtual modules
 // ─────────────────────────────────────────────
 
-async function generateTypes(outFile: string): Promise<void> {
-  const dtsFile = outFile.replace(/\.tsx?$/, ".d.ts");
+async function generateTypes(outDir: string): Promise<void> {
+  const dtsFile = join(outDir, "pages.d.ts");
 
   const types = [
     `// @generated by @ilha/router — do not edit`,
     ``,
-    `declare module "ilha:pages" {`,
+    `declare module "ilha:pages/server" {`,
     `  import type { RouterBuilder } from "@ilha/router";`,
+    `  import type { Island } from "ilha";`,
     `  export const pageRouter: RouterBuilder;`,
+    `  export const registry: Record<string, Island<any, any>>;`,
     `}`,
     ``,
-    `declare module "ilha:registry" {`,
+    `declare module "ilha:pages/client" {`,
+    `  import type { RouterBuilder } from "@ilha/router";`,
     `  import type { Island } from "ilha";`,
+    `  export const pageRouter: RouterBuilder;`,
     `  export const registry: Record<string, Island<any, any>>;`,
     `}`,
     ``,

--- a/packages/router/src/index.test.ts
+++ b/packages/router/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 
 import ilha, { ISLAND_MOUNT_INTERNAL, mount as ilhaMount, html } from "ilha";
+import { jsx, jsxs } from "ilha/jsx-runtime";
 
 import {
   router,
@@ -2101,5 +2102,73 @@ describe("static mode — router({ mode: 'static' })", () => {
       .renderHydratable("/about", { about: AboutPage }, { snapshot: false });
     expect(html).toContain("about");
     expect(html).not.toContain("data-ilha-state");
+  });
+});
+
+// ─────────────────────────────────────────────
+// SSR compound render-part regression
+// ─────────────────────────────────────────────
+
+describe("SSR compound render-part regression (Areia Resizable pattern)", () => {
+  const ILHA_RENDER_PART = Symbol.for("ilha.renderPart");
+  const PART = "__testPart";
+
+  function createPart(type: string, input: any) {
+    const part: any = { [PART]: type, [ILHA_RENDER_PART]: true, input };
+    Object.defineProperty(part, "toString", {
+      value: () =>
+        type === "panel"
+          ? `<div data-slot="resizable-panel">${input.children ?? ""}</div>`
+          : `<div data-slot="resizable-handle"></div>`,
+    });
+    return part;
+  }
+
+  function Resizable(props: any) {
+    const kids = Array.isArray(props.children) ? props.children : [props.children];
+    const inner = kids
+      .map((c: any) => (typeof c === "object" && c?.value ? c.value : String(c)))
+      .join("");
+    return { [Symbol.for("ilha.raw")]: true, value: `<div data-slot="resizable">${inner}</div>` };
+  }
+  (Resizable as any).Panel = (props: any) => createPart("panel", props);
+  (Resizable as any).Handle = (props: any) => createPart("handle", props);
+
+  const R = Resizable as any;
+
+  it("compound render-part children render inside parent, not as siblings", async () => {
+    const Page = ilha.render(
+      () =>
+        html`
+          <article>page</article>
+        `,
+    );
+
+    const Layout = defineLayout((children) =>
+      ilha.render(() =>
+        jsxs("main", {
+          children: [
+            jsxs(R, {
+              children: [
+                jsx(R.Panel, { children: "sidebar" }),
+                jsx(R.Handle, {}),
+                jsx(R.Panel, { children }),
+              ],
+            }),
+          ],
+        }),
+      ),
+    );
+
+    const Wrapped = wrapLayout(Layout, Page);
+    const serverRegistry = { page: Wrapped };
+
+    const result = await router().route("/", Wrapped).renderHydratable("/", serverRegistry);
+
+    expect(result).toContain('data-slot="resizable"');
+    expect(result).toMatch(
+      /data-slot="resizable"[\s\S]*data-slot="resizable-panel"[\s\S]*data-slot="resizable-handle"[\s\S]*data-slot="resizable-panel"/,
+    );
+    expect(result).not.toMatch(/<\/main>\s*<div data-slot="resizable-panel"/);
   });
 });

--- a/packages/router/src/plugin.test.ts
+++ b/packages/router/src/plugin.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "bun:test";
 import { mkdir } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 
+import { resolveGeneratedPaths } from "./codegen";
 import { ilhaPages } from "./plugin";
 import { makeDir, removeDir } from "./test-helpers";
 
@@ -20,14 +21,14 @@ function plugin(options: Record<string, string> = {}) {
 // ─────────────────────────────────────────────
 
 describe("pages — plugin", () => {
-  it("resolves ilha:pages virtual id", () => {
+  it("resolves ilha:pages/server virtual id", () => {
     const p = plugin();
-    expect(p.resolveId("ilha:pages")).toBe("\0ilha:pages");
+    expect(p.resolveId("ilha:pages/server")).toBe("\0ilha:pages/server");
   });
 
-  it("resolves ilha:registry virtual id", () => {
+  it("resolves ilha:pages/client virtual id", () => {
     const p = plugin();
-    expect(p.resolveId("ilha:registry")).toBe("\0ilha:registry");
+    expect(p.resolveId("ilha:pages/client")).toBe("\0ilha:pages/client");
   });
 
   it("returns undefined for unrelated ids", () => {
@@ -35,47 +36,49 @@ describe("pages — plugin", () => {
     expect(p.resolveId("some-other-module")).toBeUndefined();
   });
 
-  it("load for ilha:pages re-exports pageRouter as named export", async () => {
-    const root = await makeDir("vite-pages");
+  it("load for ilha:pages/server re-exports pageRouter and registry", async () => {
+    const root = await makeDir("vite-server");
     const pagesDir = join(root, "src/pages");
-    const outFile = join(root, ".ilha/routes.ts");
+    const outDir = join(root, ".ilha");
     await mkdir(pagesDir, { recursive: true });
-    const p = plugin({ dir: pagesDir, generated: outFile });
+    const p = plugin({ dir: pagesDir, outDir });
     p.configResolved({ root });
-    const result = p.load("\0ilha:pages");
-    expect(result).toContain(outFile.replace(/\.ts$/, ""));
+    const result = p.load("\0ilha:pages/server");
+    const serverSpec = resolveGeneratedPaths(outDir).serverFile.replace(/\.ts$/, "");
+    expect(result).toContain(serverSpec);
     expect(result).toContain("pageRouter");
-    expect(result).toContain("export");
-    expect(result).not.toContain("export default");
-    await removeDir(root);
-  });
-
-  it("load for ilha:registry re-exports registry as named export", async () => {
-    const root = await makeDir("vite-registry");
-    const pagesDir = join(root, "src/pages");
-    const outFile = join(root, ".ilha/routes.ts");
-    await mkdir(pagesDir, { recursive: true });
-    const p = plugin({ dir: pagesDir, generated: outFile });
-    p.configResolved({ root });
-    const result = p.load("\0ilha:registry");
-    expect(result).toContain(outFile.replace(/\.ts$/, ""));
     expect(result).toContain("registry");
-    expect(result).toContain("export");
-    expect(result).not.toContain("export default");
     await removeDir(root);
   });
 
-  it("ilha:pages and ilha:registry both point to the same generated file", async () => {
-    const root = await makeDir("vite-same-file");
+  it("load for ilha:pages/client re-exports pageRouter and registry", async () => {
+    const root = await makeDir("vite-client");
     const pagesDir = join(root, "src/pages");
-    const outFile = join(root, ".ilha/routes.ts");
+    const outDir = join(root, ".ilha");
     await mkdir(pagesDir, { recursive: true });
-    const p = plugin({ dir: pagesDir, generated: outFile });
+    const p = plugin({ dir: pagesDir, outDir });
     p.configResolved({ root });
-    const pagesResult = p.load("\0ilha:pages");
-    const registryResult = p.load("\0ilha:registry");
+    const result = p.load("\0ilha:pages/client");
+    const clientSpec = resolveGeneratedPaths(outDir).clientFile.replace(/\.ts$/, "");
+    expect(result).toContain(clientSpec);
+    expect(result).toContain("pageRouter");
+    expect(result).toContain("registry");
+    await removeDir(root);
+  });
+
+  it("server and client load from different generated files", async () => {
+    const root = await makeDir("vite-split");
+    const pagesDir = join(root, "src/pages");
+    const outDir = join(root, ".ilha");
+    await mkdir(pagesDir, { recursive: true });
+    const p = plugin({ dir: pagesDir, outDir });
+    p.configResolved({ root });
+    const serverResult = p.load("\0ilha:pages/server");
+    const clientResult = p.load("\0ilha:pages/client");
     const fileRef = (s: string | undefined) => s?.match(/from ['"](.+)['"]/)?.[1];
-    expect(fileRef(pagesResult)).toBe(fileRef(registryResult));
+    expect(fileRef(serverResult)).not.toBe(fileRef(clientResult));
+    expect(fileRef(serverResult)).toContain("pages.server");
+    expect(fileRef(clientResult)).toContain("pages.client");
     await removeDir(root);
   });
 
@@ -90,7 +93,7 @@ describe("pages — plugin", () => {
 
   it("configResolved sets root-relative paths", async () => {
     const root = await makeDir("cfg");
-    const p = plugin({ dir: "src/pages", generated: "src/generated/routes.ts" });
+    const p = plugin({ dir: "src/pages", outDir: ".ilha" });
     p.configResolved({ root });
     await mkdir(join(root, "src/pages"), { recursive: true });
     await expect(p.buildStart()).resolves.toBeUndefined();
@@ -105,19 +108,19 @@ describe("pages — plugin", () => {
 describe("pages — ?client virtual module", () => {
   it("resolveId returns the id with ?client suffix for a relative ?client import", () => {
     const p = plugin();
-    const resolved = p.resolveId("./foo.ts?client", "/proj/.ilha/routes.ts");
+    const resolved = p.resolveId("./foo.ts?client", "/proj/.ilha/pages.client.ts");
     expect(resolved).toBe("/proj/.ilha/foo.ts?client");
   });
 
   it("resolveId resolves ../ paths relative to importer", () => {
     const p = plugin();
-    const resolved = p.resolveId("../src/pages/index.ts?client", "/proj/.ilha/routes.ts");
+    const resolved = p.resolveId("../src/pages/index.ts?client", "/proj/.ilha/pages.client.ts");
     expect(resolved).toBe("/proj/src/pages/index.ts?client");
   });
 
   it("resolveId without ?client suffix is unaffected", () => {
     const p = plugin();
-    expect(p.resolveId("./foo.ts", "/proj/.ilha/routes.ts")).toBeUndefined();
+    expect(p.resolveId("./foo.ts", "/proj/.ilha/pages.client.ts")).toBeUndefined();
   });
 
   it("load(?client) emits `export { default }` from the bare path", () => {
@@ -149,13 +152,13 @@ describe("pages — ilha:loaders virtual module", () => {
   it("load for ilha:loaders imports the generated loaders file for side effects", async () => {
     const root = await makeDir("loaders-virt");
     const pagesDir = join(root, "src/pages");
-    const outFile = join(root, ".ilha/routes.ts");
+    const outDir = join(root, ".ilha");
     await mkdir(pagesDir, { recursive: true });
-    const p = plugin({ dir: pagesDir, generated: outFile });
+    const p = plugin({ dir: pagesDir, outDir });
     p.configResolved({ root });
     const result = p.load("\0ilha:loaders");
-    const loadersFile = join(dirname(outFile), "loaders.ts");
-    expect(result).toContain(loadersFile.replace(/\.ts$/, ""));
+    const loadersSpec = resolveGeneratedPaths(outDir).loadersFile.replace(/\.ts$/, "");
+    expect(result).toContain(loadersSpec);
     expect(result).toMatch(/import\s+["']/);
     expect(result).not.toContain("export");
     await removeDir(root);

--- a/packages/router/src/plugin.ts
+++ b/packages/router/src/plugin.ts
@@ -1,28 +1,32 @@
 import { watch } from "node:fs";
-import { basename, dirname, join, resolve, sep } from "node:path";
+import { basename, join, resolve, sep } from "node:path";
 
 import { createUnplugin } from "unplugin";
 import type { UnpluginFactory } from "unplugin";
 
-import { generate } from "./codegen";
+import { generate, resolveGeneratedPaths } from "./codegen";
 import type { PagesMode } from "./codegen";
 
-export const VIRTUAL_PAGES = "ilha:pages";
-export const VIRTUAL_REGISTRY = "ilha:registry";
+export const VIRTUAL_PAGES_SERVER = "ilha:pages/server";
+export const VIRTUAL_PAGES_CLIENT = "ilha:pages/client";
 export const VIRTUAL_LOADERS = "ilha:loaders";
-export const RESOLVED_PAGES = "\0ilha:pages";
-export const RESOLVED_REGISTRY = "\0ilha:registry";
+export const RESOLVED_PAGES_SERVER = "\0ilha:pages/server";
+export const RESOLVED_PAGES_CLIENT = "\0ilha:pages/client";
 export const RESOLVED_LOADERS = "\0ilha:loaders";
-export const RESOLVED_VIRTUAL_IDS = [RESOLVED_PAGES, RESOLVED_REGISTRY, RESOLVED_LOADERS] as const;
+export const RESOLVED_VIRTUAL_IDS = [
+  RESOLVED_PAGES_SERVER,
+  RESOLVED_PAGES_CLIENT,
+  RESOLVED_LOADERS,
+] as const;
 
-/** Query suffix used on page/layout imports in the client-safe routes file. */
+/** Query suffix used on page/layout imports in the client file. */
 export const CLIENT_QUERY = "?client";
 
 export interface IlhaPagesOptions {
   /** Directory containing page files. Default: `src/pages` */
   dir?: string;
-  /** Output path for the generated routes + registry file. Default: `.ilha/routes.ts` */
-  generated?: string;
+  /** Output directory for generated files. Default: `.ilha` */
+  outDir?: string;
   /**
    * File-system router navigation mode.
    * - `spa` — full client route graph with SSR/hydration and client navigation.
@@ -40,14 +44,16 @@ export interface IlhaPagesOptions {
 
 export function resolvePluginPaths(root: string, options: IlhaPagesOptions) {
   const pagesDir = resolve(root, options.dir ?? "src/pages");
-  const outFile = resolve(root, options.generated ?? ".ilha/routes.ts");
-  const loadersFile = join(dirname(outFile), "loaders.ts");
-  return { pagesDir, outFile, loadersFile };
+  const outDir = resolve(root, options.outDir ?? ".ilha");
+  const { serverFile, clientFile, loadersFile } = resolveGeneratedPaths(outDir);
+  return { pagesDir, outDir, serverFile, clientFile, loadersFile };
 }
 
 export interface PagesPluginState {
   pagesDir: string;
-  outFile: string;
+  outDir: string;
+  serverFile: string;
+  clientFile: string;
   loadersFile: string;
   setPaths(root: string): void;
   regen(): Promise<void>;
@@ -57,16 +63,18 @@ export interface PagesPluginState {
 
 export function createPagesPluginState(options: IlhaPagesOptions): PagesPluginState {
   let pagesDir!: string;
-  let outFile!: string;
+  let outDir!: string;
+  let serverFile!: string;
+  let clientFile!: string;
   let loadersFile!: string;
 
   const setPaths = (root: string) => {
-    ({ pagesDir, outFile, loadersFile } = resolvePluginPaths(root, options));
+    ({ pagesDir, outDir, serverFile, clientFile, loadersFile } = resolvePluginPaths(root, options));
   };
 
   const regen = async () => {
     try {
-      await generate(pagesDir, outFile, {
+      await generate(pagesDir, outDir, {
         mode: options.mode,
         interceptLinks: options.interceptLinks,
       });
@@ -87,8 +95,14 @@ export function createPagesPluginState(options: IlhaPagesOptions): PagesPluginSt
     get pagesDir() {
       return pagesDir;
     },
-    get outFile() {
-      return outFile;
+    get outDir() {
+      return outDir;
+    },
+    get serverFile() {
+      return serverFile;
+    },
+    get clientFile() {
+      return clientFile;
     },
     get loadersFile() {
       return loadersFile;
@@ -110,27 +124,25 @@ export async function regenFromPagesChange(
 }
 
 export function resolvePagesId(_state: PagesPluginState, id: string, importer?: string) {
-  if (id === VIRTUAL_PAGES) return RESOLVED_PAGES;
-  if (id === VIRTUAL_REGISTRY) return RESOLVED_REGISTRY;
+  if (id === VIRTUAL_PAGES_SERVER) return RESOLVED_PAGES_SERVER;
+  if (id === VIRTUAL_PAGES_CLIENT) return RESOLVED_PAGES_CLIENT;
   if (id === VIRTUAL_LOADERS) return RESOLVED_LOADERS;
 
   if (id.endsWith(CLIENT_QUERY)) {
     const bare = id.slice(0, -CLIENT_QUERY.length);
-    const resolved = importer
-      ? resolve(dirname(importer.replace(/\?.*$/, "")), bare)
-      : resolve(bare);
+    const resolved = importer ? resolve(importer.replace(/\?.*$/, ""), "..", bare) : resolve(bare);
     return resolved + CLIENT_QUERY;
   }
 }
 
 export function loadPagesModule(state: PagesPluginState, id: string) {
-  if (id === RESOLVED_PAGES) {
-    const spec = state.outFile.replace(/\.tsx?$/, "");
-    return `export { pageRouter } from ${JSON.stringify(spec)};`;
+  if (id === RESOLVED_PAGES_SERVER) {
+    const spec = state.serverFile.replace(/\.tsx?$/, "");
+    return `export { pageRouter, registry } from ${JSON.stringify(spec)};`;
   }
-  if (id === RESOLVED_REGISTRY) {
-    const spec = state.outFile.replace(/\.tsx?$/, "");
-    return `export { registry } from ${JSON.stringify(spec)};`;
+  if (id === RESOLVED_PAGES_CLIENT) {
+    const spec = state.clientFile.replace(/\.tsx?$/, "");
+    return `export { pageRouter, registry } from ${JSON.stringify(spec)};`;
   }
   if (id === RESOLVED_LOADERS) {
     const spec = state.loadersFile.replace(/\.tsx?$/, "");

--- a/templates/elysia/package.json
+++ b/templates/elysia/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@elysiajs/html": "^1.4.2",
     "@elysiajs/static": "^1.4.10",
-    "@ilha/router": "^0.5.1",
+    "@ilha/router": "^0.6.0",
     "areia": "^0.1.15",
     "elysia": "^1.4.28",
     "ilha": "^0.7.1",

--- a/templates/hono/package.json
+++ b/templates/hono/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.2",
-    "@ilha/router": "^0.5.1",
+    "@ilha/router": "^0.6.0",
     "areia": "^0.1.15",
     "hono": "^4.12.18",
     "ilha": "^0.7.1",

--- a/templates/nitro/package.json
+++ b/templates/nitro/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.5.1",
+    "@ilha/router": "^0.6.0",
     "areia": "^0.1.15",
     "ilha": "^0.7.1",
     "nitro": "^3.0.260522-beta",

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.5.1",
+    "@ilha/router": "^0.6.0",
     "areia": "^0.1.15",
     "ilha": "^0.7.1",
     "quando": "^0.1.6"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated router examples to reflect new `/server` and `/client` virtual module variants for improved SSR and client handling.
  * Updated configuration to use `outDir` option.

* **Chores**
  * Bumped `@ilha/router` to v0.6.0 across all templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->