### PR TITLE
feat(store): add preventDefault wrapper for ilha store form

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -14,7 +14,7 @@
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@ilha/router": "^0.6.5",
-    "@ilha/store": "^0.5.0",
+    "@ilha/store": "^0.5.2",
     "areia": "^0.1.29",
     "dedent": "^1.7.2",
     "ilha": "^0.8.2",

--- a/apps/website/src/pages/(content)/guide/island/derived.mdx
+++ b/apps/website/src/pages/(content)/guide/island/derived.mdx
@@ -219,5 +219,6 @@ See [`.hydratable()`](/guide/island/hydratable) for full snapshot options.
 ## Notes
 
 - Derived keys must be unique within the same builder chain.
-- Async schemas are not supported as derived functions — the function itself can be async, but ilha[`.input()`](/guide/island/input) schemas must remain synchronous.
+- **Rejected or thrown async derived work** sets `derived.key.error` on the envelope — it is **not** routed to [`.onError()`](/guide/island/onerror). Handle failures in the render path via `error` / `loading`.
+- Async schemas are not supported as derived functions — the function itself can be async, but ilha [`.input()`](/guide/island/input) schemas must remain synchronous.
 - Multiple derived entries are independent. Each tracks its own dependencies and re-runs on its own schedule.

--- a/apps/website/src/pages/(content)/guide/island/effect.mdx
+++ b/apps/website/src/pages/(content)/guide/island/effect.mdx
@@ -190,5 +190,7 @@ If you need something to happen only once after mount, use [`.onMount()`](/guide
 ## Notes
 
 - Effects run client-side only. They are not called during SSR.
-- The effect runs synchronously after the first mount, before the browser paints. Keep effects fast to avoid blocking rendering.
+- Effects are registered **after** [`.onMount()`](/guide/island/onmount) (and after any `enter` transition). See [Transition — mount order](/guide/island/transition#mount-order).
+- Sync throws from an effect (or its cleanup) go to [`.onError()`](/guide/island/onerror) with `source: "effect"`. Unhandled promise rejections from fire-and-forget async inside an effect are **not** caught — use `await` or `.catch()` inside the effect.
+- The first effect run happens soon after mount; keep effect bodies fast to avoid blocking rendering.
 - Avoid writing to signals inside an effect that reads those same signals — this creates an infinite loop.

--- a/apps/website/src/pages/(content)/guide/island/hydratable.mdx
+++ b/apps/website/src/pages/(content)/guide/island/hydratable.mdx
@@ -183,8 +183,7 @@ If the island uses [`.css()`](/guide/island/css), the `<style>` tag is included 
 When using file-system routing, `.hydratable()` is called internally by `renderHydratable()` and `renderResponse()`. You typically do not call it directly — the router handles it:
 
 ```ts
-import { pageRouter } from "ilha:pages";
-import { registry } from "ilha:registry";
+import { pageRouter, registry } from "ilha:pages/server";
 
 // The router calls .hydratable() internally for the matched island
 const html = await pageRouter.renderHydratable(
@@ -192,6 +191,8 @@ const html = await pageRouter.renderHydratable(
   registry,
 );
 ```
+
+On the client, import from `ilha:pages/client` (see [Router — virtual modules](/guide/libraries/router#virtual-modules)).
 
 For manual setups without the router, call `.hydratable()` directly in your SSR handler.
 

--- a/apps/website/src/pages/(content)/guide/island/on.mdx
+++ b/apps/website/src/pages/(content)/guide/island/on.mdx
@@ -170,7 +170,7 @@ Race-cancellation is scoped per-target — clicking button A does not cancel an 
 
 ## Async handlers and errors
 
-Async errors (and sync throws) are caught automatically and routed to [`.onError()`](/guide/island/onerror) handlers if any are registered. `AbortError` rejections from cancelled work are filtered out and do not reach `.onError()` or `console.error`.
+Async errors (and sync throws) are caught automatically and routed through the [error sink](/guide/island/onerror): per-island [`.onError()`](/guide/island/onerror), then [`onUncaughtError()`](/guide/island/onerror#global-error-sink-onuncaughterror), then `console.error`. `AbortError` rejections from cancelled work are filtered out and do not reach any of those handlers.
 
 ```tsx twoslash
 import ilha from "ilha";

--- a/apps/website/src/pages/(content)/guide/island/onerror.mdx
+++ b/apps/website/src/pages/(content)/guide/island/onerror.mdx
@@ -1,6 +1,6 @@
 ---
 title: .onError()
-description: Register error handlers that catch throws and rejections from .on() handlers and .effect() runs.
+description: Per-island .onError() handlers and app-wide onUncaughtError() for errors from .on(), .effect(), .onMount(), and transitions.
 order: 207
 ---
 
@@ -31,7 +31,16 @@ export default ilha
 
 # On Error
 
-Registers an error handler that catches errors thrown by [`.on()`](/guide/island/on) handlers (sync throws and async rejections) and [`.effect()`](/guide/island/effect) runs (sync throws). If no `.onError()` handler is registered, errors fall back to `console.error` so they are never silently swallowed.
+Registers a **per-island** error handler. The runtime routes uncaught errors through a central sink: **local `.onError()` handlers first** (in declaration order), then the app-wide **[`onUncaughtError()`](#global-error-sink-onuncaughterror)** sink if the island has none, then **`console.error`** so nothing is swallowed silently.
+
+Island errors that reach the sink include:
+
+- [`.on()`](/guide/island/on) — sync throws and async rejections (except filtered `AbortError`)
+- [`.effect()`](/guide/island/effect) — sync throws from the effect body or its cleanup
+- [`.onMount()`](/guide/island/onmount) — throws from the mount callback or its returned cleanup
+- [`.transition()`](/guide/island/transition) — throws or rejections from `enter` / `leave`
+
+**Derived** failures are not reported here — they surface on `derived.key.error`. Malformed hydration snapshots degrade gracefully and are not routed to `.onError()`.
 
 ## Basic usage
 
@@ -76,7 +85,7 @@ The handler receives an `ErrorContext`:
 ```ts
 {
   error: Error; // always wrapped to Error if a non-Error was thrown
-  source: "on" | "effect"; // where the error originated
+  source: "on" | "effect" | "mount" | "transition";
   state: IslandState; // reactive state signals
   derived: IslandDerived; // current derived values
   input: TInput; // resolved input props
@@ -84,7 +93,7 @@ The handler receives an `ErrorContext`:
 }
 ```
 
-Use `source` to distinguish between `.on()` handler errors and `.effect()` run errors:
+Use `source` to branch logging or UX:
 
 ```tsx twoslash
 import ilha from "ilha";
@@ -94,11 +103,53 @@ const Island = ilha
     throw new Error("click failed");
   })
   .onError(({ error, source }) => {
-    if (source === "on") {
-      console.error("Handler error:", error);
-    } else {
-      console.error("Effect error:", error);
-    }
+    const label =
+      source === "on"
+        ? "Handler"
+        : source === "effect"
+          ? "Effect"
+          : source === "mount"
+            ? "Mount"
+            : "Transition";
+    console.error(`${label}:`, error);
+  })
+  .render(() => <button>Go</button>);
+```
+
+## Global error sink — `onUncaughtError()`
+
+Import **`onUncaughtError`** from `ilha` (not chained on the builder). Register it once in your client entry — for example logging, toast, or telemetry — for **any island that has no local `.onError()`**:
+
+```ts
+import ilha, { onUncaughtError } from "ilha";
+
+const off = onUncaughtError((error, source) => {
+  console.error(`[ilha:${source}]`, error);
+});
+
+// later: off() stops delivery
+```
+
+The callback receives `(error, source)` only — not full `ErrorContext` (`state`, `host`, etc.). Use per-island `.onError()` when you need that context.
+
+| Behavior         | Detail                                                                                                                |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Precedence       | Islands with `.onError()` handle errors locally; the global sink is **not** called for those errors.                  |
+| Fallback order   | No local handlers → global sink(s) → `console.error` if no global handler is registered.                              |
+| Multiple globals | Each `onUncaughtError()` registration runs; a throw inside one global handler is logged and does not stop the others. |
+| Unsubscribe      | The returned function removes that handler from the global set.                                                       |
+
+```tsx twoslash
+import ilha, { onUncaughtError } from "ilha";
+
+onUncaughtError((error, source) => {
+  if (source === "on") console.error("[click]", error);
+});
+
+// This island has no .onError() — clicks reach the global sink.
+const Loose = ilha
+  .on("button@click", () => {
+    throw new Error("oops");
   })
   .render(() => <button>Go</button>);
 ```
@@ -168,7 +219,8 @@ const Island = ilha
 
 ## Notes
 
-- If no `.onError()` handler is registered, errors fall back to `console.error`.
-- `AbortError` rejections from cancelled `.on()` work are always filtered out.
-- Errors thrown inside `.onError()` handlers are logged but do not break subsequent handlers.
-- `.onError()` runs client-side only and is never called during SSR.
+- Fallback order: local `.onError()` → `onUncaughtError()` → `console.error`.
+- `AbortError` rejections from cancelled `.on()` work are always filtered out (not errors).
+- Errors thrown inside `.onError()` or global handlers are logged but do not break other handlers in the same tier.
+- `.onError()` and `onUncaughtError()` run **client-side only** — not during SSR.
+- Rejected promises from fire-and-forget async work inside `.effect()` are not awaited by the runtime; handle them inside the effect (`.catch()` / `await`), not via `.onError()`.

--- a/apps/website/src/pages/(content)/guide/island/onmount.mdx
+++ b/apps/website/src/pages/(content)/guide/island/onmount.mdx
@@ -165,5 +165,6 @@ If you need something to stay in sync with state over time, use [`.effect()`](/g
 ## Notes
 
 - `.onMount()` runs client-side only and is never called during SSR.
-- The mount function runs after the first render and after all effects have been set up.
+- On mount, **`.onMount()` runs after the `enter` transition** (if any) and **before** [`.effect()`](/guide/island/effect) callbacks are registered. See [Transition — mount order](/guide/island/transition#mount-order).
+- Throws from `.onMount()` (or its returned cleanup) are reported to [`.onError()` / `onUncaughtError()`](/guide/island/onerror) with `source: "mount"`.
 - Writing to signals inside `.onMount()` is safe and will trigger a re-render.

--- a/apps/website/src/pages/(content)/guide/island/render.mdx
+++ b/apps/website/src/pages/(content)/guide/island/render.mdx
@@ -305,6 +305,82 @@ const List = ilha.render(() => (
 ));
 ```
 
+### Slot wrapper — `.as(tag)`
+
+Embedded child islands are wrapped in a host element so ilha can hydrate and morph them independently of the parent. By default that wrapper is a `<div>` with a `data-ilha-slot` attribute:
+
+```html
+<div data-ilha-slot="p:0">…child markup…</div>
+```
+
+Call **`.as(tag)`** on the **child** island builder (anywhere before `.render()`) to use a different HTML tag — for valid structure (`<li>` inside `<ul>`), semantics, or styling:
+
+```tsx twoslash
+import ilha from "ilha";
+
+const Age = ilha
+  .as("span")
+  .state("age", 0)
+  .render(({ state }) => <>{state.age()}</>);
+
+const Parent = ilha.render(() => <p>Age: {Age}</p>);
+// → <p>Age: <span data-ilha-slot="p:0">0</span></p>
+```
+
+```tsx twoslash
+import ilha from "ilha";
+
+const Row = ilha
+  .as("li")
+  .input<{ label: string }>()
+  .render(({ input }) => <>{input.label}</>);
+
+const List = ilha.render(() => (
+  <ul>
+    {["a", "b"].map((label) => (
+      <Row key={label} label={label} />
+    ))}
+  </ul>
+));
+```
+
+For list items that keep local state across reorders, combine **`.as("li")`** with **`.key(id)`** on the child (see [keyed child islands](#child-islands) above):
+
+```tsx twoslash
+import ilha from "ilha";
+
+const Item = ilha
+  .as("li")
+  .input<{ label: string }>()
+  .state("n", 0)
+  .on("[data-bump]@click", ({ state }) => {
+    state.n(state.n() + 1);
+  })
+  .render(({ input, state }) => (
+    <>
+      {input.label}:{state.n()}
+      <button type="button" data-bump>
+        +
+      </button>
+    </>
+  ));
+
+const List = ilha
+  .state("order", ["a", "b"] as string[])
+  .render(({ state }) => (
+    <ul>
+      {state.order().map((k) => {
+        const Keyed = Item.key(k);
+        return <Keyed label={k} />;
+      })}
+    </ul>
+  ));
+```
+
+The tag must be a non-empty [valid HTML element name](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name) (for example `span`, `li`, `section`). Invalid names throw at builder time.
+
+`.as()` on the ilha builder is **only** for child island slot wrappers. List helpers such as **`each()`** (for example from [Quando](https://github.com/ilhajs/quando)) use a separate `.as((item, index) => …)` API for mapping items to JSX — not the same method.
+
 ## Function components
 
 Small JSX helper components can return JSX or strings. They receive an object even when no props are passed, so destructuring is safe:

--- a/apps/website/src/pages/(content)/guide/island/render.mdx
+++ b/apps/website/src/pages/(content)/guide/island/render.mdx
@@ -377,7 +377,7 @@ const List = ilha
   ));
 ```
 
-The tag must be a non-empty [valid HTML element name](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name) (for example `span`, `li`, `section`). Invalid names throw at builder time.
+The tag must be a non-empty name matching ilha’s rule: start with an ASCII letter, then letters, digits, or hyphens (same idea as built-in tags like `span`, `li`, `section` — not arbitrary strings). Invalid names throw at builder time.
 
 `.as()` on the ilha builder is **only** for child island slot wrappers. List helpers such as **`each()`** (for example from [Quando](https://github.com/ilhajs/quando)) use a separate `.as((item, index) => …)` API for mapping items to JSX — not the same method.
 

--- a/apps/website/src/pages/(content)/guide/island/transition.mdx
+++ b/apps/website/src/pages/(content)/guide/island/transition.mdx
@@ -165,7 +165,7 @@ const Island = ilha
   .render(() => <div>content</div>);
 ```
 
-If `leave` throws or rejects, cleanup still runs — the transition error is logged to the console but does not prevent unmounting.
+If `leave` throws or rejects, cleanup still runs — the error is routed to [`.onError()` / `onUncaughtError()`](/guide/island/onerror) with `source: "transition"` but does not prevent unmounting.
 
 ## Combining enter and leave
 
@@ -234,16 +234,15 @@ const Island = ilha
   .render(() => <div>content</div>);
 ```
 
-## Interaction with [`.onMount()`](/guide/island/onmount)
+## Mount order
 
-The enter transition and [`.onMount()`](/guide/island/onmount) both run after mount, but in a specific order:
+After the first render is in the DOM, slots are mounted, and event listeners are attached, ilha runs client setup in this order:
 
-1. Island mounts and renders into the DOM.
-2. Effects are set up.
-3. [`.onMount()`](/guide/island/onmount) callbacks run.
-4. Enter transition runs.
+1. **`enter` transition** (if [`.transition()`](/guide/island/transition) is set) — may be sync or async; rejections are reported to [`.onError()` / `onUncaughtError()`](/guide/island/onerror) with `source: "transition"`.
+2. **[`.onMount()`](/guide/island/onmount)** callbacks (unless skipped via hydration `skipOnMount`).
+3. **[`.effect()`](/guide/island/effect)** and derived watchers — then the render effect keeps the host in sync with signals.
 
-This means [`.onMount()`](/guide/island/onmount) always completes before the enter animation starts.
+Enter animations therefore start **before** `.onMount()` and `.effect()`. If you need the DOM fully wired (including child islands) before animating, do that work in `enter` after a `requestAnimationFrame`, or run one-time setup in `.onMount()` knowing it runs after `enter` begins (await `enter` first if `enter` is async and you chain work there).
 
 ## Notes
 

--- a/apps/website/src/pages/(content)/guide/island/transition.mdx
+++ b/apps/website/src/pages/(content)/guide/island/transition.mdx
@@ -242,7 +242,7 @@ After the first render is in the DOM, slots are mounted, and event listeners are
 2. **[`.onMount()`](/guide/island/onmount)** callbacks (unless skipped via hydration `skipOnMount`).
 3. **[`.effect()`](/guide/island/effect)** and derived watchers — then the render effect keeps the host in sync with signals.
 
-Enter animations therefore start **before** `.onMount()` and `.effect()`. If you need the DOM fully wired (including child islands) before animating, do that work in `enter` after a `requestAnimationFrame`, or run one-time setup in `.onMount()` knowing it runs after `enter` begins (await `enter` first if `enter` is async and you chain work there).
+**`.effect()` callbacks are not registered until after `enter` and `.onMount()` finish** — nothing in the effect system runs during `enter`. Use `enter` for the animation itself; use `.onMount()` for one-time setup that must run after `enter` completes (when `enter` is async, await your animation inside `enter` before returning). If you need child slots mounted before measuring or animating, the DOM is already rendered and slots are mounted before step 1 — only effects and the ongoing render loop start later.
 
 ## Notes
 

--- a/apps/website/src/pages/(content)/guide/libraries/ilha.mdx
+++ b/apps/website/src/pages/(content)/guide/libraries/ilha.mdx
@@ -96,17 +96,18 @@ import type {
 } from "ilha";
 ```
 
-| Type                | Use it for                                           |
-| ------------------- | ---------------------------------------------------- |
-| `Island`            | A renderable/mountable island value.                 |
-| `KeyedIsland`       | A registry entry with a stable hydration key.        |
-| `HydratableOptions` | Options accepted by `.hydratable()`.                 |
-| `IslandState`       | State accessors passed to render/handlers/effects.   |
-| `IslandDerived`     | Derived accessors passed to render/handlers/effects. |
-| `HandlerContext`    | Event handler context.                               |
-| `EffectContext`     | Reactive effect context.                             |
-| `OnMountContext`    | Mount hook context.                                  |
-| `ErrorContext`      | Error handler context.                               |
+| Type                | Use it for                                                                   |
+| ------------------- | ---------------------------------------------------------------------------- |
+| `Island`            | A renderable/mountable island value.                                         |
+| `KeyedIsland`       | A registry entry with a stable hydration key.                                |
+| `HydratableOptions` | Options accepted by `.hydratable()`.                                         |
+| `IslandState`       | State accessors passed to render/handlers/effects.                           |
+| `IslandDerived`     | Derived accessors passed to render/handlers/effects.                         |
+| `HandlerContext`    | Event handler context.                                                       |
+| `EffectContext`     | Reactive effect context.                                                     |
+| `OnMountContext`    | Mount hook context.                                                          |
+| `ErrorContext`      | Error handler context.                                                       |
+| `ErrorSource`       | Where an error originated: `"on"`, `"effect"`, `"mount"`, or `"transition"`. |
 
 ## Related packages
 

--- a/apps/website/src/pages/(content)/guide/libraries/ilha.mdx
+++ b/apps/website/src/pages/(content)/guide/libraries/ilha.mdx
@@ -24,7 +24,7 @@ import ilha from "ilha";
 | `.on(selector, handler)`                 | Add delegated event handlers.                | [On](/guide/island/on)                 |
 | `.effect(fn)`                            | Run reactive side effects.                   | [Effect](/guide/island/effect)         |
 | `.onMount(fn)`                           | Run mount-only client effects.               | [On Mount](/guide/island/onmount)      |
-| `.onError(fn)`                           | Catch async/event/effect errors.             | [On Error](/guide/island/onerror)      |
+| `.onError(fn)`                           | Per-island error handler.                    | [On Error](/guide/island/onerror)      |
 | `.transition(options)`                   | Enter/leave animations on mount and unmount. | [Transition](/guide/island/transition) |
 | `.css(styles)`                           | Attach scoped styles.                        | [CSS](/guide/island/css)               |
 | `.render(fn)`                            | Produce an island from JSX/HTML.             | [Render](/guide/island/render)         |
@@ -43,20 +43,22 @@ import {
   batch,
   untrack,
   from,
+  onUncaughtError,
 } from "ilha";
 ```
 
-| Export                      | Purpose                                     | Learn more                        |
-| --------------------------- | ------------------------------------------- | --------------------------------- |
-| `mount(registry, options?)` | Mount islands in the browser.               | [Mount](/guide/helpers/mount)     |
-| `html\`...\``               | Create escaped HTML template output.        | [HTML](/guide/helpers/html)       |
-| `raw(value)`                | Mark trusted HTML as unescaped.             | [Raw](/guide/helpers/raw)         |
-| `css\`...\``                | Create CSS template output.                 | [CSS helper](/guide/helpers/css)  |
-| `signal(initial)`           | Create a shared reactive accessor.          | [Signals](/guide/helpers/signals) |
-| `context(key, initial)`     | Create a keyed shared signal.               | [Signals](/guide/helpers/signals) |
-| `batch(fn)`                 | Batch multiple writes into one update.      | [Signals](/guide/helpers/signals) |
-| `untrack(fn)`               | Read signals without tracking dependencies. | [Signals](/guide/helpers/signals) |
-| `from(source)`              | Adapt external signal-like values for Ilha. | [Signals](/guide/helpers/signals) |
+| Export                      | Purpose                                             | Learn more                                                          |
+| --------------------------- | --------------------------------------------------- | ------------------------------------------------------------------- |
+| `onUncaughtError(fn)`       | App-wide error sink when islands lack `.onError()`. | [On Error](/guide/island/onerror#global-error-sink-onuncaughterror) |
+| `mount(registry, options?)` | Mount islands in the browser.                       | [Mount](/guide/helpers/mount)                                       |
+| `html\`...\``               | Create escaped HTML template output.                | [HTML](/guide/helpers/html)                                         |
+| `raw(value)`                | Mark trusted HTML as unescaped.                     | [Raw](/guide/helpers/raw)                                           |
+| `css\`...\``                | Create CSS template output.                         | [CSS helper](/guide/helpers/css)                                    |
+| `signal(initial)`           | Create a shared reactive accessor.                  | [Signals](/guide/helpers/signals)                                   |
+| `context(key, initial)`     | Create a keyed shared signal.                       | [Signals](/guide/helpers/signals)                                   |
+| `batch(fn)`                 | Batch multiple writes into one update.              | [Signals](/guide/helpers/signals)                                   |
+| `untrack(fn)`               | Read signals without tracking dependencies.         | [Signals](/guide/helpers/signals)                                   |
+| `from(source)`              | Adapt external signal-like values for Ilha.         | [Signals](/guide/helpers/signals)                                   |
 
 ## JSX runtime
 
@@ -90,6 +92,7 @@ import type {
   EffectContext,
   OnMountContext,
   ErrorContext,
+  ErrorSource,
 } from "ilha";
 ```
 

--- a/apps/website/src/pages/(content)/guide/libraries/router.mdx
+++ b/apps/website/src/pages/(content)/guide/libraries/router.mdx
@@ -75,10 +75,9 @@ return new Response(
 ### SSR + hydration (recommended)
 
 ```ts
-// server entry
-import { pageRouter } from "ilha:pages";
-import { registry } from "ilha:registry";
-import "ilha:loaders"; // wires server-only loaders
+// server entry — SSR / Nitro
+import { pageRouter, registry } from "ilha:pages/server";
+import "ilha:loaders"; // wires server-only loaders onto pageRouter
 
 export default defineEventHandler(async (event) => {
   const html = await pageRouter.renderHydratable(
@@ -96,8 +95,7 @@ export default defineEventHandler(async (event) => {
 
 ```ts
 // client entry
-import { pageRouter } from "ilha:pages";
-import { registry } from "ilha:registry";
+import { pageRouter, registry } from "ilha:pages/client";
 
 pageRouter.hydrate(registry);
 ```
@@ -206,7 +204,7 @@ The loader receives a `LoaderContext`:
 }
 ```
 
-On the server, loaders run inside `.renderHydratable()`. On the client, navigations fetch loader data from the `/__ilha/loader` endpoint before mounting the next island.
+On the server, loaders run inside `.renderHydratable()`. You can also call **`.runLoader(url, request?)`** on the builder to execute a loader without rendering HTML. On the client, navigations fetch loader data from the `/__ilha/loader` endpoint before mounting the next island.
 
 ### `redirect(to, status?)`
 
@@ -260,6 +258,27 @@ prefetch("/dashboard?tab=overview");
 ```
 
 `RouterLink` calls this automatically on `mouseenter` for links with the `data-prefetch` attribute.
+
+## Hash mode
+
+By default the router uses the HTML5 History API (`location.pathname`). That needs a server or host that serves your SPA shell for every URL. When that is not possible — `file://`, Electron, or hosts without SPA fallback — use **hash mode** so the route lives in `location.hash`:
+
+```ts
+import { setHistoryMode, router } from "@ilha/router";
+
+setHistoryMode("hash"); // once, before .mount() / .hydrate() / prime()
+
+router()
+  .route("/", HomePage)
+  .route("/about", AboutPage)
+  .mount("#app");
+```
+
+URLs look like `index.html#/about` or `index.html#/user/42?tab=1`. `navigate("/about")` still takes a logical path (no `#` prefix). `<RouterLink>` emits `href="#/…"` in hash mode.
+
+**SSR + hydration is not supported in hash mode** — the hash is never sent to the server. Use plain `.mount("#app")` without `{ hydrate: true }`. Loaders can still run on the client via `/__ilha/loader` or `runLoader()`.
+
+History mode is **process-global** (`navigate`, `RouterLink`, and `prefetch` share it). Set it once at app entry.
 
 ## Route context
 
@@ -516,13 +535,21 @@ export default ((err, route) =>
 
 ### Virtual modules
 
-The plugin exposes three virtual modules:
+Use the **explicit** `/server` or `/client` suffix — they resolve to different generated files (raw imports for SSR vs `?client` imports for the browser bundle).
 
-| Module          | Export       | Description                                  |
-| --------------- | ------------ | -------------------------------------------- |
-| `ilha:pages`    | `pageRouter` | `RouterBuilder` with all routes registered   |
-| `ilha:registry` | `registry`   | `Record<string, Island>` for hydration       |
-| `ilha:loaders`  | —            | Side-effect import that wires server loaders |
+| Module              | Exports                  | Use for                                |
+| ------------------- | ------------------------ | -------------------------------------- |
+| `ilha:pages/server` | `pageRouter`, `registry` | SSR, prerender, Nitro handlers         |
+| `ilha:pages/client` | `pageRouter`, `registry` | Browser hydration entry                |
+| `ilha:loaders`      | —                        | Server-only side-effect: wires loaders |
+
+For **`mode: "static"`** (MPA / pre-rendered HTML), hydrate per page with:
+
+```ts
+import { pageRouter, registry } from "ilha:pages/client";
+
+pageRouter.hydrateStatic(registry);
+```
 
 ### Plugin options
 
@@ -532,8 +559,14 @@ Options are the same for every bundler entry (`vite`, `rspack`, `rolldown`):
 pages({
   dir: "src/pages", // default
   outDir: ".ilha", // default
+  mode: "spa", // "spa" | "static" (default: "spa")
+  interceptLinks: true, // spa only — false = full page loads on <a> clicks
 });
 ```
+
+- **`mode: "spa"`** — full route graph, SSR/hydration, client navigation.
+- **`mode: "spa", interceptLinks: false`** — SSR/hydration, but internal links reload the document.
+- **`mode: "static"`** — registry only on the client; no bundled route graph — use `hydrateStatic`.
 
 For advanced use, import `ilhaPages` from any bundler entry and call `.vite()`, `.rspack()`, or `.rolldown()` on the shared factory.
 
@@ -575,8 +608,10 @@ import type {
 
 ## Related
 
-| Topic                      | Guide                             |
-| -------------------------- | --------------------------------- |
-| Core `ilha` API            | [ilha](/guide/libraries/ilha)     |
-| Shared state across routes | [Store](/guide/libraries/store)   |
-| Route context signals      | [Signals](/guide/helpers/signals) |
+| Topic                      | Guide                                                            |
+| -------------------------- | ---------------------------------------------------------------- |
+| Core `ilha` API            | [ilha](/guide/libraries/ilha)                                    |
+| Shared state across routes | [Store](/guide/libraries/store)                                  |
+| Form submit handlers       | [Store — Forms](/guide/libraries/store#forms) (`preventDefault`) |
+| Route context signals      | [Signals](/guide/helpers/signals)                                |
+| Hydratable SSR             | [Hydratable](/guide/island/hydratable)                           |

--- a/apps/website/src/pages/(content)/guide/libraries/store.mdx
+++ b/apps/website/src/pages/(content)/guide/libraries/store.mdx
@@ -28,10 +28,10 @@ Island [`.state()`](/guide/island/state) is **local** to one component. Use `@il
 
 ## Import paths
 
-| Import path        | Use it for                                                                            |
-| ------------------ | ------------------------------------------------------------------------------------- |
-| `@ilha/store`      | `store`, store types, subscriptions, `select`, `bind`, and `effectScope`              |
-| `@ilha/store/form` | Form extraction, Standard Schema validation, async validation, issue-to-error mapping |
+| Import path        | Use it for                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------------ |
+| `@ilha/store`      | `store`, store types, subscriptions, `select`, `bind`, and `effectScope`                   |
+| `@ilha/store/form` | Form extraction, validation, issue-to-error mapping, `preventDefault` for `.on()` handlers |
 
 ## Quick start
 
@@ -177,7 +177,7 @@ s.count(); // reactive read
 s.count(5); // write → goes through middleware
 ```
 
-Writes are reactive: any ilha render or derived that called `s.count()` re-runs. Accessors carry `[SIGNAL_ACCESSOR]` so they work directly in `html\`\``templates and`bind:\*` directives.
+Writes are reactive: any ilha render or derived that called `s.count()` re-runs. Accessors carry `[SIGNAL_ACCESSOR]` so they work directly in `html` templates and `bind:*` directives.
 
 #### `store.setState(patch)`
 
@@ -278,6 +278,8 @@ Both islands stay in sync. `CartBadge` re-renders only when `count` changes; `Ca
 
 Use `.select()` for ad-hoc projections not worth a named `.derived()`, and `.bind()` for two-way form fields.
 
+**Note:** `state.todos.select((t) => t[i].done)` in island templates is ilha’s nested [`.select()` for `bind:*`](/guide/island/render#nested-fields-with-select) — not `store.select()` on `@ilha/store`.
+
 ## Forms
 
 Three small helpers for building typed, validated forms with any [Standard Schema](https://standardschema.dev)-compatible library.
@@ -288,6 +290,7 @@ import {
   validateWithSchema,
   validateWithSchemaAsync,
   issuesToErrors,
+  preventDefault,
 } from "@ilha/store/form";
 ```
 
@@ -316,6 +319,22 @@ issuesToErrors([
 // → { email: ["Required"], "user.email": ["Invalid"] }
 ```
 
+### `preventDefault(fn)`
+
+Wraps an ilha `.on()` handler so `event.preventDefault()` runs first, then your callback receives the same context (`event`, `state`, `target`, …).
+
+```ts
+ilha.on(
+  "form@submit",
+  preventDefault(({ event }) => {
+    const data = extractFormData(
+      event.target as HTMLFormElement,
+    );
+    // ...
+  }),
+);
+```
+
 ### Full example — contact form
 
 ```tsx
@@ -324,6 +343,7 @@ import {
   extractFormData,
   validateWithSchema,
   issuesToErrors,
+  preventDefault,
 } from "@ilha/store/form";
 import type { FormErrors } from "@ilha/store/form";
 import ilha, { html } from "ilha";
@@ -350,10 +370,10 @@ const formStore = store({ errors: {} as FormErrors })
 const errors = formStore.errors; // state accessor — reactive
 
 export default ilha
-  .on("form@submit", ({ event }) => {
-    event.preventDefault();
-    formStore.submit(event);
-  })
+  .on(
+    "form@submit",
+    preventDefault(({ event }) => formStore.submit(event)),
+  )
   .render(
     () => html`
       <form>

--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,7 @@
     },
     "packages/store": {
       "name": "@ilha/store",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "dependencies": {
         "alien-signals": "3.2.1",
       },

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -315,11 +315,20 @@ Runs a Standard Schema synchronously. Never throws. Returns `{ ok: true, data }`
 
 Flattens Standard Schema issues into a `Record<string, string[]>` keyed by dot-separated path. Form-level errors (no path) land under `""`.
 
+### `preventDefault(fn)` → handler
+
+Wraps an ilha `.on()` callback so `event.preventDefault()` runs first, then your function receives the same context (`event`, `state`, `target`, …).
+
 ### Full example
 
 ```ts
 import { store } from "@ilha/store";
-import { extractFormData, validateWithSchema, issuesToErrors } from "@ilha/store/form";
+import {
+  extractFormData,
+  validateWithSchema,
+  issuesToErrors,
+  preventDefault,
+} from "@ilha/store/form";
 import type { FormErrors } from "@ilha/store/form";
 import ilha, { html } from "ilha";
 import { z } from "zod";
@@ -340,10 +349,10 @@ const formStore = store({ errors: {} as FormErrors })
   .build();
 
 export default ilha
-  .on("form@submit", ({ event }) => {
-    event.preventDefault();
-    formStore.submit(event);
-  })
+  .on(
+    "form@submit",
+    preventDefault(({ event }) => formStore.submit(event)),
+  )
   .render(
     () => html`
       <form>

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/store",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Shared reactive store for Ilha islands.",
   "keywords": [
     "forms",

--- a/packages/store/src/form.test.ts
+++ b/packages/store/src/form.test.ts
@@ -80,6 +80,18 @@ describe("preventDefault()", () => {
 
     receiver.run.call(receiver, { event });
   });
+
+  it("returns the wrapped handler's sync value", () => {
+    const event = new Event("submit", { cancelable: true });
+    const handler = preventDefault(() => 42);
+    expect(handler({ event })).toBe(42);
+  });
+
+  it("returns the wrapped handler's Promise", async () => {
+    const event = new Event("submit", { cancelable: true });
+    const handler = preventDefault(async () => "ok");
+    await expect(handler({ event })).resolves.toBe("ok");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/store/src/form.test.ts
+++ b/packages/store/src/form.test.ts
@@ -11,6 +11,7 @@ import {
   validateWithSchema,
   validateWithSchemaAsync,
   issuesToErrors,
+  preventDefault,
 } from "./form";
 
 // ---------------------------------------------------------------------------
@@ -31,6 +32,55 @@ function fd(entries: Array<[string, FormDataEntryValue]>): FormData {
   for (const [key, value] of entries) data.append(key, value);
   return data;
 }
+
+// ---------------------------------------------------------------------------
+// preventDefault()
+// ---------------------------------------------------------------------------
+
+describe("preventDefault()", () => {
+  it("calls event.preventDefault() before the wrapped handler", () => {
+    const order: string[] = [];
+    const event = new Event("submit", { cancelable: true });
+    const original = event.preventDefault.bind(event);
+    event.preventDefault = () => {
+      order.push("prevent");
+      original();
+    };
+
+    const handler = preventDefault(() => {
+      order.push("fn");
+    });
+
+    handler({ event });
+    expect(order).toEqual(["prevent", "fn"]);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("passes the full handler context to the callback", () => {
+    const event = new Event("submit", { cancelable: true });
+    const state = { count: 1 };
+    let received: { event: Event; state: typeof state } | undefined;
+
+    const handler = preventDefault((ctx: { event: Event; state: typeof state }) => {
+      received = ctx;
+    });
+
+    handler({ event, state });
+    expect(received).toEqual({ event, state });
+  });
+
+  it("forwards `this` to the wrapped function", () => {
+    const event = new Event("click", { cancelable: true });
+    const receiver = {
+      run: preventDefault(function (this: { tag: string }) {
+        expect(this.tag).toBe("receiver");
+      }),
+      tag: "receiver",
+    };
+
+    receiver.run.call(receiver, { event });
+  });
+});
 
 // ---------------------------------------------------------------------------
 // extractFormData()

--- a/packages/store/src/form.ts
+++ b/packages/store/src/form.ts
@@ -87,12 +87,12 @@ export type EventHandlerContext = { event: Event };
  *   }))
  *   .render(...);
  */
-export function preventDefault<C extends EventHandlerContext, This = unknown>(
-  fn: (this: This, ctx: C) => void,
-): (this: This, ctx: C) => void {
+export function preventDefault<C extends EventHandlerContext, This = unknown, R = void>(
+  fn: (this: This, ctx: C) => R,
+): (this: This, ctx: C) => R {
   return function (this: This, ctx: C) {
     ctx.event.preventDefault();
-    fn.call(this, ctx);
+    return fn.call(this, ctx);
   };
 }
 

--- a/packages/store/src/form.ts
+++ b/packages/store/src/form.ts
@@ -68,6 +68,35 @@ export type FormResult<T> =
 export type FormErrors = Record<string, string[]>;
 
 // ---------------------------------------------------------------------------
+// preventDefault
+// ---------------------------------------------------------------------------
+
+/** Minimal context shape ilha passes to `.on()` handlers. */
+export type EventHandlerContext = { event: Event };
+
+/**
+ * Wrap an ilha `.on()` handler so the DOM event is cancelled before your logic runs.
+ *
+ * @example
+ * import { preventDefault } from "@ilha/store/form";
+ *
+ * ilha
+ *   .on("form@submit", preventDefault(({ event, state }) => {
+ *     const data = extractFormData(event.target as HTMLFormElement);
+ *     // ...
+ *   }))
+ *   .render(...);
+ */
+export function preventDefault<C extends EventHandlerContext, This = unknown>(
+  fn: (this: This, ctx: C) => void,
+): (this: This, ctx: C) => void {
+  return function (this: This, ctx: C) {
+    ctx.event.preventDefault();
+    fn.call(this, ctx);
+  };
+}
+
+// ---------------------------------------------------------------------------
 // extractFormData
 // ---------------------------------------------------------------------------
 

--- a/templates/elysia/package.json
+++ b/templates/elysia/package.json
@@ -18,9 +18,9 @@
     "quando": "^0.1.6"
   },
   "devDependencies": {
-    "@tailwindcss/cli": "^4.3.0",
+    "@tailwindcss/cli": "^4.3.1",
     "@types/bun": "latest",
-    "tailwindcss": "^4.3.0",
-    "tsdown": "^0.22.0"
+    "tailwindcss": "^4.3.1",
+    "tsdown": "^0.22.3"
   }
 }

--- a/templates/hono/package.json
+++ b/templates/hono/package.json
@@ -15,10 +15,10 @@
     "quando": "^0.1.6"
   },
   "devDependencies": {
-    "@tailwindcss/cli": "^4.3.0",
+    "@tailwindcss/cli": "^4.3.1",
     "@types/node": "^24",
-    "tailwindcss": "^4.3.0",
-    "tsdown": "^0.22.0",
+    "tailwindcss": "^4.3.1",
+    "tsdown": "^0.22.3",
     "typescript": "^6.0.3"
   }
 }

--- a/templates/nitro/package.json
+++ b/templates/nitro/package.json
@@ -16,8 +16,8 @@
     "quando": "^0.1.6"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^4.3.0",
-    "tailwindcss": "^4.3.0",
+    "@tailwindcss/vite": "^4.3.1",
+    "tailwindcss": "^4.3.1",
     "typescript": "^6.0.3",
     "vite": "^8.0.16"
   }

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -15,8 +15,8 @@
     "quando": "^0.1.6"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^4.3.0",
-    "tailwindcss": "^4.3.0",
+    "@tailwindcss/vite": "^4.3.1",
+    "tailwindcss": "^4.3.1",
     "typescript": "^6.0.3",
     "vite": "^8.0.16"
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `preventDefault(fn)` helper for form event handlers.
  * Documented child-island `.as(tag)` wrapper customization.
* **Documentation**
  * Refreshed island error routing and lifecycle/mount-order guidance (including transition/derived/effect and `AbortError` behavior).
  * Updated router SSR/hydration examples, virtual module import paths, and added router hash-mode documentation.
  * Added/clarified `onUncaughtError()` global error sink and `ErrorSource` docs.
* **Chores**
  * Bumped `@ilha/store` to v0.5.2 and updated template tooling versions.
* **Tests**
  * Expanded tests for `preventDefault(fn)` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->