### PR TITLE
fix: remove overloads & any type

### DIFF
--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -2,7 +2,7 @@
 // @ilha/store — shared reactive store for Ilha islands (alien-signals)
 // =============================================================================
 
-import { signal, computed, effect } from "alien-signals";
+import { computed, effect, signal } from "alien-signals";
 
 import { capturePropertyPath, patchStateAtPath } from "./bind-path";
 
@@ -71,7 +71,7 @@ export interface StoreApi<T extends object> {
 
 type ActionsCreator<TState extends object, TActions extends object> = (
   set: SetState<TState>,
-  get: GetState<any>,
+  get: GetState<TState>,
   getInitialState: () => TState,
 ) => TActions;
 
@@ -79,14 +79,10 @@ type ActionsCreator<TState extends object, TActions extends object> = (
 // createStore
 // ---------------------------------------------------------------------------
 
-export function createStore<TState extends object>(initialState: TState): StoreApi<TState>;
-
-export function createStore<TState extends object, TActions extends object>(
-  initialState: TState,
-  actions: ActionsCreator<TState, TActions>,
-): StoreApi<TState & TActions>;
-
-export function createStore<TState extends object, TActions extends object = Record<never, never>>(
+export function createStore<
+  TState extends object,
+  TActions extends object = Record<string, unknown>,
+>(
   initialState: TState,
   actionsCreator?: ActionsCreator<TState, TActions>,
 ): StoreApi<TState & TActions> {
@@ -176,7 +172,7 @@ export function createStore<TState extends object, TActions extends object = Rec
   const resolvedActions = actionsCreator
     ? actionsCreator(
         setState as unknown as SetState<TState>,
-        getState as GetState<any>,
+        getState as GetState<TState>,
         () => resolvedInitialState as unknown as TState,
       )
     : ({} as TActions);

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -81,7 +81,7 @@ type ActionsCreator<TState extends object, TActions extends object> = (
 
 export function createStore<
   TState extends object,
-  TActions extends object = Record<string, unknown>,
+  TActions extends object = Record<never, never>,
 >(
   initialState: TState,
   actionsCreator?: ActionsCreator<TState, TActions>,


### PR DESCRIPTION
Fixed issue where generic type would not be provided without typing omitting `actions`, plus `GetState` always being `any` rather than `TState`.

ref: [discord convo](https://discord.com/channels/1428724223756472373/1428726739651264542/1516183890606428180)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the store factory API by consolidating multiple overloads into a single, unified generic signature.
* **Type Safety Improvements**
  * Improved action creator typing so state passed to action creators is strongly typed, reducing reliance on untyped state access.
* **Backward Compatibility**
  * No runtime behavior changes; existing functionality remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->