### PR TITLE
chore(store): allow void actions

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -14,7 +14,7 @@
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@ilha/router": "^0.6.5",
-    "@ilha/store": "^0.5.2",
+    "@ilha/store": "^0.5.3",
     "areia": "^0.1.29",
     "dedent": "^1.7.2",
     "ilha": "^0.8.2",

--- a/apps/website/src/pages/(content)/guide/libraries/store.mdx
+++ b/apps/website/src/pages/(content)/guide/libraries/store.mdx
@@ -118,7 +118,7 @@ Re-running (when `id` changes) keeps the previous `.value` visible while `.loadi
 
 ### `.action(key, fn)`
 
-Registers a named mutation. `fn` receives props and `ctx`; return a `Partial` patch that merges into state through middleware.
+Registers a named mutation. `fn` receives props and `ctx`. Return a `Partial` patch to merge through middleware, or return nothing when writes use `ctx.set` only or the action has no state updates.
 
 ```ts
 // Zero-arg — omit or leave first param unannotated
@@ -128,13 +128,12 @@ Registers a named mutation. `fn` receives props and `ctx`; return a `Partial` pa
 .action("setLabel", (label: string) => ({ label }))
 ```
 
-`ctx` exposes `{ get(), getInitial(), set(patch) }`. Use `ctx.set` for async/multi-step actions and `return {}`:
+`ctx` exposes `{ get(), getInitial(), set(patch) }`. Use `ctx.set` for async/multi-step actions (no return value needed):
 
 ```ts
 .action("load", (_, ctx) => {
   ctx.set({ loading: true });
   fetchUser(ctx.get().id).then((user) => ctx.set({ user, loading: false }));
-  return {};
 })
 ```
 

--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,7 @@
     },
     "packages/store": {
       "name": "@ilha/store",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "dependencies": {
         "alien-signals": "3.2.1",
       },

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -126,7 +126,7 @@ userStore.user.error; // Error | undefined if it rejected
 
 #### `.action(key, fn)`
 
-Registers a named mutation. `fn` receives the props and a context object, and returns a `Partial` state patch that is merged in via `setState`.
+Registers a named mutation. `fn` receives the props and a context object. Return a `Partial` patch to merge via `setState`, or return nothing when all writes go through `ctx.set` or the action is side-effect-only.
 
 ```ts
 // Zero-arg action — omit or leave first param unannotated
@@ -150,7 +150,6 @@ The returned patch is the primary write path. Use `ctx.set` for async actions th
 .action("load", (_, ctx) => {
   ctx.set({ loading: true });
   fetchUser().then((user) => ctx.set({ user, loading: false }));
-  return {}; // writes happen via ctx.set
 })
 ```
 

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/store",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Shared reactive store for Ilha islands.",
   "keywords": [
     "forms",

--- a/packages/store/src/index.test.ts
+++ b/packages/store/src/index.test.ts
@@ -349,6 +349,26 @@ describe(".action()", () => {
     expect(listener).not.toHaveBeenCalled();
   });
 
+  it("void return skips setState (side effects via ctx.set only)", () => {
+    const s = store({ count: 0 })
+      .action("bump", (_, ctx) => {
+        ctx.set({ count: ctx.get().count + 1 });
+      })
+      .build();
+    s.bump();
+    expect(s.count()).toBe(1);
+  });
+
+  it("implicit void return does not fire change", () => {
+    const s = store({ count: 0 })
+      .action("sideEffect", () => {})
+      .build();
+    const listener = mock();
+    s.subscribe(listener);
+    s.sideEffect();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
   it("ctx.getInitial() reads the initial snapshot", () => {
     const s = store({ count: 5 })
       .action("resetCount", (_, ctx) => ({ count: ctx.getInitial().count }))
@@ -364,7 +384,6 @@ describe(".action()", () => {
         ctx.set({ loading: true });
         // simulate async resolve
         queueMicrotask(() => ctx.set({ count: 42, loading: false }));
-        return {}; // no-op return; writes happen via ctx.set
       })
       .build();
     s.load();
@@ -383,7 +402,6 @@ describe(".action()", () => {
       })
       .action("viaSet", (_, ctx) => {
         ctx.set({ count: 7 });
-        return {};
       })
       .build();
     s.viaSet();

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -83,8 +83,8 @@ export interface MiddlewareCtx<TState> {
 /** A derived entry: `(ctx) => V`. */
 type DerivedFn<TState, V = unknown> = (ctx: DerivedCtx<TState>) => V;
 
-/** An action entry: `(props, ctx) => Partial<TState>`. */
-type ActionFn<TState, P = any> = (props: P, ctx: ActionCtx<TState>) => Partial<TState>;
+/** An action entry: `(props, ctx) => Partial<TState> | void`. */
+type ActionFn<TState, P = any> = (props: P, ctx: ActionCtx<TState>) => Partial<TState> | void;
 
 type Middleware<TState> = (
   patch: Partial<TState>,
@@ -253,7 +253,7 @@ export class StoreBuilder<
 
   action<K extends string, P = undefined>(
     key: K,
-    fn: (props: P, ctx: ActionCtx<TState>) => Partial<TState>,
+    fn: (props: P, ctx: ActionCtx<TState>) => Partial<TState> | void,
   ): StoreBuilder<TState, D, A & Record<K, typeof fn>> {
     return new StoreBuilder({
       ...this._cfg,
@@ -535,7 +535,8 @@ function buildStore<
   const actionHandlers = new Map<string, (props?: unknown) => void>();
   for (const { key, fn } of cfg.actions) {
     actionHandlers.set(key, (props?: unknown) => {
-      setState(fn(props as never, actionCtx));
+      const patch = fn(props as never, actionCtx);
+      if (patch !== undefined) setState(patch);
     });
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Actions now support returning `void` when no state patch is needed.

* **Documentation**
  - Clarified action return contract and updated guidance for `ctx.set()` usage patterns.

* **Chores**
  - Updated `@ilha/store` to version 0.5.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->