### PR TITLE
Feat/store schema init

### DIFF
--- a/apps/website/src/pages/(content)/guide/island/input.mdx
+++ b/apps/website/src/pages/(content)/guide/island/input.mdx
@@ -25,6 +25,27 @@ Declares the island's external props and their types. Two forms are supported: a
 
 <Preview code={example} size="sm" />
 
+**Default props object** — inference plus runtime defaults (shallow merge, no validator):
+
+```tsx twoslash
+import ilha from "ilha";
+
+const Greeting = ilha
+  .input({ name: "World" })
+  .render(({ input }) => <p>Hello, {input.name}!</p>);
+
+Greeting(); // → <p>Hello, World!</p>
+Greeting({ name: "ilha" }); // → <p>Hello, ilha!</p>
+```
+
+```tsx twoslash
+import ilha from "ilha";
+
+ilha
+  .input<{ name: string }>({ name: "World" })
+  .render(({ input }) => <p>{input.name}</p>);
+```
+
 **With a schema** — inference plus runtime validation and coercion:
 
 ```tsx twoslash
@@ -49,18 +70,20 @@ Without `.input()`, any props passed to an island are untyped and unvalidated. A
 
 ## Choosing a form
 
-|                      | `.input<T>()` | `.input(schema)`       |
-| -------------------- | ------------- | ---------------------- |
-| TypeScript inference | ✓             | ✓                      |
-| Runtime validation   | —             | ✓                      |
-| Default values       | —             | ✓ (via schema)         |
-| Extra dependency     | —             | ✓ (Zod, Valibot, etc.) |
+|                      | `.input<T>()` | `.input({ … })` / `.input<T>({ … })` | `.input(schema)`       |
+| -------------------- | ------------- | ------------------------------------ | ---------------------- |
+| TypeScript inference | ✓             | ✓                                    | ✓                      |
+| Runtime validation   | —             | —                                    | ✓                      |
+| Default values       | —             | ✓ (shallow merge)                    | ✓ (via schema)         |
+| Extra dependency     | —             | —                                    | ✓ (Zod, Valibot, etc.) |
 
-Use `.input<T>()` for simple islands where you control the call sites and don't need validation. Use `.input(schema)` when you need defaults, coercion, or validation — especially for islands that are hydrated from serialized server props.
+Use `.input<T>()` when callers always pass props. Use `.input({ … })` for lightweight defaults without a schema (same idea as `store({ … })`). Use `.input(schema)` when you need coercion or validation — especially for islands hydrated from serialized server props.
 
 ## Using defaults
 
-Defaults are defined in the schema, not in ilha. Any Standard Schema validator that supports defaults will apply them automatically when a prop is omitted.
+**POJO form** — pass a defaults object to `.input({ … })`. Ilha shallow-merges `{ ...defaults, ...props }` on each call.
+
+**Schema form** — defaults live in the schema (Zod `.default()`, etc.). Validation runs on the merged props object.
 
 ```tsx twoslash
 import ilha from "ilha";

--- a/apps/website/src/pages/(content)/guide/libraries/store.mdx
+++ b/apps/website/src/pages/(content)/guide/libraries/store.mdx
@@ -75,12 +75,30 @@ ilha's built-in `.state()` is the right choice when only one island reads and wr
 
 ## API
 
-### `store(initialState)`
+### `store(initialState)` · `store(schema)`
 
 Returns a `StoreBuilder`. Chain builder methods then call `.build()` to get a live reactive store. `.build()` throws if any key collides across state, derived, actions, and built-in method names.
 
 ```ts
 const s = store({ count: 0 }).build();
+
+store<{ foo: string }>({ foo: "bar" }).build(); // explicit POJO type
+```
+
+Or pass a [Standard Schema](https://standardschema.dev) so **every write** (accessors, `setState`, `bind:*`, actions) validates the merged state. Invalid commits are rejected; use `.onError()` to handle them. Initial state is parsed from the schema (use `.default()` on fields you want at startup).
+
+```ts
+import { z } from "zod";
+
+const s = store(
+  z.object({
+    email: z.email().default("ada@example.com"),
+  }),
+)
+  .onError(({ error, issues }) => {
+    /* toast, fieldErrors: error.fieldErrors */
+  })
+  .build();
 ```
 
 Builder methods are **immutable** — each returns a new `StoreBuilder`.
@@ -158,6 +176,10 @@ Registers a lifecycle listener. `handler` receives `(nextState, prevState)`.
 | ---------- | ------------------------------------------------ |
 | `"init"`   | Once, synchronously inside `.build()`            |
 | `"change"` | After every committed mutation (post-middleware) |
+
+### `.onError(handler)`
+
+Schema-backed stores only. Runs when a commit fails validation — state stays at the last good snapshot. Context: `{ error, source: "validate", patch?, path?, issues?, get() }`. `error` is a `StoreValidationError` (`issues`, `fieldErrors`). Without a handler, `console.error` is used.
 
 ### `.build()`
 
@@ -402,6 +424,8 @@ import type {
   DerivedCtx, // { get(), signal } — passed to .derived()
   ActionCtx, // { get(), getInitial(), set() } — passed to .action()
   MiddlewareCtx, // { get(), getInitial() } — passed to .middleware()
+  StoreErrorContext, // { error, source, patch?, issues?, get() } — .onError()
+  StoreValidationError,
   StoreBindable, // <S>: read/write accessor for bind:*
   Listener, // (state, prevState) => void
   SliceListener, // (slice, prevSlice) => void

--- a/apps/website/src/pages/(content)/guide/libraries/store.mdx
+++ b/apps/website/src/pages/(content)/guide/libraries/store.mdx
@@ -424,7 +424,7 @@ import type {
   DerivedCtx, // { get(), signal } — passed to .derived()
   ActionCtx, // { get(), getInitial(), set() } — passed to .action()
   MiddlewareCtx, // { get(), getInitial() } — passed to .middleware()
-  StoreErrorContext, // { error, source, patch?, issues?, get() } — .onError()
+  StoreErrorContext, // { error, source, path?, patch?, issues?, get() } — .onError()
   StoreValidationError,
   StoreBindable, // <S>: read/write accessor for bind:*
   Listener, // (state, prevState) => void

--- a/bun.lock
+++ b/bun.lock
@@ -40,7 +40,7 @@
     },
     "packages/ilha": {
       "name": "ilha",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "alien-signals": "3.2.1",
       },
@@ -50,7 +50,7 @@
     },
     "packages/router": {
       "name": "@ilha/router",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "dependencies": {
         "ilha": "0.8.2",
         "rou3": "0.8.1",
@@ -62,12 +62,12 @@
     },
     "packages/store": {
       "name": "@ilha/store",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "alien-signals": "3.2.1",
       },
       "devDependencies": {
-        "ilha": "0.8.2",
+        "ilha": "0.8.3",
         "zod": "^4.4.3",
       },
       "peerDependencies": {

--- a/packages/ilha/package.json
+++ b/packages/ilha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ilha",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "A tiny, framework-free island architecture library",
   "keywords": [
     "framework-free",

--- a/packages/ilha/src/index.test.ts
+++ b/packages/ilha/src/index.test.ts
@@ -294,6 +294,50 @@ describe("raw()", () => {
 // Island — SSR
 // ---------------------------------------------
 
+describe(".input() POJO defaults", () => {
+  it("merges defaults when island is called with no args", () => {
+    const Island = ilha
+      .input({ name: "World" })
+      .render(({ input }) => `<p>Hello, ${input.name}</p>`);
+
+    expect(Island()).toBe("<p>Hello, World</p>");
+  });
+
+  it("props override defaults", () => {
+    const Island = ilha.input({ name: "World" }).render(({ input }) => `<p>${input.name}</p>`);
+
+    expect(Island({ name: "ilha" })).toBe("<p>ilha</p>");
+  });
+
+  it("initializes state from merged input", () => {
+    const Island = ilha
+      .input({ start: 3 })
+      .state("count", ({ start }) => start)
+      .render(({ state }) => `<p>${state.count()}</p>`);
+
+    expect(Island()).toBe("<p>3</p>");
+    expect(Island({ start: 9 })).toBe("<p>9</p>");
+  });
+
+  it("explicit generic widens the input type", () => {
+    type Props = { foo: string; extra?: number };
+    const Island = ilha
+      .input<Props>({ foo: "bar" })
+      .render(({ input }) => `<span>${input.foo}</span>`);
+
+    expect(Island()).toBe("<span>bar</span>");
+    expect(Island({ foo: "baz", extra: 1 })).toBe("<span>baz</span>");
+  });
+
+  it("type-only .input<T>() still uses empty props when no defaults", () => {
+    const Island = ilha
+      .input<{ name?: string }>()
+      .render(({ input }) => `<p>${input.name ?? "none"}</p>`);
+
+    expect(Island()).toBe("<p>none</p>");
+  });
+});
+
 describe("Island SSR", () => {
   it("renders with schema defaults when called with no args", () => {
     const Counter = ilha

--- a/packages/ilha/src/index.ts
+++ b/packages/ilha/src/index.ts
@@ -335,6 +335,12 @@ function morphInner(from: Element, to: Element): void {
 // Internal helpers
 // ---------------------------------------------
 
+function isStandardSchema(value: unknown): value is StandardSchemaV1 {
+  if (value == null || typeof value !== "object") return false;
+  const std = (value as StandardSchemaV1)["~standard"];
+  return std != null && typeof std.validate === "function" && std.version === 1;
+}
+
 function validateSchema<S extends StandardSchemaV1>(
   schema: S,
   value: unknown,
@@ -2023,6 +2029,8 @@ interface BuilderConfig<
   TDerivedMap extends Record<string, unknown>,
 > {
   schema: StandardSchemaV1 | null;
+  /** Shallow defaults merged before props (POJO `.input({ ... })` only). */
+  defaultInput: Record<string, unknown> | null;
   states: StateEntry<TInput>[];
   deriveds: DerivedEntry<TInput, TStateMap>[];
   ons: OnEntry<TInput, TStateMap, TDerivedMap>[];
@@ -2068,9 +2076,21 @@ class IlhaBuilder<
     Record<never, never>,
     Record<never, never>
   >;
-  input(schema?: StandardSchemaV1): IlhaBuilder<Record<string, unknown>, Record<never, never>> {
+  input<T extends Record<string, unknown>>(
+    defaults: T,
+  ): IlhaBuilder<T, Record<never, never>, Record<never, never>>;
+  input(
+    initialOrSchema?: StandardSchemaV1 | Record<string, unknown>,
+  ): IlhaBuilder<Record<string, unknown>, Record<never, never>, Record<never, never>> {
+    let schema: StandardSchemaV1 | null = null;
+    let defaultInput: Record<string, unknown> | null = null;
+    if (initialOrSchema !== undefined) {
+      if (isStandardSchema(initialOrSchema)) schema = initialOrSchema;
+      else defaultInput = initialOrSchema;
+    }
     return new IlhaBuilder({
-      schema: schema ?? null,
+      schema,
+      defaultInput,
       states: [],
       deriveds: [],
       ons: [],
@@ -2194,6 +2214,7 @@ class IlhaBuilder<
   ): Island<TInput, TStateMap> {
     const {
       schema,
+      defaultInput,
       states,
       deriveds,
       ons,
@@ -2209,9 +2230,12 @@ class IlhaBuilder<
     const configuredSlotTag = slotAs ?? "div";
 
     function resolveInput(props?: Partial<TInput>): TInput {
-      const value = props ?? {};
-      if (!schema) return value as TInput;
-      return validateSchema(schema, value) as TInput;
+      const merged = {
+        ...(defaultInput ?? {}),
+        ...(props ?? {}),
+      } as Record<string, unknown>;
+      if (!schema) return merged as TInput;
+      return validateSchema(schema, merged) as TInput;
     }
 
     // Run fn inside a fresh render context so any interpolated ${Island}
@@ -3338,6 +3362,7 @@ const EMPTY_CFG: BuilderConfig<
   Record<never, never>
 > = {
   schema: null,
+  defaultInput: null,
   states: [],
   deriveds: [],
   ons: [],

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/router",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "A tiny SPA router for Ilha",
   "keywords": [
     "frontend",
@@ -60,7 +60,7 @@
     "test": "bun test"
   },
   "dependencies": {
-    "ilha": "0.8.2",
+    "ilha": "0.8.3",
     "rou3": "0.8.1",
     "unplugin": "3.0.0"
   },

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -72,12 +72,32 @@ counterStore.reset(); // restores to initial state
 
 ## API
 
-### `store(initialState)`
+### `store(initialState)` · `store(schema)`
 
 Returns a `StoreBuilder`. Chain builder methods, then call `.build()` to get a live reactive store.
 
 ```ts
 const s = store({ count: 0 }).build();
+
+// explicit state type when inference is too wide
+const typed = store<{ foo: string }>({ foo: "bar" }).build();
+```
+
+Pass a [Standard Schema](https://standardschema.dev) (Zod, Valibot, ArkType, …) to validate **every commit** — accessor writes, `setState`, `bind:*`, and action patches. Initial state is parsed from the schema (`.default()` fields apply when seeding with `{}`).
+
+```ts
+import { z } from "zod";
+
+const s = store(
+  z.object({
+    email: z.email().default(""),
+    age: z.coerce.number().min(0).default(0),
+  }),
+)
+  .onError(({ error, issues, patch }) => {
+    // invalid bind / setState — state is unchanged
+  })
+  .build();
 ```
 
 `.build()` throws if any key collides — state vs derived vs action vs built-in names (`setState`, `subscribe`, `select`, `bind`, `getState`, `getInitialState`).
@@ -179,6 +199,10 @@ Registers a lifecycle listener. `handler` receives `(nextState, prevState)`.
 | ---------- | ------------------------------------------------ |
 | `"init"`   | Once, synchronously inside `.build()`            |
 | `"change"` | After every committed mutation (post-middleware) |
+
+#### `.onError(handler)`
+
+When the store was created with a Standard Schema, invalid commits are **rejected** (state unchanged). `handler` receives `{ error, source, patch?, path?, issues?, get() }`. `error` is a `StoreValidationError` with `.issues` and `.fieldErrors`. Without `.onError()`, failures log to `console.error`.
 
 ```ts
 store({ count: 0 })

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/store",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Shared reactive store for Ilha islands.",
   "keywords": [
     "forms",
@@ -55,7 +55,7 @@
     "alien-signals": "3.2.1"
   },
   "devDependencies": {
-    "ilha": "0.8.2",
+    "ilha": "0.8.3",
     "zod": "^4.4.3"
   },
   "peerDependencies": {

--- a/packages/store/src/index.test.ts
+++ b/packages/store/src/index.test.ts
@@ -7,8 +7,9 @@ import { describe, it, expect, mock, beforeEach } from "bun:test";
 
 import { effect } from "alien-signals";
 import ilha, { html } from "ilha";
+import { z } from "zod";
 
-import { store, effectScope } from "./index";
+import { store, effectScope, StoreValidationError } from "./index";
 
 beforeEach(() => {
   document.body.innerHTML = "";
@@ -50,6 +51,15 @@ describe("store() builder", () => {
     // b0 has no actions; building it yields a store without inc.
     const s0 = b0.build();
     expect((s0 as unknown as { inc?: unknown }).inc).toBeUndefined();
+  });
+
+  it("accepts an explicit type argument for POJO stores", () => {
+    type Model = { foo: string; n: number };
+    const s = store<Model>({ foo: "bar", n: 0 }).build();
+    s.foo("baz");
+    expect(s.foo()).toBe("baz");
+    // @ts-expect-error — foo must be string
+    s.foo(1);
   });
 
   it("two independent stores do not share state", () => {
@@ -1032,5 +1042,112 @@ describe("type inference", () => {
     // @ts-expect-error — actions are not part of the state snapshot
     void st.inc;
     expect(n).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Standard Schema store + .onError()
+// ---------------------------------------------------------------------------
+
+describe("store(Standard Schema)", () => {
+  it("derives initial state from schema defaults", () => {
+    const Schema = z.object({
+      label: z.string().default("hello"),
+      n: z.number().default(2),
+    });
+    const s = store(Schema).build();
+    expect(s.getState()).toEqual({ label: "hello", n: 2 });
+  });
+
+  it("rejects invalid setState and does not mutate", () => {
+    const Schema = z.object({ email: z.email().default("ada@example.com") });
+    const s = store(Schema)
+      .onError(() => {})
+      .build();
+    s.setState({ email: "not-an-email" });
+    expect(s.getState().email).toBe("ada@example.com");
+  });
+
+  it(".onError receives StoreValidationError with issues", () => {
+    const Schema = z.object({ age: z.number().min(0).default(0) });
+    const seen: Array<{ message: string; issuesLen: number }> = [];
+    const s = store(Schema)
+      .onError(({ error, source, issues, patch }) => {
+        expect(source).toBe("validate");
+        expect(error).toBeInstanceOf(StoreValidationError);
+        expect(patch).toEqual({ age: -1 });
+        seen.push({
+          message: error.message,
+          issuesLen: issues?.length ?? 0,
+        });
+      })
+      .build();
+    s.setState({ age: -1 });
+    expect(seen.length).toBe(1);
+    expect(seen[0]!.issuesLen).toBeGreaterThan(0);
+  });
+
+  it("applies coercion on successful commit", () => {
+    const Schema = z.object({ n: z.coerce.number().default(0) });
+    const s = store(Schema).build();
+    s.setState({ n: "42" as unknown as number });
+    expect(s.n()).toBe(42);
+  });
+
+  it("bind write rejects invalid value and leaves state unchanged", () => {
+    const Schema = z.object({ email: z.email().default("ada@example.com") });
+    let errors = 0;
+    const s = store(Schema)
+      .onError(() => {
+        errors++;
+      })
+      .build();
+    const email = s.bind((st) => st.email);
+    email("bad");
+    expect(errors).toBe(1);
+    expect(email()).toBe("ada@example.com");
+  });
+
+  it("bind write accepts valid email", () => {
+    const Schema = z.object({ email: z.email().default("ada@example.com") });
+    const s = store(Schema).build();
+    const email = s.bind((st) => st.email);
+    email("ada@example.com");
+    expect(email()).toBe("ada@example.com");
+  });
+
+  it("ilha bind:value rejects invalid email without updating state", () => {
+    const Schema = z.object({ email: z.email().default("ok@example.com") });
+    let n = 0;
+    const formStore = store(Schema)
+      .onError(() => {
+        n++;
+      })
+      .build();
+    const Island = ilha.render(() => html`<input bind:value=${formStore.bind((s) => s.email)} />`);
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const unmount = Island.mount(el);
+    const input = el.querySelector("input")!;
+    input.value = "not-email";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    expect(n).toBe(1);
+    expect(formStore.email()).toBe("ok@example.com");
+    unmount();
+    el.remove();
+  });
+
+  it("falls back to console.error when no .onError()", () => {
+    const errSpy = mock(() => {});
+    const orig = console.error;
+    console.error = errSpy as typeof console.error;
+    try {
+      const Schema = z.object({ x: z.number().default(0) });
+      const s = store(Schema).build();
+      s.setState({ x: "nope" as unknown as number });
+      expect(errSpy).toHaveBeenCalled();
+    } finally {
+      console.error = orig;
+    }
   });
 });

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -7,6 +7,20 @@
 import { signal, computed, effect, setActiveSub } from "alien-signals";
 
 import { capturePropertyPath, patchStateAtPath } from "./bind-path";
+import type { StandardSchemaV1 } from "./form";
+import {
+  isStandardSchema,
+  parseInitialStateFromSchema,
+  primaryIssuePath,
+  StoreValidationError,
+  validateStateSnapshot,
+  type StoreErrorSource,
+} from "./schema";
+
+export type { StandardSchemaV1 } from "./form";
+export { isStandardSchema, StoreValidationError, type StoreErrorSource } from "./schema";
+
+export type SchemaState<S extends StandardSchemaV1> = StandardSchemaV1.InferOutput<S> & object;
 
 const SIGNAL_ACCESSOR = Symbol.for("ilha.signalAccessor");
 
@@ -51,6 +65,20 @@ export type DerivedAccessor<T> = {
 };
 
 export type StoreEvent = "change" | "init";
+
+/** Context passed to `.onError()` when a schema-backed commit is rejected. */
+export type StoreErrorContext<TState extends object> = {
+  error: Error;
+  source: StoreErrorSource;
+  /** Partial patch that was merged before validation (if any). */
+  patch?: Partial<TState>;
+  /** Dot path of the first issue, when available. */
+  path?: string;
+  issues?: ReadonlyArray<StandardSchemaV1.Issue>;
+  get(): TState;
+};
+
+type StoreErrorHandler<TState extends object> = (ctx: StoreErrorContext<TState>) => void;
 
 /** Context passed to `.derived()` callbacks. Read-only — derived must stay pure. */
 export interface DerivedCtx<TState> {
@@ -193,6 +221,18 @@ function isNoopPatch<T extends object>(prev: T, patch: Partial<T>): boolean {
   return true;
 }
 
+function shallowStateEqual<T extends object>(a: T, b: T): boolean {
+  const ak = Object.keys(a);
+  const bk = Object.keys(b);
+  if (ak.length !== bk.length) return false;
+  for (const k of ak) {
+    if (!Object.is((a as Record<string, unknown>)[k], (b as Record<string, unknown>)[k])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function collisionError(key: string, kind: "state" | "derived" | "action" | "built-in"): Error {
   return new Error(`@ilha/store: key collision — "${key}" is already defined as a ${kind} key.`);
 }
@@ -207,10 +247,12 @@ interface BuilderConfig<
   A extends Record<string, ActionFn<TState>>,
 > {
   initialState: TState;
+  schema?: StandardSchemaV1;
   deriveds: ReadonlyArray<{ key: string; fn: DerivedFn<TState> }>;
   actions: ReadonlyArray<{ key: string; fn: ActionFn<TState> }>;
   middlewares: ReadonlyArray<Middleware<TState>>;
   listeners: ReadonlyArray<{ event: StoreEvent; handler: Listener<TState> }>;
+  errorHandlers: ReadonlyArray<{ fn: StoreErrorHandler<TState> }>;
   // Phantom carriers so D/A flow through the chained return types.
   readonly _d?: D;
   readonly _a?: A;
@@ -238,6 +280,20 @@ export class StoreBuilder<
       actions: [],
       middlewares: [],
       listeners: [],
+      errorHandlers: [],
+    });
+  }
+
+  static createWithSchema<S extends StandardSchemaV1>(schema: S): StoreBuilder<SchemaState<S>> {
+    const initialState = parseInitialStateFromSchema(schema) as SchemaState<S>;
+    return new StoreBuilder<SchemaState<S>>({
+      initialState,
+      schema,
+      deriveds: [],
+      actions: [],
+      middlewares: [],
+      listeners: [],
+      errorHandlers: [],
     });
   }
 
@@ -272,6 +328,13 @@ export class StoreBuilder<
     return new StoreBuilder({
       ...this._cfg,
       listeners: [...this._cfg.listeners, { event, handler }],
+    });
+  }
+
+  onError(fn: StoreErrorHandler<TState>): StoreBuilder<TState, D, A> {
+    return new StoreBuilder({
+      ...this._cfg,
+      errorHandlers: [...this._cfg.errorHandlers, { fn }],
     });
   }
 
@@ -319,12 +382,52 @@ function buildStore<
 
   const changeListeners = cfg.listeners.filter((l) => l.event === "change").map((l) => l.handler);
   const initListeners = cfg.listeners.filter((l) => l.event === "init").map((l) => l.handler);
+  const onErrors = cfg.errorHandlers;
+
+  function getState(): TState {
+    return stateSignal();
+  }
+
+  function reportStoreError(error: Error, source: StoreErrorSource, patch?: Partial<TState>): void {
+    const issues = error instanceof StoreValidationError ? error.issues : undefined;
+    const ctx: StoreErrorContext<TState> = {
+      error,
+      source,
+      patch,
+      path: issues ? primaryIssuePath(issues) : undefined,
+      issues,
+      get: getState,
+    };
+    if (onErrors.length === 0) {
+      console.error(error);
+      return;
+    }
+    for (const { fn } of onErrors) {
+      try {
+        fn(ctx);
+      } catch (handlerErr) {
+        console.error(handlerErr);
+      }
+    }
+  }
 
   // --- mutation pipeline ----------------------------------------------------
   const committed = (patch: Partial<TState>): void => {
     const prev = stateSignal();
-    if (isNoopPatch(prev, patch)) return; // skip spurious commits
-    const next = { ...prev, ...patch };
+    if (isNoopPatch(prev, patch)) return;
+    const candidate = { ...prev, ...patch } as TState;
+
+    let next: TState = candidate;
+    if (cfg.schema) {
+      const result = validateStateSnapshot(cfg.schema, candidate);
+      if (!result.ok) {
+        reportStoreError(new StoreValidationError(result.issues, patch), "validate", patch);
+        return;
+      }
+      next = result.data as TState;
+    }
+
+    if (shallowStateEqual(prev, next)) return;
     stateSignal(next);
     for (const fn of changeListeners) fn(next, prev);
   };
@@ -351,10 +454,6 @@ function buildStore<
     if (Object.keys(patch).length === 0) return;
     untrackRun(() => chain(patch));
   };
-
-  function getState(): TState {
-    return stateSignal();
-  }
 
   // --- built-ins ------------------------------------------------------------
   function select<S>(selector: (state: TState) => S): () => S {
@@ -601,8 +700,14 @@ function buildStore<
 // store() factory
 // ---------------------------------------------------------------------------
 
-export function store<TState extends object>(initialState: TState): StoreBuilder<TState> {
-  return StoreBuilder.create(initialState);
+export function store<S extends StandardSchemaV1>(schema: S): StoreBuilder<SchemaState<S>>;
+/** Plain object initial state. Pass an explicit type argument when inference is too wide. */
+export function store<TState extends object>(initialState: TState): StoreBuilder<TState>;
+export function store(initialOrSchema: object): StoreBuilder<object> {
+  if (isStandardSchema(initialOrSchema)) {
+    return StoreBuilder.createWithSchema(initialOrSchema);
+  }
+  return StoreBuilder.create(initialOrSchema);
 }
 
 export { effectScope } from "alien-signals";

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -9,6 +9,7 @@ import { signal, computed, effect, setActiveSub } from "alien-signals";
 import { capturePropertyPath, patchStateAtPath } from "./bind-path";
 import type { StandardSchemaV1 } from "./form";
 import {
+  assertStoreStateObject,
   isStandardSchema,
   parseInitialStateFromSchema,
   primaryIssuePath,
@@ -285,7 +286,9 @@ export class StoreBuilder<
   }
 
   static createWithSchema<S extends StandardSchemaV1>(schema: S): StoreBuilder<SchemaState<S>> {
-    const initialState = parseInitialStateFromSchema(schema) as SchemaState<S>;
+    const parsed = parseInitialStateFromSchema(schema);
+    assertStoreStateObject(parsed, "initial state from schema");
+    const initialState = parsed as SchemaState<S>;
     return new StoreBuilder<SchemaState<S>>({
       initialState,
       schema,
@@ -424,6 +427,7 @@ function buildStore<
         reportStoreError(new StoreValidationError(result.issues, patch), "validate", patch);
         return;
       }
+      assertStoreStateObject(result.data, "validated state");
       next = result.data as TState;
     }
 

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -1,0 +1,73 @@
+// =============================================================================
+// Standard Schema — initial state + commit-time validation for @ilha/store
+// =============================================================================
+
+import type { StandardSchemaV1 } from "./form";
+import { issuesToErrors, validateWithSchema } from "./form";
+
+export type { StandardSchemaV1 } from "./form";
+
+export type StoreErrorSource = "validate";
+
+/** Thrown into `.onError()` handlers; also `instanceof` checkable. */
+export class StoreValidationError extends Error {
+  readonly issues: ReadonlyArray<StandardSchemaV1.Issue>;
+  readonly fieldErrors: Record<string, string[]>;
+
+  readonly patch?: object;
+
+  constructor(issues: ReadonlyArray<StandardSchemaV1.Issue>, patch?: object) {
+    const fieldErrors = issuesToErrors(issues);
+    const first = Object.values(fieldErrors).flat()[0] ?? "Validation failed";
+    super(first);
+    this.name = "StoreValidationError";
+    this.issues = issues;
+    this.fieldErrors = fieldErrors;
+    this.patch = patch;
+  }
+}
+
+export function isStandardSchema(value: unknown): value is StandardSchemaV1 {
+  if (value == null || typeof value !== "object") return false;
+  const std = (value as StandardSchemaV1)["~standard"];
+  return std != null && typeof std.validate === "function" && std.version === 1;
+}
+
+/**
+ * Derive initial store state from a Standard Schema (defaults, coercion).
+ * Tries `{}` then `undefined` so Zod/Valibot `.default()` fields resolve.
+ */
+export function parseInitialStateFromSchema<S extends StandardSchemaV1>(
+  schema: S,
+): StandardSchemaV1.InferOutput<S> {
+  for (const seed of [{}, undefined] as const) {
+    const result = validateWithSchema(schema, seed);
+    if (result.ok) return result.data;
+  }
+  const failed = validateWithSchema(schema, {});
+  const detail = failed.ok ? "" : JSON.stringify(issuesToErrors(failed.issues));
+  throw new Error(
+    `@ilha/store: could not derive initial state from schema (tried {} and undefined). ${detail}`,
+  );
+}
+
+export function validateStateSnapshot<S extends StandardSchemaV1>(
+  schema: S,
+  snapshot: unknown,
+):
+  | { ok: true; data: StandardSchemaV1.InferOutput<S> }
+  | { ok: false; issues: StandardSchemaV1.Issue[] } {
+  const result = validateWithSchema(schema, snapshot);
+  if (result.ok) return { ok: true, data: result.data };
+  return { ok: false, issues: [...result.issues] };
+}
+
+export function primaryIssuePath(
+  issues: ReadonlyArray<StandardSchemaV1.Issue>,
+): string | undefined {
+  const first = issues[0];
+  if (!first?.path?.length) return undefined;
+  return first.path
+    .map((p) => (typeof p === "object" && p != null && "key" in p ? String(p.key) : String(p)))
+    .join(".");
+}

--- a/packages/store/src/schema.ts
+++ b/packages/store/src/schema.ts
@@ -33,6 +33,14 @@ export function isStandardSchema(value: unknown): value is StandardSchemaV1 {
   return std != null && typeof std.validate === "function" && std.version === 1;
 }
 
+/** Store state must be a non-null plain object (not array/primitive). */
+export function assertStoreStateObject(value: unknown, label: string): asserts value is object {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) {
+    const kind = value === null ? "null" : Array.isArray(value) ? "array" : typeof value;
+    throw new Error(`@ilha/store: ${label} must be a plain object, got ${kind}.`);
+  }
+}
+
 /**
  * Derive initial store state from a Standard Schema (defaults, coercion).
  * Tries `{}` then `undefined` so Zod/Valibot `.default()` fields resolve.

--- a/templates/elysia/package.json
+++ b/templates/elysia/package.json
@@ -11,10 +11,10 @@
   "dependencies": {
     "@elysiajs/html": "^1.4.2",
     "@elysiajs/static": "^1.4.10",
-    "@ilha/router": "^0.6.5",
+    "@ilha/router": "^0.6.6",
     "areia": "^0.1.29",
     "elysia": "^1.4.29",
-    "ilha": "^0.8.2",
+    "ilha": "^0.8.3",
     "quando": "^0.1.6"
   },
   "devDependencies": {

--- a/templates/hono/package.json
+++ b/templates/hono/package.json
@@ -7,11 +7,11 @@
     "start": "node dist/server.mjs"
   },
   "dependencies": {
-    "@hono/node-server": "^2.0.5",
-    "@ilha/router": "^0.6.5",
+    "@hono/node-server": "^2.0.6",
+    "@ilha/router": "^0.6.6",
     "areia": "^0.1.29",
     "hono": "^4.12.26",
-    "ilha": "^0.8.2",
+    "ilha": "^0.8.3",
     "quando": "^0.1.6"
   },
   "devDependencies": {

--- a/templates/nitro/package.json
+++ b/templates/nitro/package.json
@@ -9,9 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.6.5",
+    "@ilha/router": "^0.6.6",
     "areia": "^0.1.29",
-    "ilha": "^0.8.2",
+    "ilha": "^0.8.3",
     "nitro": "^3.0.260610-beta",
     "quando": "^0.1.6"
   },

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -9,9 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.6.5",
+    "@ilha/router": "^0.6.6",
     "areia": "^0.1.29",
-    "ilha": "^0.8.2",
+    "ilha": "^0.8.3",
     "quando": "^0.1.6"
   },
   "devDependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `.input()` now supports plain-object default values with TypeScript inference, shallow-merged at runtime before rendering
  * `store(schema)` now validates every commit/write; invalid changes are rejected
  * Added `store().onError(handler)` to handle schema validation failures with error details
* **Bug Fixes**
  * Rejected schema-validated updates no longer mutate state and avoid unnecessary re-commits for no-op changes
* **Documentation**
  * Expanded the `.input()` and `store` guides with the new defaults and schema-validation/error-handling behavior
* **Tests**
  * Added coverage for POJO defaults, schema validation, and error handler behavior
* **Version Bumps**
  * Updated package versions across related modules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->