### PR TITLE
feat(ilha): add .as() api to ilha

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - **Flexible scope** — progressively enhance server-rendered HTML, or build fully self-contained apps
 - **SSR + hydration** — render on the server, restore state on the client with zero flicker
 - **File-system routing** — optional Vite plugin for automatic, convention-based routing
-- **Shared global state** — zustand-shaped store backed by the same signal engine as the core
+- **Shared global state** — `@ilha/store` for cross-island state on the same signal engine as the core
 - **Backend agnostic** — integrates with any backend; first-class Nitro and Hono support
 - **Prompt-sized source** — small enough to fit the entire codebase into an AI context window
 - **Type-safe by default** — first-class TypeScript support throughout

--- a/apps/website/docs/guide/libraries/store.mdx
+++ b/apps/website/docs/guide/libraries/store.mdx
@@ -1,23 +1,25 @@
 ---
 title: "@ilha/store"
-description: A zustand-shaped reactive store for shared global state backed by alien-signals. Includes /form helpers for type-safe, schema-validated forms.
+description: Shared reactive store for Ilha islands (alien-signals). Includes /form helpers for type-safe, schema-validated forms.
 ---
 
 # Ilha Store
 
 import { PackageManagerTabs } from "@rspress/core/theme";
 
-`@ilha/store` is a zustand-shaped reactive store for ilha apps. It lives outside any island and is backed by [alien-signals](https://github.com/stackblitz/alien-signals) — the same engine that powers ilha core state — so stores and islands share a single reactive graph with no extra bridging.
+`@ilha/store` is a shared reactive store for Ilha apps. It lives outside any island and is backed by [alien-signals](https://github.com/stackblitz/alien-signals) — the same engine that powers ilha core state — so stores and islands share a single reactive graph with no extra bridging.
 
 It also ships a `/form` subpath with unopinionated, type-safe form helpers built on [Standard Schema](https://standardschema.dev), compatible with Zod, Valibot, ArkType, and any other compliant library.
 
 ## How it relates to ilha
 
-ilha state is **island-local** — signals are scoped to a single component instance. `@ilha/store` adds a layer of **shared global state** that any island (or any non-island code) can read and write. A store is a plain object with `getState`, `setState`, `subscribe`, and `bind` — no context providers, no wrapping components, no framework lock-in.
+ilha state is **island-local** — signals are scoped to a single component instance. `@ilha/store` adds a layer of **shared global state** that any island (or any non-island code) can read and write. A store is a plain object with `getState`, `setState`, `subscribe`, `select`, and `bind` (for Ilha `bind:*` fields) — no context providers, no wrapping components, no framework lock-in.
 
 ## Install
 
-<PackageManagerTabs command="install @ilha/store" />
+<PackageManagerTabs command="install @ilha/store ilha" />
+
+`@ilha/store` lists `ilha` as a peer dependency (optional at install time). Island apps should depend on both so `select` / `bind` accessors work with `bind:*` in templates.
 
 ## Quick start
 
@@ -145,52 +147,45 @@ const unsub = store.subscribe(
 );
 ```
 
-### `store.bind(el, render)`
+### `store.select(selector)` — reactive read
 
-Reactively renders store-driven markup into a DOM element whenever state changes. The render function may return JSX, a plain string, or any `RawHtml` value. Runs immediately on call to set initial content.
+Projects a slice into a signal-shaped `() => S` accessor. Use inside island `.render()` (or `.derived()` / `.effect()`) so Ilha tracks store changes and re-renders automatically.
+
+```ts
+const count = store.select((s) => s.count);
+count(); // read; reactive in render scopes
+```
+
+Hoist `select` (and `bind`) at module scope — each call allocates a fresh computed.
+
+### `store.bind(selector)` — two-way `bind:*`
+
+Returns a read/write accessor for a **property path** only (`s => s.search.query`), marked for Ilha `bind:value`, `bind:checked`, `bind:open`, etc. Use `select` for read-only lists and derived UI.
 
 ```tsx
 /** @jsxImportSource ilha */
 // ---cut---
-const unsub = store.bind(document.getElementById("counter")!, (state) => (
-  <p>Count: {state.count}</p>
-));
+const cartStore = createStore({ name: "" });
+const name = cartStore.bind((s) => s.name);
 
-unsub(); // detach
+export const Field = ilha.render(() => <input bind:value={name} />);
 ```
 
-### `store.bind(el, selector, render)` — slice bind
-
-Only re-renders when the selected slice changes.
-
-```tsx
-/** @jsxImportSource ilha */
-// ---cut---
-store.bind(
-  document.getElementById("badge")!,
-  (s) => s.count,
-  (count) => <span>{count}</span>,
-);
-```
-
-Both forms assign to `el.innerHTML`. Binding two selectors to the same element is allowed — each bind effect is independent, and the last write wins whenever both fire.
+`bind(selector)` does not render HTML into arbitrary DOM nodes — use islands + `select` for display.
 
 ---
 
 ## `effectScope`
 
-Re-exported from alien-signals. Runs a setup function inside a reactive scope and returns a `stop()` function that tears down every `subscribe` and `bind` effect registered inside it in one call. Use this when you need to mount and unmount a group of store consumers together.
+Re-exported from alien-signals. Runs a setup function inside a reactive scope and returns `stop()` to tear down every `subscribe` effect registered inside it.
 
 ```ts
 import { createStore, effectScope } from "@ilha/store";
 
 const stop = effectScope(() => {
   store.subscribe((s) => console.log(s.count));
-  store.bind(document.getElementById("count")!, (s) => `${s.count}`);
-  store.bind(document.getElementById("name")!, (s) => s.name);
 });
 
-// Later — stops all three effects at once:
 stop();
 ```
 
@@ -198,7 +193,7 @@ stop();
 
 ## Usage with ilha islands
 
-The standard pattern is subscribing to a store slice inside an island's `.effect()` and driving a local signal from it. The `.effect()` cleanup return keeps things tidy on unmount.
+Prefer `store.select()` inside `.render()` so the island subscribes to the store through the same reactive graph as island state — no manual `.effect()` bridge unless you need imperative sync.
 
 ```tsx
 /** @jsxImportSource ilha */
@@ -215,24 +210,18 @@ export const cartStore = createStore({ items: [] as string[] }, (set, get) => ({
   },
 }));
 
-export const CartIsland = ilha
-  .state("items", cartStore.getState().items)
-  .effect(({ state }) => {
-    return cartStore.subscribe(
-      (s) => s.items,
-      (items) => state.items(items),
-    );
-  })
-  .render(({ state }) => (
-    <ul>
-      {state.items().map((item) => (
-        <li>{item}</li>
-      ))}
-    </ul>
-  ));
+const items = cartStore.select((s) => s.items);
+
+export const CartIsland = ilha.render(() => (
+  <ul>
+    {items().map((item) => (
+      <li>{item}</li>
+    ))}
+  </ul>
+));
 ```
 
-When the store updates, the slice subscription fires, the island signal updates, and ilha re-renders only the affected DOM — no manual wiring needed.
+When the store updates, accessors read in render re-run the island and Ilha updates the DOM.
 
 ---
 

--- a/apps/website/docs/guide/libraries/store.mdx
+++ b/apps/website/docs/guide/libraries/store.mdx
@@ -193,7 +193,7 @@ stop();
 
 ## Usage with ilha islands
 
-Prefer `store.select()` inside `.render()` so the island subscribes to the store through the same reactive graph as island state — no manual `.effect()` bridge unless you need imperative sync.
+Prefer reading the accessor inside `.render()` so the island subscribes to the store through the same reactive graph as island state — no manual `.effect()` bridge unless you need imperative sync.
 
 ```tsx
 /** @jsxImportSource ilha */

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -12,7 +12,7 @@
     "@codesandbox/sandpack-react": "^2.20.0",
     "areia": "^0.1.6",
     "dedent": "^1.7.2",
-    "ilha": "0.7.0",
+    "ilha": "0.8.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "shiki": "^4.0.2",
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@fontsource-variable/geist": "^5.2.8",
     "@fontsource-variable/geist-mono": "^5.2.7",
-    "@ilha/router": "0.6.2",
+    "@ilha/router": "0.6.3",
     "@rspress/core": "^2.0.11",
     "@rspress/plugin-llms": "^2.0.11",
     "@rspress/plugin-sitemap": "^2.0.11",

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
       "devDependencies": {
         "@fontsource-variable/geist": "^5.2.8",
         "@fontsource-variable/geist-mono": "^5.2.7",
-        "@ilha/router": "0.5.0",
+        "@ilha/router": "0.6.2",
         "@rspress/core": "^2.0.11",
         "@rspress/plugin-llms": "^2.0.11",
         "@rspress/plugin-sitemap": "^2.0.11",
@@ -56,7 +56,7 @@
     },
     "packages/router": {
       "name": "@ilha/router",
-      "version": "0.5.1",
+      "version": "0.6.2",
       "dependencies": {
         "ilha": "0.7.1",
         "rou3": "0.8.1",
@@ -68,14 +68,20 @@
     },
     "packages/store": {
       "name": "@ilha/store",
-      "version": "0.3.8",
+      "version": "0.4.0",
       "dependencies": {
         "alien-signals": "3.2.1",
-        "ilha": "0.5.0",
       },
       "devDependencies": {
+        "ilha": "0.7.1",
         "zod": "^4.4.3",
       },
+      "peerDependencies": {
+        "ilha": ">=0.7.0",
+      },
+      "optionalPeers": [
+        "ilha",
+      ],
     },
   },
   "packages": {
@@ -1050,8 +1056,6 @@
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "vite/rolldown": ["rolldown@1.0.2", "", { "dependencies": { "@oxc-project/types": "=0.132.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.2", "@rolldown/binding-darwin-arm64": "1.0.2", "@rolldown/binding-darwin-x64": "1.0.2", "@rolldown/binding-freebsd-x64": "1.0.2", "@rolldown/binding-linux-arm-gnueabihf": "1.0.2", "@rolldown/binding-linux-arm64-gnu": "1.0.2", "@rolldown/binding-linux-arm64-musl": "1.0.2", "@rolldown/binding-linux-ppc64-gnu": "1.0.2", "@rolldown/binding-linux-s390x-gnu": "1.0.2", "@rolldown/binding-linux-x64-gnu": "1.0.2", "@rolldown/binding-linux-x64-musl": "1.0.2", "@rolldown/binding-openharmony-arm64": "1.0.2", "@rolldown/binding-wasm32-wasi": "1.0.2", "@rolldown/binding-win32-arm64-msvc": "1.0.2", "@rolldown/binding-win32-x64-msvc": "1.0.2" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g=="],
-
-    "website/@ilha/router": ["@ilha/router@0.5.0", "", { "dependencies": { "ilha": "0.7.0", "rou3": "0.8.1", "unplugin": "3.0.0" } }, "sha512-988ct3A/uaR9SJuZSK/wcQpLFuyp+jWmaeC7d/lnM9SIu2SBy4L36ajSW5BbrSkigGDwNNN/jCkRPo3ZdG5n7A=="],
 
     "website/ilha": ["ilha@0.7.0", "", { "dependencies": { "alien-signals": "3.2.1" } }, "sha512-ospMnQ9Faw66dVyTE1kNkcmvBilNbEzp7ppmR10xs1AuYAoyw8eHmupUkYOHQKo2Fg38FeHdf/KyNRG+yu6MMQ=="],
 

--- a/packages/ilha/package.json
+++ b/packages/ilha/package.json
@@ -1,7 +1,23 @@
 {
   "name": "ilha",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "A tiny, framework-free island architecture library",
+  "keywords": [
+    "framework-free",
+    "frontend",
+    "hydration",
+    "island-architecture",
+    "islands",
+    "jsx",
+    "reactive",
+    "signals",
+    "ssr",
+    "web-components"
+  ],
+  "homepage": "https://github.com/ilhajs/ilha#readme",
+  "bugs": {
+    "url": "https://github.com/ilhajs/ilha/issues"
+  },
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",
   "repository": {
@@ -12,9 +28,12 @@
     "dist"
   ],
   "type": "module",
+  "sideEffects": false,
+  "module": "./dist/index.js",
   "browser": {
     "process": false
   },
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -28,6 +47,9 @@
       "types": "./dist/jsx-dev-runtime.d.ts",
       "import": "./dist/jsx-dev-runtime.js"
     }
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "scripts": {
     "build": "tsc && tsdown",

--- a/packages/ilha/src/index.test.ts
+++ b/packages/ilha/src/index.test.ts
@@ -14,6 +14,7 @@ import ilha, {
   untrack,
   type SignalAccessor,
 } from "./index";
+import * as mainExports from "./index";
 
 // ---------------------------------------------
 // Helpers
@@ -50,6 +51,36 @@ function makeEl(inner = ""): Element {
 function cleanup(el: Element) {
   document.body.removeChild(el);
 }
+
+// ---------------------------------------------
+// Public entry shape
+// ---------------------------------------------
+
+describe("public entry shape", () => {
+  it("main entry does not expose JSX runtime helpers", () => {
+    expect("jsx" in ilha).toBe(false);
+    expect("jsxs" in ilha).toBe(false);
+    expect("jsxDEV" in ilha).toBe(false);
+    expect("Fragment" in ilha).toBe(false);
+    expect("jsx" in mainExports).toBe(false);
+    expect("jsxs" in mainExports).toBe(false);
+    expect("jsxDEV" in mainExports).toBe(false);
+    expect("Fragment" in mainExports).toBe(false);
+  });
+
+  it("main entry keeps the expected runtime helpers", () => {
+    expect(typeof mainExports.default.render).toBe("function");
+    expect(typeof mainExports.html).toBe("function");
+    expect(typeof mainExports.raw).toBe("function");
+    expect(typeof mainExports.css).toBe("function");
+    expect(typeof mainExports.mount).toBe("function");
+    expect(typeof mainExports.from).toBe("function");
+    expect(typeof mainExports.context).toBe("function");
+    expect(typeof mainExports.signal).toBe("function");
+    expect(typeof mainExports.batch).toBe("function");
+    expect(typeof mainExports.untrack).toBe("function");
+  });
+});
 
 // ---------------------------------------------
 // html`` tagged template
@@ -1739,6 +1770,13 @@ describe("Island mount", () => {
         expect(result).toMatch(/<\/section>$/);
       });
 
+      it("rejects invalid hydratable as tag names", async () => {
+        const Counter = ilha.render(() => `<p>ok</p>`);
+        await expect(Counter.hydratable({}, { name: "Counter", as: "bad tag" })).rejects.toThrow(
+          /valid HTML element name/,
+        );
+      });
+
       it("defaults to a div wrapper when 'as' is not provided", async () => {
         const Counter = ilha
           .input(z.object({ count: z.number().default(0) }))
@@ -2359,6 +2397,104 @@ describe("ilha.mount()", () => {
     expect(elB.innerHTML).toBe("<b>hello Ada</b>");
     unmount();
   });
+
+  it("lazy mount waits for IntersectionObserver before activating", () => {
+    let callback!: IntersectionObserverCallback;
+    const observed: Element[] = [];
+    const original = globalThis.IntersectionObserver;
+    class FakeIntersectionObserver {
+      constructor(cb: IntersectionObserverCallback) {
+        callback = cb;
+      }
+      observe(el: Element) {
+        observed.push(el);
+      }
+      unobserve(el: Element) {
+        const i = observed.indexOf(el);
+        if (i >= 0) observed.splice(i, 1);
+      }
+      disconnect() {
+        observed.length = 0;
+      }
+    }
+    globalThis.IntersectionObserver =
+      FakeIntersectionObserver as unknown as typeof IntersectionObserver;
+
+    try {
+      const Counter = ilha.state("count", 1).render(({ state }) => `<p>${state.count()}</p>`);
+      const el = document.createElement("div");
+      el.setAttribute("data-ilha", "Counter");
+      document.body.appendChild(el);
+
+      const { unmount } = mount({ Counter }, { lazy: true });
+      expect(el.innerHTML).toBe("");
+      expect(observed).toEqual([el]);
+
+      callback(
+        [{ target: el, isIntersecting: true } as unknown as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+      expect(el.innerHTML).toBe("<p>1</p>");
+      expect(observed).toEqual([]);
+      unmount();
+    } finally {
+      globalThis.IntersectionObserver = original;
+    }
+  });
+
+  it("lazy mount disconnects and ignores future intersections after unmount", () => {
+    let callback!: IntersectionObserverCallback;
+    let disconnected = false;
+    const original = globalThis.IntersectionObserver;
+    class FakeIntersectionObserver {
+      constructor(cb: IntersectionObserverCallback) {
+        callback = cb;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {
+        disconnected = true;
+      }
+    }
+    globalThis.IntersectionObserver =
+      FakeIntersectionObserver as unknown as typeof IntersectionObserver;
+
+    try {
+      const Counter = ilha.state("count", 1).render(({ state }) => `<p>${state.count()}</p>`);
+      const el = document.createElement("div");
+      el.setAttribute("data-ilha", "Counter");
+      document.body.appendChild(el);
+
+      const { unmount } = mount({ Counter }, { lazy: true });
+      unmount();
+      expect(disconnected).toBe(true);
+      callback(
+        [{ target: el, isIntersecting: true } as unknown as IntersectionObserverEntry],
+        {} as IntersectionObserver,
+      );
+      expect(el.innerHTML).toBe("");
+    } finally {
+      globalThis.IntersectionObserver = original;
+    }
+  });
+
+  it("lazy mount falls back to immediate activation when IntersectionObserver is unavailable", () => {
+    const original = globalThis.IntersectionObserver;
+    // @ts-expect-error simulates older runtimes without IntersectionObserver
+    globalThis.IntersectionObserver = undefined;
+    try {
+      const Counter = ilha.state("count", 1).render(({ state }) => `<p>${state.count()}</p>`);
+      const el = document.createElement("div");
+      el.setAttribute("data-ilha", "Counter");
+      document.body.appendChild(el);
+
+      const { unmount } = mount({ Counter }, { lazy: true });
+      expect(el.innerHTML).toBe("<p>1</p>");
+      unmount();
+    } finally {
+      globalThis.IntersectionObserver = original;
+    }
+  });
 });
 
 // ---------------------------------------------
@@ -2566,6 +2702,113 @@ describe("child islands (render-time composition)", () => {
     cleanup(el);
   });
 
+  describe(".as()", () => {
+    it("default embedded island uses div slot wrapper", () => {
+      const Child = ilha.render(() => `<em>x</em>`);
+      const Parent = ilha.render(() => html`<div>${Child}</div>`);
+      expect(Parent()).toBe(`<div><div data-ilha-slot="p:0"><em>x</em></div></div>`);
+    });
+
+    it("SSR uses span slot wrapper when .as('span')", () => {
+      const Age = ilha
+        .as("span")
+        .state("age", 0)
+        .render(({ state }) => html`${state.age()}`);
+      const Parent = ilha.render(() => html`<p>Age: ${Age}</p>`);
+      expect(Parent()).toBe(`<p>Age: <span data-ilha-slot="p:0">0</span></p>`);
+    });
+
+    it("SSR uses li slot wrapper when .as('li')", () => {
+      const Row = ilha
+        .as("li")
+        .state("label", "a")
+        .render(({ state }) => html`${state.label()}`);
+      const Parent = ilha.render(() => html`<ul>${Row}</ul>`);
+      expect(Parent()).toBe(`<ul><li data-ilha-slot="p:0">a</li></ul>`);
+    });
+
+    it("client mount: span slot host runs effects and updates DOM", () => {
+      const Age = ilha
+        .as("span")
+        .state("age", 0)
+        .effect(({ state }) => {
+          state.age(1);
+        })
+        .render(({ state }) => html`${state.age()}`);
+
+      const Parent = ilha.render(() => html`<div>${Age}</div>`);
+
+      const el = makeEl();
+      const unmount = Parent.mount(el);
+      const slot = el.querySelector("span[data-ilha-slot='p:0']");
+      expect(slot).not.toBeNull();
+      expect(slot!.textContent).toBe("1");
+      unmount();
+      cleanup(el);
+    });
+
+    it("SSR awaited async child preserves .as('span') wrapper", async () => {
+      const Child = ilha
+        .as("span")
+        .derived("msg", async () => "resolved")
+        .render(({ derived }) => html`${derived.msg.loading ? "loading" : derived.msg.value}`);
+
+      const Parent = ilha.derived("ready", async () => true).render(() => html`<p>${Child}</p>`);
+
+      await expect(Parent()).resolves.toBe(`<p><span data-ilha-slot="p:0">resolved</span></p>`);
+    });
+
+    it("span slot is preserved while prop updates re-render the child", () => {
+      let setLabel!: (v?: string) => string | void;
+      const Child = ilha
+        .input<{ label: string }>()
+        .as("span")
+        .render(({ input }) => html`${input.label}`);
+      const Parent = ilha.state("label", "a").render(({ state }) => {
+        setLabel = state.label as typeof setLabel;
+        return html`<div>${Child({ label: state.label() })}</div>`;
+      });
+
+      const el = makeEl();
+      const unmount = Parent.mount(el);
+      const slot = el.querySelector("span[data-ilha-slot='p:0']")!;
+      expect(slot.textContent).toBe("a");
+      setLabel("b");
+      expect(el.querySelector("span[data-ilha-slot='p:0']")).toBe(slot);
+      expect(slot.textContent).toBe("b");
+      unmount();
+      cleanup(el);
+    });
+
+    it("rejects invalid .as() tag names", () => {
+      expect(() => ilha.as("")).toThrow(/non-empty/);
+      expect(() => ilha.as("   ")).toThrow(/non-empty/);
+      expect(() => ilha.as("not a tag")).toThrow(/valid HTML element name/);
+      expect(() => ilha.as("123")).toThrow(/valid HTML element name/);
+    });
+
+    it("nested mixed slot tags mount and stay interactive", () => {
+      const Inner = ilha
+        .as("span")
+        .state("n", 0)
+        .on("[data-inc]@click", ({ state }) => state.n(state.n() + 1))
+        .render(({ state }) => html`${state.n()}<button data-inc>+</button>`);
+
+      const Outer = ilha.as("section").render(() => html`<div>${Inner}</div>`);
+
+      const Parent = ilha.render(() => html`<main>${Outer}</main>`);
+
+      const el = makeEl();
+      const unmount = Parent.mount(el);
+      expect(el.querySelector("section[data-ilha-slot='p:0']")).not.toBeNull();
+      expect(el.querySelector("span[data-ilha-slot='p:0']")).not.toBeNull();
+      el.querySelector<HTMLButtonElement>("[data-inc]")!.click();
+      expect(el.querySelector("span[data-ilha-slot='p:0']")!.textContent).toContain("1");
+      unmount();
+      cleanup(el);
+    });
+  });
+
   // .key() — explicit keys for stable identity across re-renders, required when
   // positional order is not reliable (reorderable lists, conditional children).
   describe(".key()", () => {
@@ -2621,6 +2864,36 @@ describe("child islands (render-time composition)", () => {
       // Child state survives.
       expect(slotA.querySelector("li")!.textContent).toBe("1+");
 
+      unmount();
+      cleanup(el);
+    });
+
+    it("keyed .as('li') children emit li slots and preserve identity across reorder", () => {
+      const Item = ilha
+        .input<{ label: string }>()
+        .as("li")
+        .state("n", 0)
+        .on("[data-bump]@click", ({ state }) => state.n(state.n() + 1))
+        .render(
+          ({ input, state }) => html`${input.label}:${state.n()}<button data-bump>+</button>`,
+        );
+
+      let setOrder!: (v: string[]) => void;
+      const List = ilha.state<string[]>("order", ["a", "b"]).render(({ state }) => {
+        setOrder = state.order as unknown as typeof setOrder;
+        return html`<ul>${state.order().map((k) => Item.key(k)({ label: k }))}</ul>`;
+      });
+
+      expect(List.toString()).toContain(`<li data-ilha-slot="k:a"`);
+
+      const el = makeEl();
+      const unmount = List.mount(el);
+      const slotA = el.querySelector("li[data-ilha-slot='k:a']")!;
+      slotA.querySelector<HTMLButtonElement>("[data-bump]")!.click();
+      expect(slotA.textContent).toContain("a:1");
+      setOrder(["b", "a"]);
+      expect(el.querySelector("li[data-ilha-slot='k:a']")).toBe(slotA);
+      expect(slotA.textContent).toContain("a:1");
       unmount();
       cleanup(el);
     });
@@ -4909,7 +5182,8 @@ describe("bind: template syntax", () => {
     });
 
     it("warns when bind: target is not a signal accessor", () => {
-      html`<input bind:value=${"plain string"}>`;
+      const result = html`<input bind:value=${"plain string"}>`;
+      expect(result.value).toBe("<input bind:value=plain string>");
       const msgs = warnSpy.mock.calls.map((c: unknown[]) => String(c[0]));
       expect(msgs.some((m: string) => m.includes("requires a signal accessor"))).toBe(true);
     });
@@ -6308,6 +6582,28 @@ describe(".css()", () => {
       // Two separate @scope wrappers, one per Island
       const scopeCount = (out.match(/@scope \(:scope\) to \(\[data-ilha\]\)/g) ?? []).length;
       expect(scopeCount).toBe(2);
+    });
+
+    it("Child Island with .as('span') keeps scoped style inside span slot across re-render", () => {
+      const Inner = ilha
+        .as("span")
+        .state("n", 0)
+        .on("button@click", ({ state }) => state.n(state.n() + 1))
+        .css("button { color: red; }")
+        .render(({ state }) => html`${state.n()}<button>+</button>`);
+      const Outer = ilha.render(() => html`<div>${Inner}</div>`);
+
+      const el = makeEl();
+      const unmount = Outer.mount(el);
+      const slot = el.querySelector("span[data-ilha-slot='p:0']")!;
+      const style = slot.querySelector("style[data-ilha-css]")!;
+      expect(style.textContent).toContain("button { color: red; }");
+      slot.querySelector<HTMLButtonElement>("button")!.click();
+      expect(el.querySelector("span[data-ilha-slot='p:0']")).toBe(slot);
+      expect(slot.querySelector("style[data-ilha-css]")).toBe(style);
+      expect(slot.textContent).toContain("1+");
+      unmount();
+      cleanup(el);
     });
 
     it("does not interfere with .toString() synchronous contract when derived are async", () => {

--- a/packages/ilha/src/index.ts
+++ b/packages/ilha/src/index.ts
@@ -99,12 +99,39 @@ function extractDirectChildSlotIdsInOrder(html: string): string[] {
 function extractSlotPropsAttr(html: string, slotId: string): string | null {
   const escaped = slotId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const withProps = new RegExp(
-    `<div\\s[^>]*data-ilha-slot="${escaped}"[^>]*data-ilha-props='([^']*)'`,
+    `<[a-z][a-z0-9-]*\\s[^>]*data-ilha-slot="${escaped}"[^>]*data-ilha-props='([^']*)'`,
+    "i",
   );
   const m = html.match(withProps);
   if (m) return m[1]!;
-  const withoutProps = new RegExp(`<div\\s[^>]*data-ilha-slot="${escaped}"`);
+  const withoutProps = new RegExp(`<[a-z][a-z0-9-]*\\s[^>]*data-ilha-slot="${escaped}"`, "i");
   return html.match(withoutProps) ? "" : null;
+}
+
+const SLOT_TAG_NAME_RE = /^[a-z][a-z0-9-]*$/i;
+
+function assertValidSlotTagName(tag: string): string {
+  const trimmed = tag.trim();
+  if (trimmed.length === 0) {
+    throw new Error("island.as() requires a non-empty HTML tag name.");
+  }
+  if (!SLOT_TAG_NAME_RE.test(trimmed)) {
+    throw new Error(
+      `island.as() tag must be a valid HTML element name (got "${tag}"). ` +
+        `Use names like "span", "div", or "li".`,
+    );
+  }
+  return trimmed.toLowerCase();
+}
+
+function getIslandSlotTag(island: AnyIsland): string {
+  const tag = (island as unknown as Record<symbol, unknown>)[ISLAND_SLOT_TAG];
+  if (typeof tag === "string" && tag.length > 0) return tag;
+  return "div";
+}
+
+function wrapIslandSlotHtml(tag: string, id: string, propsAttr: string, inner: string): string {
+  return `<${tag} ${SLOT_ATTR}="${escapeHtml(id)}"${propsAttr}>${inner}</${tag}>`;
 }
 
 function isStableInlineSlotMount(
@@ -292,6 +319,7 @@ const ISLAND_CALL = Symbol.for("ilha.islandCall");
  * retain a handle to push updated props into it on subsequent parent
  * re-renders. Not part of the public surface. */
 export const ISLAND_MOUNT_INTERNAL = Symbol.for("ilha.islandMountInternal");
+const ISLAND_SLOT_TAG = Symbol.for("ilha.islandSlotTag");
 
 const SLOT_ATTR = "data-ilha-slot";
 const PROPS_ATTR = "data-ilha-props";
@@ -333,8 +361,9 @@ export interface RawHtml {
 //      positional based on appearance order within the current render frame.
 //   2. Records { id -> { island, props } } in the active RenderContext so the
 //      parent's mount pass can look it up and mount the child onto the slot.
-//   3. Emits <div data-ilha-slot="{id}" data-ilha-props="...">{child SSR}</div>
-//      — the data-* attributes let hydration recover props without the map.
+//   3. Emits <tag data-ilha-slot="{id}" data-ilha-props="...">{child SSR}</tag>
+//      (tag from child island .as(), default div) — data-* attrs let hydration
+//      recover props without the map.
 //
 // Nested islands: each island's renderToString pushes its own RenderContext
 // onto the stack, so child-of-child interpolations are scoped to the correct
@@ -367,6 +396,8 @@ interface IslandRenderCtx {
   // here, and emits a data-ilha-bind sentinel attribute referencing the
   // entry by index. Mount-time wiring reads these back out.
   binds: BindRecord[];
+  // Slot id -> wrapper tag recorded during emitIslandSlot (async SSR substitution).
+  slotTags: Map<string, string>;
 }
 
 type BindKind =
@@ -393,6 +424,7 @@ function pushRenderCtx(liveHost?: Element, asyncChildren?: boolean): IslandRende
     liveHost,
     pending: asyncChildren ? new Map() : undefined,
     binds: [],
+    slotTags: new Map(),
   };
   renderCtxStack.push(ctx);
   return ctx;
@@ -459,6 +491,9 @@ function emitIslandSlot(
 
   if (ctx) ctx.slots.set(id, { island, props });
 
+  const slotTag = getIslandSlotTag(island);
+  if (ctx) ctx.slotTags.set(id, slotTag);
+
   const propsAttr = props ? ` ${PROPS_ATTR}='${escapeHtml(JSON.stringify(props))}'` : "";
 
   // Client re-render path: emit an EMPTY stub. Post-morph, mountSlots rehomes
@@ -468,7 +503,7 @@ function emitIslandSlot(
   // thing afterwards. New (not-yet-mounted) slots stay as stubs and get mounted
   // by mountSlots.
   if (ctx?.liveHost) {
-    return `<div ${SLOT_ATTR}="${escapeHtml(id)}"${propsAttr}></div>`;
+    return wrapIslandSlotHtml(slotTag, id, propsAttr, "");
   }
 
   // SSR path: render the child's HTML inline.
@@ -488,11 +523,11 @@ function emitIslandSlot(
         ctx.pending.set(id, result.then(String));
         // Emit a placeholder stub; resolveAsyncChildren will substitute the
         // resolved inner HTML after all children have been awaited.
-        return `<div ${SLOT_ATTR}="${escapeHtml(id)}"${propsAttr}></div>`;
+        return wrapIslandSlotHtml(slotTag, id, propsAttr, "");
       }
 
       // Child rendered synchronously — inline its HTML as usual.
-      return `<div ${SLOT_ATTR}="${escapeHtml(id)}"${propsAttr}>${result}</div>`;
+      return wrapIslandSlotHtml(slotTag, id, propsAttr, String(result));
     } finally {
       renderCtxStack.push(ctx);
     }
@@ -501,7 +536,7 @@ function emitIslandSlot(
   // Sync SSR path (no async children support). The child's renderToString
   // pushes its own render context so grandchildren are scoped correctly.
   const inner = island.toString(props);
-  return `<div ${SLOT_ATTR}="${escapeHtml(id)}"${propsAttr}>${inner}</div>`;
+  return wrapIslandSlotHtml(slotTag, id, propsAttr, inner);
 }
 
 // After the parent's render function has produced HTML with placeholder stubs
@@ -510,8 +545,9 @@ function emitIslandSlot(
 async function resolveAsyncChildren(html: string, ctx: IslandRenderCtx): Promise<string> {
   for (const [id, promise] of ctx.pending!) {
     const inner = await promise;
+    const tag = ctx.slotTags.get(id) ?? "div";
     // The placeholder is an empty stub
-    //   <div data-ilha-slot="…" data-ilha-props="…"></div>
+    //   <tag data-ilha-slot="…" data-ilha-props="…"></tag>
     // Replace it with the same tag but containing the resolved inner HTML.
     const escaped = escapeHtml(id);
     // Guard against ReDoS from pathologically long slot ids.
@@ -520,13 +556,15 @@ async function resolveAsyncChildren(html: string, ctx: IslandRenderCtx): Promise
         `Slot id exceeds safe length for regex replacement (${escaped.length} > 500).`,
       );
     }
-    // Build a regex that matches the empty slot div for this id.
-    // Pattern: <div ... data-ilha-slot="ESCAPED" ...></div>
     const attrPattern = escaped.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const placeholder = new RegExp(`<div\\s[^>]*${SLOT_ATTR}="${attrPattern}"[^>]*></div>`, "g");
+    const tagPattern = tag.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const placeholder = new RegExp(
+      `<${tagPattern}\\s[^>]*${SLOT_ATTR}="${attrPattern}"[^>]*></${tagPattern}>`,
+      "g",
+    );
     html = html.replace(placeholder, (match) => {
-      // Slice off `></div>` (last 6 chars) and insert inner HTML.
-      return match.slice(0, -6) + `>${inner}</div>`;
+      const suffix = `></${tag}>`;
+      return match.slice(0, -suffix.length) + `>${inner}</${tag}>`;
     });
   }
   return html;
@@ -679,231 +717,6 @@ function ilhaCss(strings: TemplateStringsArray | string, ...values: (string | nu
 }
 
 // ---------------------------------------------
-// JSX runtime
-// ---------------------------------------------
-
-type JsxChild = unknown;
-type JsxProps = Record<string, unknown> | null | undefined;
-type JsxType = string | ((props: Record<string, unknown>) => unknown);
-
-const SAFE_NAME_RE = /^[A-Za-z_:][A-Za-z0-9:._-]*$/;
-const SAFE_BIND_LOCAL_RE = /^[A-Za-z][A-Za-z0-9]*$/;
-const VOID_ELEMENTS = new Set([
-  "area",
-  "base",
-  "br",
-  "col",
-  "embed",
-  "hr",
-  "img",
-  "input",
-  "link",
-  "meta",
-  "param",
-  "source",
-  "track",
-  "wbr",
-]);
-
-// Allows standard CSS properties and CSS custom properties (--*)
-const SAFE_CSS_PROP_RE = /^(-{2}[a-zA-Z][a-zA-Z0-9-]*|-?[a-zA-Z][a-zA-Z0-9-]*)$/;
-
-const URL_ATTRS = new Set(["href", "src", "action", "formaction", "cite", "data", "poster"]);
-const SAFE_URL_RE =
-  /^(?!javascript:|data:text\/html|data:text\/xml|data:application\/xhtml\+xml|data:image\/svg|vbscript:)/i;
-
-function normalizeClass(value: unknown): string {
-  if (Array.isArray(value)) return value.filter(Boolean).join(" ");
-  if (value && typeof value === "object") {
-    return Object.entries(value as Record<string, unknown>)
-      .filter(([, enabled]) => Boolean(enabled))
-      .map(([name]) => name)
-      .join(" ");
-  }
-  return String(value);
-}
-
-function normalizeJsxChildren(props: JsxProps, children: JsxChild[]): JsxChild[] {
-  const propChildren = props && "children" in props ? props.children : undefined;
-  const all = children.length > 0 ? children : propChildren === undefined ? [] : [propChildren];
-  return all.flat(1);
-}
-
-function normalizeJsxSlotKey(raw: string | number): string {
-  const key = String(raw);
-  if (key.trim().length === 0) {
-    throw new Error("jsx key requires a non-empty string.");
-  }
-  if (key.includes(":")) {
-    throw new Error(`jsx key cannot contain the slot separator ":" (got "${key}").`);
-  }
-  return key;
-}
-
-/** React-style `key` (props or 3rd jsx arg) on island components → `k:{key}` slot ids. */
-function extractJsxSlotKey(props: JsxProps, keyArg?: string | number): string | undefined {
-  const fromProps = props?.key;
-  const raw =
-    keyArg ??
-    (typeof fromProps === "string" || typeof fromProps === "number" ? fromProps : undefined);
-  if (raw == null) return undefined;
-  return normalizeJsxSlotKey(raw);
-}
-
-function serializeStyle(value: Record<string, unknown>): string {
-  return Object.entries(value)
-    .map(([k, v]) => {
-      if (!SAFE_CSS_PROP_RE.test(k)) return "";
-      const prop = k.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
-      let safeV = String(v).replace(/["<>{};]/g, "");
-      // Block IE expression() and javascript: URLs in style values
-      if (/expression\(/i.test(safeV) || /^javascript:/i.test(safeV)) {
-        return "";
-      }
-      return `${prop}:${safeV}`;
-    })
-    .filter(Boolean)
-    .join(";");
-}
-
-function pushJsxAttr(chunks: string[], values: unknown[], name: string, value: unknown): void {
-  if (value == null || value === false || name === "children" || name === "key") return;
-  if (name === "__proto__" || name === "constructor" || name === "prototype") return;
-
-  if (name.startsWith("bind:")) {
-    const [prefix, localName, ...rest] = name.split(":");
-    if (prefix !== "bind" || rest.length > 0 || !localName || !SAFE_BIND_LOCAL_RE.test(localName)) {
-      return;
-    }
-    if (!isSignalAccessor(value)) return;
-
-    const safeName = `${prefix}:${localName}`;
-    chunks[chunks.length - 1] += ` ${safeName}=`;
-    values.push(value);
-    chunks.push("");
-    return;
-  }
-
-  if (!SAFE_NAME_RE.test(name)) return;
-
-  let safeName = name;
-  if (safeName === "className") safeName = "class";
-  if (safeName === "htmlFor") safeName = "for";
-  if (safeName.startsWith("on")) return;
-  if (safeName === "class") value = normalizeClass(value);
-  if (safeName === "style" && value && typeof value === "object") {
-    value = serializeStyle(value as Record<string, unknown>);
-  }
-  if (
-    (URL_ATTRS.has(safeName) || /:(href|src|action|formaction|cite|data|poster)$/.test(safeName)) &&
-    typeof value === "string" &&
-    !SAFE_URL_RE.test(value.trim())
-  ) {
-    return;
-  }
-
-  if (value === true) {
-    chunks[chunks.length - 1] += ` ${safeName}`;
-    return;
-  }
-
-  chunks[chunks.length - 1] += ` ${safeName}="`;
-  values.push(value);
-  chunks.push('"');
-}
-
-function renderJsxElement(type: string, props: JsxProps, children: JsxChild[]): RawHtml {
-  const chunks = [`<${type}`];
-  const values: unknown[] = [];
-
-  if (props) {
-    for (const [name, value] of Object.entries(props)) pushJsxAttr(chunks, values, name, value);
-  }
-
-  chunks[chunks.length - 1] += ">";
-
-  if (!VOID_ELEMENTS.has(type)) {
-    for (const child of children) {
-      values.push(child);
-      chunks.push("");
-    }
-    chunks[chunks.length - 1] += `</${type}>`;
-  } else if (children.length > 0 && __DEV__) {
-    warn(`Void element <${type}> should not have children. They will be ignored.`);
-  }
-
-  return ilhaHtml(chunks as unknown as TemplateStringsArray, ...values);
-}
-
-function ilhaJsx(
-  type: JsxType,
-  props: JsxProps,
-  maybeKey?: JsxChild | string | number,
-  ...restChildren: JsxChild[]
-): RawHtml {
-  const hasKeyArg = typeof maybeKey === "string" || typeof maybeKey === "number";
-  const keyFromArg = hasKeyArg ? maybeKey : undefined;
-  // React automatic runtime passes `key` as the 3rd argument (not a child).
-  const children: JsxChild[] =
-    hasKeyArg || maybeKey === undefined ? restChildren : [maybeKey, ...restChildren];
-  const normalizedChildren = normalizeJsxChildren(props, children);
-
-  if (typeof type === "function") {
-    const slotKey = extractJsxSlotKey(
-      props,
-      typeof keyFromArg === "string" || typeof keyFromArg === "number" ? keyFromArg : undefined,
-    );
-    const componentProps: Record<string, unknown> = {
-      ...(props ?? {}),
-      ...(normalizedChildren.length > 0 ? { children: normalizedChildren } : {}),
-    };
-    delete componentProps["key"];
-    const out = type(Object.keys(componentProps).length ? componentProps : {});
-    if (isIslandCall(out)) {
-      if (slotKey !== undefined) (out as IslandCall).key = slotKey;
-      return ilhaHtml`${out}`;
-    }
-    if (isRawHtml(out)) return out;
-    // Another ilha copy (e.g. Areia) didn't see our render ctx and fell back
-    // to renderToString — emit a slot instead of double-escaping the HTML.
-    if (typeof out === "string" && isIsland(type)) {
-      return ilhaRaw(emitIslandSlot(type as AnyIsland, componentProps, slotKey));
-    }
-    if (typeof out === "string") return ilhaHtml`${out}`;
-    // Plain object explicitly marked as a renderable part (e.g. Areia compound-component
-    // parts like ResizablePanel). The marker Symbol.for("ilha.renderPart") must be set
-    // on the object, and toString must be a callable that produces safe HTML.
-    if (
-      typeof out === "object" &&
-      out !== null &&
-      Object.getPrototypeOf(out) === Object.prototype &&
-      (out as Record<symbol, unknown>)[Symbol.for("ilha.renderPart")] === true &&
-      typeof (out as any).toString === "function"
-    ) {
-      return ilhaRaw((out as object).toString());
-    }
-    return ilhaHtml`${out}`;
-  }
-
-  return renderJsxElement(type, props, normalizedChildren);
-}
-
-function ilhaFragment(props: { children?: JsxChild } | null, ...children: JsxChild[]): RawHtml {
-  const normalizedChildren = normalizeJsxChildren(props, children);
-  const chunks = ["", ...normalizedChildren.map(() => "")];
-  return ilhaHtml(chunks as unknown as TemplateStringsArray, ...normalizedChildren);
-}
-
-function ilhaJsxDEV(
-  type: JsxType,
-  props: JsxProps,
-  maybeKey?: string | number,
-  _source?: unknown,
-  _self?: unknown,
-): RawHtml {
-  return ilhaJsx(type, props, maybeKey);
-}
-
 // Resolves any interpolated value to an HTML string.
 // Arrays are joined with "" — each item is recursively resolved.
 // This means string[] is escaped per-item, RawHtml[] is passed through raw,
@@ -2109,6 +1922,8 @@ interface BuilderConfig<
   onErrors: OnErrorEntry<TInput, TStateMap, TDerivedMap>[];
   transition: TransitionOptions | null;
   css: string | null;
+  /** Slot wrapper tag when this island is embedded in a parent (default div). */
+  as: string | null;
 }
 
 // ---------------------------------------------
@@ -2155,7 +1970,12 @@ class IlhaBuilder<
       onErrors: [],
       transition: null,
       css: null,
+      as: null,
     });
+  }
+
+  as<Tag extends string>(tag: Tag): IlhaBuilder<TInput, TStateMap, TDerivedMap> {
+    return new IlhaBuilder({ ...this._cfg, as: assertValidSlotTagName(tag) });
   }
 
   state<V = undefined, K extends string = string>(
@@ -2273,9 +2093,11 @@ class IlhaBuilder<
       onErrors,
       transition,
       css: cssSource,
+      as: slotAs,
     } = this._cfg;
 
     const stylePrefix = cssSource != null ? buildScopedStyle(cssSource) : "";
+    const configuredSlotTag = slotAs ?? "div";
 
     function resolveInput(props?: Partial<TInput>): TInput {
       const value = props ?? {};
@@ -2642,7 +2464,7 @@ class IlhaBuilder<
         if (result instanceof Promise) {
           let stub: Element | undefined;
           if (entry.el.isConnected) {
-            stub = document.createElement("div");
+            stub = document.createElement(entry.el.tagName.toLowerCase());
             stub.setAttribute(SLOT_ATTR, id);
             entry.el.replaceWith(stub);
           }
@@ -3055,7 +2877,8 @@ class IlhaBuilder<
             teardownMountedSlot(id, entry);
             continue;
           }
-          const stub = document.createElement("div");
+          const stubTag = entry.el.tagName.toLowerCase();
+          const stub = document.createElement(stubTag);
           stub.setAttribute(SLOT_ATTR, id);
           const incomingProps = serializeSlotProps(newSlotMap.get(id)?.props);
           if (incomingProps !== "") stub.setAttribute(PROPS_ATTR, incomingProps);
@@ -3064,7 +2887,8 @@ class IlhaBuilder<
         }
 
         const tpl = document.createElement("template");
-        tpl.innerHTML = `<div>${html}</div>`;
+        const morphRootTag = host.tagName.toLowerCase();
+        tpl.innerHTML = `<${morphRootTag}>${html}</${morphRootTag}>`;
         morphInner(host, tpl.content.firstElementChild as Element);
 
         // Rehome preserved slots: swap post-morph stubs back to live elements.
@@ -3169,6 +2993,8 @@ class IlhaBuilder<
       props?: Partial<TInput>,
     ): MountHandle => mountIslandInternal(host, props);
 
+    (island as unknown as Record<symbol, unknown>)[ISLAND_SLOT_TAG] = configuredSlotTag;
+
     // Create a keyed invocation for stable slot identity across re-renders
     // (useful in reorderable lists). Returns a callable that, when given
     // optional props, produces an IslandCall that interpolateValue recognises.
@@ -3195,7 +3021,8 @@ class IlhaBuilder<
       props: Partial<TInput>,
       opts: HydratableOptions,
     ): Promise<string> => {
-      const { name, as: tag = "div", snapshot = false, skipOnMount: explicitSkipOnMount } = opts;
+      const { name, as: rawTag = "div", snapshot = false, skipOnMount: explicitSkipOnMount } = opts;
+      const tag = assertValidSlotTagName(rawTag);
 
       const resolvedProps = props ?? {};
       const inner = await renderToString(resolvedProps);
@@ -3383,6 +3210,7 @@ const EMPTY_CFG: BuilderConfig<
   onErrors: [],
   transition: null,
   css: null,
+  as: null,
 };
 
 const rootBuilder = new IlhaBuilder(EMPTY_CFG);
@@ -3390,10 +3218,6 @@ const rootBuilder = new IlhaBuilder(EMPTY_CFG);
 const ilha = Object.assign(rootBuilder, {
   html: ilhaHtml,
   raw: ilhaRaw,
-  jsx: ilhaJsx,
-  jsxs: ilhaJsx,
-  jsxDEV: ilhaJsxDEV,
-  Fragment: ilhaFragment,
   mount: mountAll,
   from: ilhaFrom,
   context: ilhaContext,
@@ -3402,12 +3226,17 @@ const ilha = Object.assign(rootBuilder, {
   untrack,
 });
 
+/** @internal Used by the separate JSX runtime entry to preserve island slot composition. */
+export function __ilhaJsxSlot(
+  island: unknown,
+  props: Record<string, unknown> | undefined,
+  key: string | undefined,
+): RawHtml {
+  return ilhaRaw(emitIslandSlot(island as AnyIsland, props, key));
+}
+
 export const html = ilhaHtml;
 export const raw = ilhaRaw;
-export const jsx = ilhaJsx;
-export const jsxs = ilhaJsx;
-export const jsxDEV = ilhaJsxDEV;
-export const Fragment = ilhaFragment;
 export const css = ilhaCss;
 export const mount = mountAll;
 export const from = ilhaFrom;

--- a/packages/ilha/src/jsx-dev-runtime.ts
+++ b/packages/ilha/src/jsx-dev-runtime.ts
@@ -1,2 +1,2 @@
-export { Fragment, jsxDEV } from "./index";
+export { Fragment, jsxDEV } from "./jsx-runtime";
 export type { JSX } from "./jsx-types";

--- a/packages/ilha/src/jsx-runtime.test.tsx
+++ b/packages/ilha/src/jsx-runtime.test.tsx
@@ -3,6 +3,9 @@ import { describe, expect, it } from "bun:test";
 import { z } from "zod";
 
 import ilha, { html, raw } from "./index";
+import * as jsxDevRuntime from "./jsx-dev-runtime";
+import { jsx, jsxs } from "./jsx-runtime";
+import * as jsxRuntime from "./jsx-runtime";
 
 function normalizeHtml(s: string | { value: string }): string {
   const str = typeof s === "object" ? s.value : s;
@@ -21,6 +24,15 @@ function cleanup(el: Element): void {
 }
 
 describe("ilha JSX runtime", () => {
+  it("subpath runtime exports JSX helpers", () => {
+    expect(typeof jsxRuntime.jsx).toBe("function");
+    expect(typeof jsxRuntime.jsxs).toBe("function");
+    expect(typeof jsxRuntime.jsxDEV).toBe("function");
+    expect(typeof jsxRuntime.Fragment).toBe("function");
+    expect(typeof jsxDevRuntime.jsxDEV).toBe("function");
+    expect(typeof jsxDevRuntime.Fragment).toBe("function");
+  });
+
   it("renders simple JSX in an ilha island", () => {
     const Greeting = ilha.render(() => <p>Hello, ilha!</p>);
 
@@ -688,7 +700,7 @@ describe("ilha JSX runtime", () => {
   });
 
   it("explicit children prop is overridden by JSX children", () => {
-    const result = ilha.jsx("p", { children: "from prop" }, ["from slot"]);
+    const result = jsx("p", { children: "from prop" }, ["from slot"]);
     expect(result.value).toBe("<p>from slot</p>");
   });
 
@@ -880,6 +892,23 @@ describe("ilha JSX runtime", () => {
     expect((<Parent />).value).toContain("42");
   });
 
+  it("cross-entry JSX island composition mounts interactively", () => {
+    const Child = ilha
+      .state("count", 0)
+      .on("button@click", ({ state }) => state.count(state.count() + 1))
+      .render(({ state }) => <button>{state.count()}</button>);
+    const Parent = ilha.render(() =>
+      jsxRuntime.jsx("div", { children: jsxRuntime.jsx(Child, {}) }),
+    );
+
+    const el = makeEl();
+    const unmount = Parent.mount(el);
+    el.querySelector<HTMLButtonElement>("button")!.click();
+    expect(el.querySelector("button")!.textContent).toBe("1");
+    unmount();
+    cleanup(el);
+  });
+
   it("JSX island component returning SSR string emits slot instead of escaping", () => {
     const Child = ilha.render(
       () =>
@@ -934,7 +963,6 @@ describe("ilha JSX runtime", () => {
   });
 
   it("jsxs produces the same output as jsx with multiple children", () => {
-    const { jsx, jsxs } = ilha;
     const viaJsx = jsx("div", {
       children: [jsx("span", { children: "a" }), jsx("span", { children: "b" })],
     });

--- a/packages/ilha/src/jsx-runtime.ts
+++ b/packages/ilha/src/jsx-runtime.ts
@@ -1,2 +1,228 @@
-export { Fragment, jsx, jsxs } from "./index";
+import { __ilhaJsxSlot, html, raw, type RawHtml } from "./index";
 export type { JSX } from "./jsx-types";
+
+type JsxChild = unknown;
+type JsxProps = Record<string, unknown> | null | undefined;
+type JsxType = string | ((props: Record<string, unknown>) => unknown);
+
+const RAW = Symbol.for("ilha.raw");
+const SIGNAL_ACCESSOR = Symbol.for("ilha.signalAccessor");
+const ISLAND = Symbol.for("ilha.island");
+const ISLAND_CALL = Symbol.for("ilha.islandCall");
+const RENDER_PART = Symbol.for("ilha.renderPart");
+
+const SAFE_NAME_RE = /^[A-Za-z_:][A-Za-z0-9:._-]*$/;
+const SAFE_BIND_LOCAL_RE = /^[A-Za-z][A-Za-z0-9]*$/;
+const VOID_ELEMENTS = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+]);
+const SAFE_CSS_PROP_RE = /^(-{2}[a-zA-Z][a-zA-Z0-9-]*|-?[a-zA-Z][a-zA-Z0-9-]*)$/;
+const URL_ATTRS = new Set(["href", "src", "action", "formaction", "cite", "data", "poster"]);
+const SAFE_URL_RE =
+  /^(?!javascript:|data:text\/html|data:text\/xml|data:application\/xhtml\+xml|data:image\/svg|vbscript:)/i;
+
+function isRawHtml(v: unknown): v is RawHtml {
+  return !!(v && typeof v === "object" && RAW in v);
+}
+
+function isSignalAccessor(v: unknown): boolean {
+  return typeof v === "function" && SIGNAL_ACCESSOR in (v as object);
+}
+
+function isIsland(v: unknown): boolean {
+  if (typeof v !== "function") return false;
+  if (ISLAND in (v as object)) return true;
+  return Object.getOwnPropertySymbols(v as object).some((s) => s.description === "ilha.island");
+}
+
+function isIslandCall(v: unknown): boolean {
+  if (v == null || (typeof v !== "object" && typeof v !== "function")) return false;
+  if (ISLAND_CALL in (v as object)) return true;
+  if (Object.getOwnPropertySymbols(v as object).some((s) => s.description === "ilha.islandCall")) {
+    return true;
+  }
+  return typeof v === "object" && "island" in v && isIsland((v as { island?: unknown }).island);
+}
+
+function normalizeClass(value: unknown): string {
+  if (Array.isArray(value)) return value.filter(Boolean).join(" ");
+  if (value && typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>)
+      .filter(([, enabled]) => Boolean(enabled))
+      .map(([name]) => name)
+      .join(" ");
+  }
+  return String(value);
+}
+
+function normalizeJsxChildren(props: JsxProps, children: JsxChild[]): JsxChild[] {
+  const propChildren = props && "children" in props ? props.children : undefined;
+  const all = children.length > 0 ? children : propChildren === undefined ? [] : [propChildren];
+  return all.flat(1);
+}
+
+function normalizeJsxSlotKey(rawKey: string | number): string {
+  const key = String(rawKey);
+  if (key.trim().length === 0) throw new Error("jsx key requires a non-empty string.");
+  if (key.includes(":")) {
+    throw new Error(`jsx key cannot contain the slot separator ":" (got "${key}").`);
+  }
+  return key;
+}
+
+function extractJsxSlotKey(props: JsxProps, keyArg?: string | number): string | undefined {
+  const fromProps = props?.key;
+  const rawKey =
+    keyArg ??
+    (typeof fromProps === "string" || typeof fromProps === "number" ? fromProps : undefined);
+  if (rawKey == null) return undefined;
+  return normalizeJsxSlotKey(rawKey);
+}
+
+function serializeStyle(value: Record<string, unknown>): string {
+  return Object.entries(value)
+    .map(([k, v]) => {
+      if (!SAFE_CSS_PROP_RE.test(k)) return "";
+      const prop = k.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`);
+      const safeV = String(v).replace(/["<>{};]/g, "");
+      if (/expression\(/i.test(safeV) || /^javascript:/i.test(safeV)) return "";
+      return `${prop}:${safeV}`;
+    })
+    .filter(Boolean)
+    .join(";");
+}
+
+function pushJsxAttr(chunks: string[], values: unknown[], name: string, value: unknown): void {
+  if (value == null || value === false || name === "children" || name === "key") return;
+  if (name === "__proto__" || name === "constructor" || name === "prototype") return;
+
+  if (name.startsWith("bind:")) {
+    const [prefix, localName, ...rest] = name.split(":");
+    if (prefix !== "bind" || rest.length > 0 || !localName || !SAFE_BIND_LOCAL_RE.test(localName)) {
+      return;
+    }
+    if (!isSignalAccessor(value)) return;
+    chunks[chunks.length - 1] += ` ${prefix}:${localName}=`;
+    values.push(value);
+    chunks.push("");
+    return;
+  }
+
+  if (!SAFE_NAME_RE.test(name)) return;
+  let safeName = name;
+  if (safeName === "className") safeName = "class";
+  if (safeName === "htmlFor") safeName = "for";
+  if (safeName.startsWith("on")) return;
+  if (safeName === "class") value = normalizeClass(value);
+  if (safeName === "style" && value && typeof value === "object") {
+    value = serializeStyle(value as Record<string, unknown>);
+  }
+  if (
+    (URL_ATTRS.has(safeName) || /:(href|src|action|formaction|cite|data|poster)$/.test(safeName)) &&
+    typeof value === "string" &&
+    !SAFE_URL_RE.test(value.trim())
+  ) {
+    return;
+  }
+  if (value === true) {
+    chunks[chunks.length - 1] += ` ${safeName}`;
+    return;
+  }
+  chunks[chunks.length - 1] += ` ${safeName}="`;
+  values.push(value);
+  chunks.push('"');
+}
+
+function renderJsxElement(type: string, props: JsxProps, children: JsxChild[]): RawHtml {
+  const chunks = [`<${type}`];
+  const values: unknown[] = [];
+  if (props)
+    for (const [name, value] of Object.entries(props)) pushJsxAttr(chunks, values, name, value);
+  chunks[chunks.length - 1] += ">";
+  if (!VOID_ELEMENTS.has(type)) {
+    for (const child of children) {
+      values.push(child);
+      chunks.push("");
+    }
+    chunks[chunks.length - 1] += `</${type}>`;
+  }
+  return html(chunks as unknown as TemplateStringsArray, ...values);
+}
+
+export function jsx(
+  type: JsxType,
+  props: JsxProps,
+  maybeKey?: JsxChild | string | number,
+  ...restChildren: JsxChild[]
+): RawHtml {
+  const hasKeyArg = typeof maybeKey === "string" || typeof maybeKey === "number";
+  const keyFromArg = hasKeyArg ? maybeKey : undefined;
+  const children: JsxChild[] =
+    hasKeyArg || maybeKey === undefined ? restChildren : [maybeKey, ...restChildren];
+  const normalizedChildren = normalizeJsxChildren(props, children);
+
+  if (typeof type === "function") {
+    const slotKey = extractJsxSlotKey(
+      props,
+      typeof keyFromArg === "string" || typeof keyFromArg === "number" ? keyFromArg : undefined,
+    );
+    const componentProps: Record<string, unknown> = {
+      ...props,
+      ...(normalizedChildren.length > 0 ? { children: normalizedChildren } : {}),
+    };
+    delete componentProps.key;
+    const out = type(Object.keys(componentProps).length ? componentProps : {});
+    if (isIslandCall(out)) {
+      if (slotKey !== undefined) (out as { key?: string }).key = slotKey;
+      return html`${out}`;
+    }
+    if (isRawHtml(out)) return out;
+    if (typeof out === "string" && isIsland(type)) {
+      return __ilhaJsxSlot(type, componentProps, slotKey);
+    }
+    if (typeof out === "string") return html`${out}`;
+    if (
+      typeof out === "object" &&
+      out !== null &&
+      Object.getPrototypeOf(out) === Object.prototype &&
+      (out as Record<symbol, unknown>)[RENDER_PART] === true &&
+      typeof (out as { toString?: unknown }).toString === "function"
+    ) {
+      return raw(String(out));
+    }
+    return html`${out}`;
+  }
+
+  return renderJsxElement(type, props, normalizedChildren);
+}
+
+export const jsxs = jsx;
+
+export function Fragment(props: { children?: JsxChild } | null, ...children: JsxChild[]): RawHtml {
+  const normalizedChildren = normalizeJsxChildren(props, children);
+  const chunks = ["", ...normalizedChildren.map(() => "")];
+  return html(chunks as unknown as TemplateStringsArray, ...normalizedChildren);
+}
+
+export function jsxDEV(
+  type: JsxType,
+  props: JsxProps,
+  maybeKey?: string | number,
+  _source?: unknown,
+  _self?: unknown,
+): RawHtml {
+  return jsx(type, props, maybeKey);
+}

--- a/packages/ilha/src/public-types.ts
+++ b/packages/ilha/src/public-types.ts
@@ -1,0 +1,38 @@
+import ilha, { batch, html, signal, untrack, type SignalAccessor } from "./index";
+import { jsx, Fragment } from "./jsx-runtime";
+
+export const typeCheckedExternalSignal: SignalAccessor<number> = signal(0);
+
+export const TypeCheckedIsland = ilha
+  .input<{ name: string }>()
+  .as("span")
+  .state("count", 0)
+  .derived("label", ({ input, state }) => `${input.name}:${state.count()}`)
+  .on("button@click", ({ event, state, derived }) => {
+    const mouseEvent: MouseEvent = event;
+    const label: string | undefined = derived.label();
+    state.count(state.count() + 1);
+    void mouseEvent;
+    void label;
+  })
+  .effect(({ state }) => {
+    const count: number = state.count();
+    void count;
+  })
+  .render(({ input, state, derived }) => {
+    const name: string = input.name;
+    const count: number = state.count();
+    const label: string | undefined = derived.label();
+    return html`<button>${name}:${count}:${label}</button>`;
+  });
+
+export const typeCheckedJsx = jsx(Fragment, {
+  children: jsx(TypeCheckedIsland, { name: "Ada" }),
+});
+
+export const typeCheckedBatchReturn: number = batch(() => {
+  typeCheckedExternalSignal(1);
+  return typeCheckedExternalSignal();
+});
+
+export const typeCheckedUntrackReturn: number = untrack(() => typeCheckedExternalSignal());

--- a/packages/ilha/tsdown.config.ts
+++ b/packages/ilha/tsdown.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
   entry: ["src/index.ts", "src/jsx-runtime.ts", "src/jsx-dev-runtime.ts"],
   platform: "neutral",
   dts: true,
+  minify: true,
 });

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,7 +1,23 @@
 {
   "name": "@ilha/router",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "A tiny SPA router for Ilha",
+  "keywords": [
+    "frontend",
+    "ilha",
+    "island-architecture",
+    "islands",
+    "router",
+    "routing",
+    "spa",
+    "ssr",
+    "unplugin",
+    "vite"
+  ],
+  "homepage": "https://github.com/ilhajs/ilha/tree/main/packages/router#readme",
+  "bugs": {
+    "url": "https://github.com/ilhajs/ilha/issues"
+  },
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",
   "repository": {
@@ -12,9 +28,12 @@
     "dist"
   ],
   "type": "module",
+  "sideEffects": false,
+  "module": "./dist/index.js",
   "browser": {
     "process": false
   },
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -33,16 +52,19 @@
       "import": "./dist/rolldown.js"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc && tsdown",
     "test": "bun test"
   },
   "dependencies": {
-    "ilha": "0.7.1",
+    "ilha": "0.8.0",
     "rou3": "0.8.1",
     "unplugin": "3.0.0"
   },
   "devDependencies": {
-    "vite": "^8.0.14"
+    "vite": "^8.0.16"
   }
 }

--- a/packages/router/tsdown.config.ts
+++ b/packages/router/tsdown.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
   entry: ["src/index.ts", "src/vite.ts", "src/rspack.ts", "src/rolldown.ts"],
   platform: "neutral",
   dts: true,
+  minify: true,
 });

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -1,15 +1,23 @@
 # `@ilha/store`
 
-A zustand-shaped reactive store for [Ilha](https://github.com/ilhajs/ilha) islands. Backed by [alien-signals](https://github.com/stackblitz/alien-signals) — the same engine that powers `ilha` core state — for shared global state that lives outside any single island.
+Shared reactive store for [Ilha](https://github.com/ilhajs/ilha) islands — global state outside any single island, backed by [alien-signals](https://github.com/stackblitz/alien-signals) (the same engine as Ilha core).
 
 Includes a `/form` subpath with unopinionated, type-safe form helpers built on [Standard Schema](https://standardschema.dev) — works with Zod, Valibot, ArkType, or any compatible library.
+
+| API                  | Use in Ilha apps                                                      |
+| -------------------- | --------------------------------------------------------------------- |
+| **`select`**         | Read-only slices in `html\`\`` / JSX — lists, labels, derived display |
+| **`bind(selector)`** | Two-way `bind:value`, `bind:checked`, `bind:open`, etc.               |
+| **`subscribe`**      | Side effects outside islands — `localStorage`, WebSockets, analytics  |
 
 ---
 
 ## Installation
 
+Ilha apps already depend on `ilha`; add the store alongside it:
+
 ```bash
-bun add @ilha/store
+bun add @ilha/store ilha
 ```
 
 ---
@@ -74,6 +82,8 @@ The actions creator receives:
 | `get()`                 | Read the current live state (includes other actions) |
 | `getInitialState()`     | Read the frozen initial state snapshot               |
 
+Actions are merged onto the same object as state (`store.getState().increment()`). Use **`select` / `bind` only on data fields** — not on action methods. For example, `store.bind((s) => s.count)` is valid; `store.bind((s) => s.increment)` is not (functions are not bindable paths).
+
 ---
 
 ### `store.setState(update)`
@@ -122,7 +132,7 @@ store.setState({ count: 5 });
 count(); // → 5    (reflects the change)
 ```
 
-The returned accessor has the same shape as `signal()` and `context()` from `ilha` core, so it composes naturally with `html\`\``interpolation and`.bind()`. See [Usage with Ilha Islands](#usage-with-ilha-islands) below for the full pattern.
+The returned accessor has the same shape as `signal()` and `context()` from `ilha` core, so it composes naturally with `html\`\`` interpolation. See [Usage with Ilha Islands](#usage-with-ilha-islands) below for the full pattern.
 
 The slice is memoized — accessors only notify dependents when the selected value changes (compared with `Object.is`). Setting `count` to its current value, or mutating an unrelated field, does not trigger downstream re-runs.
 
@@ -155,32 +165,29 @@ const unsub = store.subscribe(
 
 ---
 
-### `store.bind(el, render)`
+### `store.bind(selector)` — two-way fields for `bind:*`
 
-Reactively renders a store-driven HTML string into a DOM element whenever state changes. The render function may return a plain string or an `html\`\`` tagged template.
+Returns a **read/write accessor** for a property path in store state, compatible with Ilha's template `bind:*` syntax (`bind:value`, `bind:checked`, `bind:open`, and so on). Use this for form fields and toggles that must update the store when the user interacts with the DOM.
 
-```ts
-import { html } from "ilha";
-
-const unsub = store.bind(
-  document.getElementById("counter")!,
-  (state) => html`<p>Count: ${state.count}</p>`,
-);
-
-unsub(); // detach
-```
-
-### `store.bind(el, selector, render)` — slice bind
-
-Only re-renders when the selected slice changes.
+`select()` stays **read-only** — use it for derived values and list rendering inside `html\`\``.
 
 ```ts
-store.bind(
-  document.getElementById("badge")!,
-  (s) => s.count,
-  (count) => html`<span>${count}</span>`,
-);
+const searchStore = createStore({ search: { query: "", open: false } });
+
+const query = searchStore.bind((s) => s.search.query);
+const open = searchStore.bind((s) => s.search.open);
+const results = searchStore.select((s) => s.results);
+
+// In an island:
+// <dialog bind:open={open}><input bind:value={query} /></dialog>
 ```
+
+- **Read:** `query()` — reactive inside `.render()`, `.derived()`, and `.effect()`.
+- **Write:** `query("ilha")` — immutably updates `search.query` in the store.
+
+Only **property-path** selectors are supported (`s => s.user.name`, `s => s.items[0].title`). Derived expressions (`s => s.query.trim()`, `s => s.a + s.b`) throw at accessor creation time.
+
+Render store-driven UI with **`select` + islands**, not by writing into arbitrary DOM nodes. `@ilha/store` does not morph HTML outside Ilha's render pipeline.
 
 ---
 
@@ -240,13 +247,13 @@ const Profile = ilha
 
 When `userId()` changes, the derived re-fetches automatically.
 
-### When to use `select` vs `subscribe`
+### When to use `select`, `bind`, or `subscribe`
 
-| Use `select`                                          | Use `subscribe`                                        |
-| ----------------------------------------------------- | ------------------------------------------------------ |
-| Reading store state inside an island                  | Imperative side effects outside an island              |
-| Driving `.derived()` or `.effect()` dependencies      | Syncing to `localStorage`, WebSockets, analytics       |
-| Anywhere you'd reach for `context()` from `ilha` core | Anywhere you'd reach for `effect()` from alien-signals |
+| Use `select`                            | Use `bind(selector)`                            | Use `subscribe`                                  |
+| --------------------------------------- | ----------------------------------------------- | ------------------------------------------------ |
+| Read-only slices in `html\`\``          | Two-way `bind:*` on inputs, checkboxes, dialogs | Imperative side effects outside an island        |
+| Lists and derived display data          | `bind:value`, `bind:checked`, `bind:open`, etc. | Syncing to `localStorage`, WebSockets, analytics |
+| `.derived()` / `.effect()` dependencies | Hoist accessors at module scope like `select`   | Non-reactive listeners outside islands           |
 
 ---
 
@@ -372,7 +379,7 @@ import type {
   GetState, // () => T
   Listener, // (state, prevState) => void
   SliceListener, // (slice, prevSlice) => void
-  RenderResult, // string | RawHtml
+  StoreBindable, // read/write accessor from bind(selector)
   Unsub, // () => void
 } from "@ilha/store";
 

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -172,7 +172,10 @@ Returns a **read/write accessor** for a property path in store state, compatible
 `select()` stays **read-only** — use it for derived values and list rendering inside `html\`\``.
 
 ```ts
-const searchStore = createStore({ search: { query: "", open: false } });
+const searchStore = createStore({
+  search: { query: "", open: false },
+  results: [] as string[],
+});
 
 const query = searchStore.bind((s) => s.search.query);
 const open = searchStore.bind((s) => s.search.open);

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,7 +1,22 @@
 {
   "name": "@ilha/store",
-  "version": "0.3.8",
-  "description": "Typed store.",
+  "version": "0.4.0",
+  "description": "Shared reactive store for Ilha islands.",
+  "keywords": [
+    "forms",
+    "frontend",
+    "ilha",
+    "island-architecture",
+    "islands",
+    "reactive",
+    "signals",
+    "state-management",
+    "store"
+  ],
+  "homepage": "https://github.com/ilhajs/ilha/tree/main/packages/store#readme",
+  "bugs": {
+    "url": "https://github.com/ilhajs/ilha/issues"
+  },
   "license": "MIT",
   "author": "Ryuz <ryuzer@proton.me>",
   "repository": {
@@ -12,9 +27,12 @@
     "dist"
   ],
   "type": "module",
+  "sideEffects": false,
+  "module": "./dist/index.js",
   "browser": {
     "process": false
   },
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -25,16 +43,27 @@
       "import": "./dist/form.js"
     }
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc && tsdown",
     "test": "bun test",
     "cleanup": "rimraf dist node_modules"
   },
   "dependencies": {
-    "alien-signals": "3.2.1",
-    "ilha": "0.7.1"
+    "alien-signals": "3.2.1"
   },
   "devDependencies": {
+    "ilha": "0.8.0",
     "zod": "^4.4.3"
+  },
+  "peerDependencies": {
+    "ilha": ">=0.8.0"
+  },
+  "peerDependenciesMeta": {
+    "ilha": {
+      "optional": true
+    }
   }
 }

--- a/packages/store/src/bind-path.ts
+++ b/packages/store/src/bind-path.ts
@@ -1,0 +1,83 @@
+// =============================================================================
+// Property-path capture + immutable updates for store.bind(selector)
+// =============================================================================
+
+export type PathSegment = string | number;
+
+const BIND_PATH_ERROR =
+  "store.bind(selector) only supports property-path selectors like `s => s.user.name`.";
+
+function toPathSegment(prop: string | symbol): PathSegment | null {
+  if (typeof prop === "symbol") return null;
+  if (prop === "length") return null;
+  if (/^\d+$/.test(prop)) return Number(prop);
+  return prop;
+}
+
+function getAtPath(obj: unknown, path: readonly PathSegment[]): unknown {
+  let cur = obj;
+  for (const seg of path) {
+    if (cur == null) return undefined;
+    cur = (cur as Record<string | number, unknown>)[seg];
+  }
+  return cur;
+}
+
+export function setIn(root: unknown, path: readonly PathSegment[], value: unknown): unknown {
+  if (path.length === 0) return value;
+
+  const [head, ...tail] = path;
+  const base = root ?? (typeof head === "number" ? [] : {});
+  const clone = Array.isArray(base) ? [...base] : { ...(base as object) };
+  (clone as Record<string | number, unknown>)[head as string | number] = setIn(
+    (base as Record<string | number, unknown>)[head as string | number],
+    tail,
+    value,
+  );
+  return clone;
+}
+
+function trackPropertyPath<T, S>(rootState: T, selector: (state: T) => S): readonly PathSegment[] {
+  const path: PathSegment[] = [];
+  const track = (value: unknown): unknown => {
+    if (value === null || (typeof value !== "object" && typeof value !== "function")) {
+      return value;
+    }
+    return new Proxy(value as object, {
+      get(target, prop, receiver) {
+        const seg = toPathSegment(prop);
+        if (seg != null) path.push(seg);
+        const next = Reflect.get(target, prop, receiver);
+        return seg != null && next !== null && typeof next === "object" ? track(next) : next;
+      },
+    });
+  };
+  selector(track(rootState) as T);
+  return path;
+}
+
+export function capturePropertyPath<T extends object, S>(
+  getState: () => T,
+  selector: (state: T) => S,
+): readonly PathSegment[] {
+  const state = getState();
+  const path = trackPropertyPath(state, selector);
+  const selected = selector(state);
+  const resolved = path.length === 0 ? state : getAtPath(state, path);
+  if (!Object.is(selected, resolved) || path.length === 0) {
+    throw new Error(BIND_PATH_ERROR);
+  }
+  return path;
+}
+
+export function patchStateAtPath<T extends object>(
+  state: T,
+  path: readonly PathSegment[],
+  value: unknown,
+): Partial<T> {
+  const topKey = path[0];
+  const rest = path.slice(1);
+  const topValue = (state as Record<string | number, unknown>)[topKey as string | number];
+  const nextTopValue = setIn(topValue, rest, value);
+  return { [topKey]: nextTopValue } as Partial<T>;
+}

--- a/packages/store/src/bind-path.ts
+++ b/packages/store/src/bind-path.ts
@@ -7,10 +7,10 @@ export type PathSegment = string | number;
 const BIND_PATH_ERROR =
   "store.bind(selector) only supports property-path selectors like `s => s.user.name`.";
 
-function toPathSegment(prop: string | symbol): PathSegment | null {
+function toPathSegment(prop: string | symbol, isArray: boolean): PathSegment | null {
   if (typeof prop === "symbol") return null;
-  if (prop === "length") return null;
-  if (/^\d+$/.test(prop)) return Number(prop);
+  if (isArray && prop === "length") return null;
+  if (isArray && /^\d+$/.test(prop)) return Number(prop);
   return prop;
 }
 
@@ -45,7 +45,7 @@ function trackPropertyPath<T, S>(rootState: T, selector: (state: T) => S): reado
     }
     return new Proxy(value as object, {
       get(target, prop, receiver) {
-        const seg = toPathSegment(prop);
+        const seg = toPathSegment(prop, Array.isArray(target));
         if (seg != null) path.push(seg);
         const next = Reflect.get(target, prop, receiver);
         return seg != null && next !== null && typeof next === "object" ? track(next) : next;
@@ -64,7 +64,7 @@ export function capturePropertyPath<T extends object, S>(
   const path = trackPropertyPath(state, selector);
   const selected = selector(state);
   const resolved = path.length === 0 ? state : getAtPath(state, path);
-  if (!Object.is(selected, resolved) || path.length === 0) {
+  if (typeof selected === "function" || !Object.is(selected, resolved) || path.length === 0) {
     throw new Error(BIND_PATH_ERROR);
   }
   return path;

--- a/packages/store/src/index.test.ts
+++ b/packages/store/src/index.test.ts
@@ -6,31 +6,9 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 
 import { effect } from "alien-signals";
-import { html, raw } from "ilha";
+import ilha, { html } from "ilha";
 
 import { createStore, effectScope } from "./index";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function fixture(markup: string): HTMLElement {
-  const el = document.createElement("div");
-  el.innerHTML = markup;
-  document.body.appendChild(el);
-  return el;
-}
-
-function makeEl(inner = ""): Element {
-  const el = document.createElement("div");
-  el.innerHTML = inner;
-  document.body.appendChild(el);
-  return el;
-}
-
-function cleanup(el: Element) {
-  if (el.parentNode) el.parentNode.removeChild(el);
-}
 
 beforeEach(() => {
   document.body.innerHTML = "";
@@ -351,212 +329,6 @@ describe("subscribe() — selector form", () => {
 });
 
 // ---------------------------------------------------------------------------
-// bind() — plain string render
-// ---------------------------------------------------------------------------
-
-describe("bind() — plain string render", () => {
-  it("renders immediately on bind", () => {
-    const store = createStore({ count: 0 });
-    const el = fixture("<div id='t'></div>");
-    const target = el.querySelector("#t")!;
-    store.bind(target, (s) => `<span>${s.count}</span>`);
-    expect(target.innerHTML).toBe("<span>0</span>");
-  });
-
-  it("re-renders when state changes", () => {
-    const store = createStore({ count: 0 });
-    const el = fixture("<div id='t'></div>");
-    const target = el.querySelector("#t")!;
-    store.bind(target, (s) => `<span>${s.count}</span>`);
-    store.setState({ count: 5 });
-    expect(target.innerHTML).toBe("<span>5</span>");
-  });
-
-  it("returns an unsub function that stops re-renders", () => {
-    const store = createStore({ count: 0 });
-    const el = fixture("<div id='t'></div>");
-    const target = el.querySelector("#t")!;
-    const unsub = store.bind(target, (s) => `${s.count}`);
-    store.setState({ count: 1 });
-    unsub();
-    store.setState({ count: 99 });
-    expect(target.innerHTML).toBe("1");
-  });
-
-  it("multiple bind calls on different elements are independent", () => {
-    const store = createStore({ count: 0 });
-    const root = fixture("<div id='a'></div><div id='b'></div>");
-    const a = root.querySelector("#a")!;
-    const b = root.querySelector("#b")!;
-    store.bind(a, (s) => `a:${s.count}`);
-    store.bind(b, (s) => `b:${s.count}`);
-    store.setState({ count: 3 });
-    expect(a.innerHTML).toBe("a:3");
-    expect(b.innerHTML).toBe("b:3");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// bind() — RawHtml render (ilha html``)
-// ---------------------------------------------------------------------------
-
-describe("bind() — RawHtml render", () => {
-  it("accepts an html`` tagged template as render output", () => {
-    const store = createStore({ count: 0 });
-    const el = fixture("<div id='t'></div>");
-    const target = el.querySelector("#t")!;
-    store.bind(target, (s) => html`<span>${s.count}</span>`);
-    expect(target.innerHTML).toContain("0");
-  });
-
-  it("re-renders on state change when using html``", () => {
-    const store = createStore({ count: 0 });
-    const el = fixture("<div id='t'></div>");
-    const target = el.querySelector("#t")!;
-    store.bind(target, (s) => html`<b>${s.count}</b>`);
-    store.setState({ count: 7 });
-    expect(target.innerHTML).toContain("7");
-  });
-
-  it("html`` escapes interpolated values", () => {
-    const store = createStore({ label: "<script>xss</script>" });
-    const el = fixture("<div id='t'></div>");
-    const target = el.querySelector("#t")!;
-    store.bind(target, (s) => html`<p>${s.label}</p>`);
-    expect(target.innerHTML).not.toContain("<script>");
-    expect(target.innerHTML).toContain("&lt;script&gt;");
-  });
-
-  it("raw() passes trusted HTML through unescaped", () => {
-    const store = createStore({ bold: "<b>hi</b>" });
-    const el = fixture("<div id='t'></div>");
-    const target = el.querySelector("#t")!;
-    store.bind(target, (s) => html`<p>${raw(s.bold)}</p>`);
-    expect(target.innerHTML).toContain("<b>hi</b>");
-  });
-
-  it("list rendering with html`` — no comma-joining", () => {
-    const store = createStore({ items: ["a", "b", "c"] });
-    const el = fixture("<div id='t'></div>");
-    const target = el.querySelector("#t")!;
-    store.bind(
-      target,
-      (s) =>
-        html`<ul>
-          ${s.items.map((i) => html`<li>${i}</li>`)}
-        </ul>`,
-    );
-    expect(target.querySelectorAll("li").length).toBe(3);
-    expect(target.innerHTML).not.toContain(",");
-  });
-
-  it("updates list correctly on state change", () => {
-    const store = createStore({ items: ["a"] });
-    const el = fixture("<div id='t'></div>");
-    const target = el.querySelector("#t")!;
-    store.bind(
-      target,
-      (s) =>
-        html`<ul>
-          ${s.items.map((i) => html`<li>${i}</li>`)}
-        </ul>`,
-    );
-    store.setState({ items: ["a", "b", "c"] });
-    expect(target.querySelectorAll("li").length).toBe(3);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// bind() — selector form
-// ---------------------------------------------------------------------------
-
-describe("bind() — selector form", () => {
-  it("renders immediately with the initial slice", () => {
-    const store = createStore({ count: 0, name: "Ada" });
-    const el = fixture("<div id='t'></div>");
-    const target = el.querySelector("#t")!;
-    store.bind(
-      target,
-      (s) => s.count,
-      (count) => `<b>${count}</b>`,
-    );
-    expect(target.innerHTML).toBe("<b>0</b>");
-  });
-
-  it("re-renders when the selected slice changes", () => {
-    const store = createStore({ count: 0, name: "Ada" });
-    const el = fixture("<div id='t'></div>");
-    const target = el.querySelector("#t")!;
-    store.bind(
-      target,
-      (s) => s.count,
-      (count) => `${count}`,
-    );
-    store.setState({ count: 7 });
-    expect(target.innerHTML).toBe("7");
-  });
-
-  it("does NOT re-render when an unrelated slice changes", () => {
-    const store = createStore({ count: 0, name: "Ada" });
-    const el = fixture("<div id='t'></div>");
-    const target = el.querySelector("#t")!;
-    const render = mock((count: number) => `${count}`);
-    store.bind(target, (s) => s.count, render);
-    const callsBefore = render.mock.calls.length;
-    store.setState({ name: "Grace" });
-    expect(render.mock.calls.length).toBe(callsBefore);
-  });
-
-  it("returns an unsub that stops re-renders", () => {
-    const store = createStore({ count: 0 });
-    const el = fixture("<div id='t'></div>");
-    const target = el.querySelector("#t")!;
-    const unsub = store.bind(
-      target,
-      (s) => s.count,
-      (c) => `${c}`,
-    );
-    store.setState({ count: 1 });
-    unsub();
-    store.setState({ count: 99 });
-    expect(target.innerHTML).toBe("1");
-  });
-
-  it("accepts html`` as render output in selector form", () => {
-    const store = createStore({ name: "Ada" });
-    const el = fixture("<div id='t'></div>");
-    const target = el.querySelector("#t")!;
-    store.bind(
-      target,
-      (s) => s.name,
-      (name) => html`<span>${name}</span>`,
-    );
-    expect(target.innerHTML).toContain("Ada");
-    store.setState({ name: "Grace" });
-    expect(target.innerHTML).toContain("Grace");
-  });
-
-  it("two selectors on the same element — last bind wins (overwrites innerHTML)", () => {
-    const store = createStore({ a: 0, b: 0 });
-    const el = fixture("<div id='t'></div>");
-    const target = el.querySelector("#t")!;
-    store.bind(
-      target,
-      (s) => s.a,
-      (a) => `a:${a}`,
-    );
-    store.bind(
-      target,
-      (s) => s.b,
-      (b) => `b:${b}`,
-    );
-    expect(target.innerHTML).toBe("b:0");
-    store.setState({ a: 1 });
-    expect(target.innerHTML).toBe("a:1");
-  });
-});
-
-// ---------------------------------------------------------------------------
 // Actions
 // ---------------------------------------------------------------------------
 
@@ -644,47 +416,16 @@ describe("effectScope", () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
-  it("stops all bind effects inside the scope", () => {
+  it("stops slice subscribe effects registered inside the scope", () => {
     const store = createStore({ count: 0 });
-    const el = fixture("<div id='t'></div>");
-    const target = el.querySelector("#t")!;
-    const stop = effectScope(() => {
-      store.bind(target, (s) => `${s.count}`);
-    });
-    store.setState({ count: 5 });
-    expect(target.innerHTML).toBe("5");
-    stop();
-    store.setState({ count: 99 });
-    expect(target.innerHTML).toBe("5");
-  });
-
-  it("groups multiple binds and subscriptions — one stop tears all down", () => {
-    const store = createStore({ count: 0, name: "Ada" });
-    const root = fixture("<div id='a'></div><div id='b'></div>");
-    const a = root.querySelector("#a")!;
-    const b = root.querySelector("#b")!;
     const listener = mock();
     const stop = effectScope(() => {
-      store.bind(
-        a,
-        (s) => s.count,
-        (c) => `${c}`,
-      );
-      store.bind(
-        b,
-        (s) => s.name,
-        (n) => n,
-      );
-      store.subscribe(listener);
+      store.subscribe((s) => s.count, listener);
     });
-    store.setState({ count: 1, name: "Grace" });
-    expect(a.innerHTML).toBe("1");
-    expect(b.innerHTML).toBe("Grace");
+    store.setState({ count: 5 });
     expect(listener).toHaveBeenCalledTimes(1);
     stop();
-    store.setState({ count: 99, name: "Turing" });
-    expect(a.innerHTML).toBe("1");
-    expect(b.innerHTML).toBe("Grace");
+    store.setState({ count: 99 });
     expect(listener).toHaveBeenCalledTimes(1);
   });
 });
@@ -694,42 +435,43 @@ describe("effectScope", () => {
 // ---------------------------------------------------------------------------
 
 describe("integration", () => {
-  it("store-driven error state renders via bind with html``", () => {
+  it("store-driven error state renders in an island via select", () => {
     const store = createStore({ errors: {} as Record<string, string> }, (set) => ({
       setErrors: (errors: Record<string, string>) => set({ errors }),
       clearErrors: () => set({ errors: {} }),
     }));
-    const el = fixture("<div id='errors'></div>");
-    const target = el.querySelector("#errors")!;
-    store.bind(
-      target,
-      (s) => s.errors,
-      (errors) =>
-        html`${Object.entries(errors).map(([f, m]) => html`<p data-field="${f}">${m}</p>`)}`,
+    const errors = store.select((s) => s.errors);
+    const Island = ilha.render(
+      () => html`${Object.entries(errors()).map(([f, m]) => html`<p data-field="${f}">${m}</p>`)}`,
     );
-    expect(target.innerHTML).toBe("");
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const unmount = Island.mount(el);
+    expect(el.querySelectorAll("p").length).toBe(0);
     store.getState().setErrors({ email: "Invalid email", name: "Required" });
-    expect(target.querySelectorAll("p").length).toBe(2);
-    expect(target.querySelector("[data-field='email']")?.textContent).toBe("Invalid email");
+    expect(el.querySelectorAll("p").length).toBe(2);
+    expect(el.querySelector("[data-field='email']")?.textContent).toBe("Invalid email");
     store.getState().clearErrors();
-    expect(target.querySelector("p")).toBeNull();
+    expect(el.querySelector("p")).toBeNull();
+    unmount();
+    el.remove();
   });
 
-  it("counter with html`` label", () => {
+  it("counter label renders in an island via select", () => {
     const store = createStore({ count: 0 }, (set) => ({
       inc: () => set((s) => ({ count: s.count + 1 })),
     }));
-    const el = fixture("<div id='label'></div>");
-    const target = el.querySelector("#label")!;
-    store.bind(
-      target,
-      (s) => s.count,
-      (count) => html`<span>Count: ${count}</span>`,
-    );
-    expect(target.innerHTML).toContain("Count: 0");
+    const count = store.select((s) => s.count);
+    const Island = ilha.render(() => html`<span>Count: ${count()}</span>`);
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const unmount = Island.mount(el);
+    expect(el.textContent).toContain("Count: 0");
     store.getState().inc();
     store.getState().inc();
-    expect(target.innerHTML).toContain("Count: 2");
+    expect(el.textContent).toContain("Count: 2");
+    unmount();
+    el.remove();
   });
 
   it("island subscribes to store slice and drives its own signal", () => {
@@ -744,30 +486,37 @@ describe("integration", () => {
     expect(themes).toEqual(["dark", "light"]);
   });
 
-  it("store shared across two bind targets — both stay in sync", () => {
+  it("store shared across two islands — both stay in sync via select", () => {
     const store = createStore({ value: "hello" });
-    const root = fixture("<div id='a'></div><div id='b'></div>");
-    const a = root.querySelector("#a")!;
-    const b = root.querySelector("#b")!;
-    store.bind(a, (s) => html`<p>${s.value}</p>`);
-    store.bind(b, (s) => html`<em>${s.value}</em>`);
+    const value = store.select((s) => s.value);
+    const A = ilha.render(() => html`<p>${value()}</p>`);
+    const B = ilha.render(() => html`<em>${value()}</em>`);
+    const root = document.createElement("div");
+    document.body.appendChild(root);
+    const slotA = document.createElement("div");
+    const slotB = document.createElement("div");
+    root.append(slotA, slotB);
+    const unmountA = A.mount(slotA);
+    const unmountB = B.mount(slotB);
     store.setState({ value: "ilha" });
-    expect(a.querySelector("p")?.textContent).toBe("ilha");
-    expect(b.querySelector("em")?.textContent).toBe("ilha");
+    expect(slotA.querySelector("p")?.textContent).toBe("ilha");
+    expect(slotB.querySelector("em")?.textContent).toBe("ilha");
+    unmountA();
+    unmountB();
+    root.remove();
   });
 
-  it("unsubscribing one consumer does not affect another", () => {
+  it("unsubscribing one slice listener does not affect another", () => {
     const store = createStore({ count: 0 });
-    const root = fixture("<div id='a'></div><div id='b'></div>");
-    const a = root.querySelector("#a")!;
-    const b = root.querySelector("#b")!;
-    const unsubA = store.bind(a, (s) => `${s.count}`);
-    store.bind(b, (s) => `${s.count}`);
+    const a = mock();
+    const b = mock();
+    const unsubA = store.subscribe((s) => s.count, a);
+    store.subscribe((s) => s.count, b);
     store.setState({ count: 1 });
     unsubA();
     store.setState({ count: 2 });
-    expect(a.innerHTML).toBe("1"); // frozen after unsub
-    expect(b.innerHTML).toBe("2"); // still live
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(2);
   });
 });
 
@@ -962,75 +711,6 @@ describe("store.select() — reactivity", () => {
 });
 
 // ---------------------------------------------------------------------------
-// .select() — interplay with bind() refactor
-// ---------------------------------------------------------------------------
-
-describe("store.bind() (post-refactor)", () => {
-  it("two-arg form still updates the element when slice changes", () => {
-    const el = makeEl();
-    const store = createStore({ name: "Ada" });
-    const stop = store.bind(
-      el,
-      (s) => s.name,
-      (name) => `<p>${name}</p>`,
-    );
-    expect(el.innerHTML).toBe("<p>Ada</p>");
-    store.setState({ name: "Grace" });
-    expect(el.innerHTML).toBe("<p>Grace</p>");
-    stop();
-    cleanup(el);
-  });
-
-  it("two-arg form does NOT re-render when an unrelated field changes", () => {
-    const el = makeEl();
-    const store = createStore({ name: "Ada", count: 0 });
-
-    let renders = 0;
-    const stop = store.bind(
-      el,
-      (s) => s.name,
-      (name) => {
-        renders++;
-        return `<p>${name}</p>`;
-      },
-    );
-    expect(renders).toBe(1);
-
-    store.setState({ count: 1 });
-    store.setState({ count: 2 });
-    expect(renders).toBe(1);
-
-    store.setState({ name: "Grace" });
-    expect(renders).toBe(2);
-
-    stop();
-    cleanup(el);
-  });
-
-  it("one-arg form is unaffected and re-renders on any state change", () => {
-    const el = makeEl();
-    const store = createStore({ a: 1, b: 2 });
-
-    let renders = 0;
-    const stop = store.bind(el, (s) => {
-      renders++;
-      return `<p>${s.a}-${s.b}</p>`;
-    });
-    expect(renders).toBe(1);
-    expect(el.innerHTML).toBe("<p>1-2</p>");
-
-    store.setState({ a: 10 });
-    expect(renders).toBe(2);
-    store.setState({ b: 20 });
-    expect(renders).toBe(3);
-    expect(el.innerHTML).toBe("<p>10-20</p>");
-
-    stop();
-    cleanup(el);
-  });
-});
-
-// ---------------------------------------------------------------------------
 // .select() — type-level checks (compile-time, exercised at runtime)
 // ---------------------------------------------------------------------------
 
@@ -1059,5 +739,97 @@ describe("store.select() — type inference", () => {
     // Selector sees both state and action keys — `reset` is a function.
     const reset = store.select((s) => s.reset);
     expect(typeof reset()).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bind(selector) — Ilha bind:* accessor
+// ---------------------------------------------------------------------------
+
+describe("bind(selector) — bindable accessor", () => {
+  it("returns a function", () => {
+    const store = createStore({ query: "" });
+    const query = store.bind((s) => s.query);
+    expect(typeof query).toBe("function");
+  });
+
+  it("reads current value with no args", () => {
+    const store = createStore({ query: "ilha" });
+    const query = store.bind((s) => s.query);
+    expect(query()).toBe("ilha");
+  });
+
+  it("writes value via accessor call", () => {
+    const store = createStore({ query: "" });
+    const query = store.bind((s) => s.query);
+    query("abc");
+    expect(store.getState().query).toBe("abc");
+  });
+
+  it("updates nested path immutably", () => {
+    const other = { x: 1 };
+    const store = createStore({ search: { query: "" }, other });
+    const query = store.bind((s) => s.search.query);
+    const before = store.getState().search;
+    query("abc");
+    expect(store.getState().search.query).toBe("abc");
+    expect(store.getState().search).not.toBe(before);
+    expect(store.getState().other).toBe(other);
+  });
+
+  it("updates array index path", () => {
+    const store = createStore({ items: [{ title: "Old" }] });
+    const title = store.bind((s) => s.items[0].title);
+    title("New");
+    expect(store.getState().items[0].title).toBe("New");
+  });
+
+  it("is reactive in alien-signals effect", () => {
+    const store = createStore({ count: 0 });
+    const count = store.bind((s) => s.count);
+    const seen: number[] = [];
+    const stop = effect(() => {
+      seen.push(count());
+    });
+    expect(seen).toEqual([0]);
+    store.setState({ count: 2 });
+    expect(seen).toEqual([0, 2]);
+    stop();
+  });
+
+  it("throws for unsupported selector shapes", () => {
+    const store = createStore({ query: "  x  " });
+    expect(() => store.bind((s) => s.query.trim())).toThrow(/property-path selectors/);
+    expect(() => store.bind((s) => s.query + "!")).toThrow(/property-path selectors/);
+  });
+
+  it("preserves actions after bind writes", () => {
+    const store = createStore({ count: 0 }, (set) => ({
+      inc: () => set((s) => ({ count: s.count + 1 })),
+    }));
+    const count = store.bind((s) => s.count);
+    count(5);
+    expect(store.getState().count).toBe(5);
+    store.getState().inc();
+    expect(store.getState().count).toBe(6);
+  });
+});
+
+describe("bind(selector) — Ilha integration", () => {
+  it("bind:value updates store from input event", () => {
+    const store = createStore({ query: "" });
+    const query = store.bind((s) => s.query);
+    const Island = ilha.render(() => html`<input data-q bind:value=${query}><p>${query()}</p>`);
+
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const unmount = Island.mount(el);
+    const input = el.querySelector<HTMLInputElement>("[data-q]")!;
+    input.value = "typed";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(store.getState().query).toBe("typed");
+    expect(el.querySelector("p")!.textContent).toBe("typed");
+    unmount();
+    el.remove();
   });
 });

--- a/packages/store/src/index.test.ts
+++ b/packages/store/src/index.test.ts
@@ -798,9 +798,22 @@ describe("bind(selector) — bindable accessor", () => {
   });
 
   it("throws for unsupported selector shapes", () => {
-    const store = createStore({ query: "  x  " });
+    const store = createStore({ query: "  x  " }, (set) => ({
+      inc: () => set((s) => ({ query: s.query + "!" })),
+    }));
     expect(() => store.bind((s) => s.query.trim())).toThrow(/property-path selectors/);
     expect(() => store.bind((s) => s.query + "!")).toThrow(/property-path selectors/);
+    expect(() => store.bind((s) => s.inc)).toThrow(/property-path selectors/);
+  });
+
+  it("allows object keys named length or digit-like strings", () => {
+    const store = createStore({ meta: { length: "short", "0": "zero" } });
+    const length = store.bind((s) => s.meta.length);
+    const zero = store.bind((s) => s.meta["0"]);
+    length("long");
+    zero("nil");
+    expect(store.getState().meta.length).toBe("long");
+    expect(store.getState().meta["0"]).toBe("nil");
   });
 
   it("preserves actions after bind writes", () => {

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,9 +1,17 @@
 // =============================================================================
-// @ilha/store — zustand-shaped reactive store backed by alien-signals
+// @ilha/store — shared reactive store for Ilha islands (alien-signals)
 // =============================================================================
 
 import { signal, computed, effect } from "alien-signals";
-import type { RawHtml } from "ilha";
+
+import { capturePropertyPath, patchStateAtPath } from "./bind-path";
+
+const SIGNAL_ACCESSOR = Symbol.for("ilha.signalAccessor");
+
+export type StoreBindable<S> = {
+  (): S;
+  (value: S): void;
+};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -19,17 +27,17 @@ export type Listener<T> = (state: T, prevState: T) => void;
 export type SliceListener<_T, S> = (slice: S, prevSlice: S) => void;
 export type Unsub = () => void;
 
-/** Accepted render output — either a plain string or an ilha RawHtml value. */
-export type RenderResult = string | RawHtml;
-
 export interface StoreApi<T extends object> {
   setState(update: Partial<T> | ((state: T) => Partial<T>)): void;
   getState(): T;
   getInitialState(): T;
   subscribe(listener: Listener<T>): Unsub;
   subscribe<S>(selector: (state: T) => S, listener: SliceListener<T, S>): Unsub;
-  bind(el: Element, render: (state: T) => RenderResult): Unsub;
-  bind<S>(el: Element, selector: (state: T) => S, render: (slice: S) => RenderResult): Unsub;
+  /**
+   * Two-way field accessor for Ilha `bind:*` (e.g. `bind:value`, `bind:checked`).
+   * Property-path selectors only — `s => s.search.query`, not derived expressions.
+   */
+  bind<S>(selector: (state: T) => S): StoreBindable<S>;
   /**
    * Project a reactive slice of state into a signal-shaped accessor.
    *
@@ -66,15 +74,6 @@ type ActionsCreator<TState extends object, TActions extends object> = (
   get: GetState<any>,
   getInitialState: () => TState,
 ) => TActions;
-
-// ---------------------------------------------------------------------------
-// Internal helper — unwrap RenderResult to an HTML string
-// ---------------------------------------------------------------------------
-
-function unwrap(result: RenderResult): string {
-  if (typeof result === "string") return result;
-  return result.value;
-}
 
 // ---------------------------------------------------------------------------
 // createStore
@@ -148,26 +147,19 @@ export function createStore<TState extends object, TActions extends object = Rec
     return () => sliceComputed();
   }
 
-  function bind(el: Element, render: (state: T) => RenderResult): Unsub;
-  function bind<S>(
-    el: Element,
-    selector: (state: T) => S,
-    render: (slice: S) => RenderResult,
-  ): Unsub;
-  function bind<S>(
-    el: Element,
-    renderOrSelector: ((state: T) => RenderResult) | ((state: T) => S),
-    maybeRender?: (slice: S) => RenderResult,
-  ): Unsub {
-    if (maybeRender === undefined) {
-      return effect(() => {
-        el.innerHTML = unwrap((renderOrSelector as (state: T) => RenderResult)(stateSignal()));
-      });
-    }
-    const slice = select(renderOrSelector as (state: T) => S);
-    return effect(() => {
-      el.innerHTML = unwrap(maybeRender(slice()));
-    });
+  function createBindableAccessor<S>(selector: (state: T) => S): StoreBindable<S> {
+    const path = capturePropertyPath(getState, selector);
+    const read = select(selector);
+    const accessor = ((...args: unknown[]): unknown => {
+      if (args.length === 0) return read();
+      setState((state) => patchStateAtPath(state, path, args[0]));
+    }) as StoreBindable<S>;
+    (accessor as unknown as Record<symbol, boolean>)[SIGNAL_ACCESSOR] = true;
+    return accessor;
+  }
+
+  function bind<S>(selector: (state: T) => S): StoreBindable<S> {
+    return createBindableAccessor(selector);
   }
 
   let resolvedInitialState: T;

--- a/packages/store/tsdown.config.ts
+++ b/packages/store/tsdown.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
   entry: ["src/index.ts", "src/form.ts"],
   platform: "browser",
   dts: true,
+  minify: true,
 });

--- a/templates/elysia/package.json
+++ b/templates/elysia/package.json
@@ -11,10 +11,10 @@
   "dependencies": {
     "@elysiajs/html": "^1.4.2",
     "@elysiajs/static": "^1.4.10",
-    "@ilha/router": "^0.6.2",
+    "@ilha/router": "^0.6.3",
     "areia": "^0.1.15",
     "elysia": "^1.4.28",
-    "ilha": "^0.7.1",
+    "ilha": "^0.8.0",
     "quando": "^0.1.6"
   },
   "devDependencies": {

--- a/templates/hono/package.json
+++ b/templates/hono/package.json
@@ -8,10 +8,10 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.2",
-    "@ilha/router": "^0.6.2",
+    "@ilha/router": "^0.6.3",
     "areia": "^0.1.15",
     "hono": "^4.12.18",
-    "ilha": "^0.7.1",
+    "ilha": "^0.8.0",
     "quando": "^0.1.6"
   },
   "devDependencies": {

--- a/templates/nitro/package.json
+++ b/templates/nitro/package.json
@@ -9,9 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.6.2",
+    "@ilha/router": "^0.6.3",
     "areia": "^0.1.15",
-    "ilha": "^0.7.1",
+    "ilha": "^0.8.0",
     "nitro": "^3.0.260522-beta",
     "quando": "^0.1.6"
   },
@@ -19,6 +19,6 @@
     "@tailwindcss/vite": "^4.3.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
-    "vite": "^8.0.14"
+    "vite": "^8.0.16"
   }
 }

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -9,15 +9,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.6.2",
+    "@ilha/router": "^0.6.3",
     "areia": "^0.1.15",
-    "ilha": "^0.7.1",
+    "ilha": "^0.8.0",
     "quando": "^0.1.6"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.0",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
-    "vite": "^8.0.12"
+    "vite": "^8.0.16"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Islands support `.as(tag)` to customize slot-wrapper element tags during render and hydration.
  * Store API provides `select(selector)` for reactive reads and `bind(selector)` for two-way property-path binding.

* **Documentation**
  * Updated store guides and examples to reflect `select`/`bind` usage and selector-based accessors (DOM-element `bind` is no longer documented).

* **Bug Fixes**
  * Improved slot-marker/hydration behavior and async child placeholder reconciliation for non-`div` wrappers.

* **Tests**
  * Expanded coverage for mount behavior, slot wrappers, keyed identity, and CSS scoping.

* **Chores**
  * Version bumps and build minification updates across packages/templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->