### PR TITLE
fix(store): fix binding typing

### DIFF
--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -268,7 +268,7 @@ query("ilha"); // write — goes through middleware
 
 ## Usage with Ilha Islands
 
-State and derived accessors on the built store are **signal-shaped** — they carry `[SIGNAL_ACCESSOR]` and participate directly in ilha's reactive tracking. Use them inside `.render()`, `.derived()`, and `.effect()` without `.select()` wrappers.
+State and derived accessors on the built store are **signal-shaped** — they are typed as ilha `SignalAccessor` (including `.select()` on state keys) and carry `[SIGNAL_ACCESSOR]`, so they work with Areia/ilha `bind:*` props (e.g. `<Input bind:value={form.email} />`). Use them inside `.render()`, `.derived()`, and `.effect()` without extra wrappers.
 
 ```ts
 import { store } from "@ilha/store";

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/store",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Shared reactive store for Ilha islands.",
   "keywords": [
     "forms",

--- a/packages/store/src/bind-accessor.ts
+++ b/packages/store/src/bind-accessor.ts
@@ -1,0 +1,56 @@
+// =============================================================================
+// Signal-shaped accessors for ilha bind:* (Symbol + .select parity with ilha)
+// =============================================================================
+
+import type { SignalAccessor } from "ilha";
+
+import { capturePropertyPath, patchStateAtPath } from "./bind-path";
+
+const SIGNAL_ACCESSOR = Symbol.for("ilha.signalAccessor");
+
+export function markStoreSignalAccessor<T>(fn: { (): T; (value: T): void }): SignalAccessor<T> {
+  (fn as unknown as Record<symbol, boolean>)[SIGNAL_ACCESSOR] = true;
+  return fn as SignalAccessor<T>;
+}
+
+/** Stamp `[SIGNAL_ACCESSOR]` on read-only callables (e.g. derived accessors). */
+export function stampSignalAccessor(fn: { (): unknown }): void {
+  (fn as unknown as Record<symbol, boolean>)[SIGNAL_ACCESSOR] = true;
+}
+
+/**
+ * Top-level state key accessor with `.select()` for nested `bind:*` (same ergonomics as ilha `state.user.select(...)`).
+ */
+export function createStoreKeyAccessor<TState extends object, K extends keyof TState>(
+  key: K,
+  read: () => TState[K],
+  writeKey: (value: TState[K]) => void,
+  bind: <S>(selector: (state: TState) => S) => SignalAccessor<S>,
+): SignalAccessor<TState[K]> {
+  const fn = ((...args: [value: TState[K]] | []): TState[K] => {
+    if (args.length === 0) return read();
+    writeKey(args[0]);
+    return read();
+  }) as { (): TState[K]; (value: TState[K]): void };
+  const accessor = markStoreSignalAccessor(fn);
+  accessor.select = <S>(selector: (slice: TState[K]) => S) => bind((st) => selector(st[key]));
+  return accessor;
+}
+
+/**
+ * `store.bind(selector)` — read/write field with ilha-compatible surface.
+ */
+export function createStoreBindAccessor<TState extends object, S>(
+  getState: () => TState,
+  setState: (patch: Partial<TState>) => void,
+  selector: (state: TState) => S,
+  read: () => S,
+): SignalAccessor<S> {
+  const path = capturePropertyPath(getState, selector);
+  const fn = ((...args: [value: S] | []): S => {
+    if (args.length === 0) return read();
+    setState(patchStateAtPath(getState(), path, args[0]) as Partial<TState>);
+    return read();
+  }) as { (): S; (value: S): void };
+  return markStoreSignalAccessor(fn);
+}

--- a/packages/store/src/index.test.ts
+++ b/packages/store/src/index.test.ts
@@ -94,6 +94,15 @@ describe("state accessors", () => {
     expect(s.count).toBe(s.count);
   });
 
+  it("state key accessor has .select for nested bind paths", () => {
+    const s = store({ user: { name: "a" } }).build();
+    expect(typeof s.user.select).toBe("function");
+    const name = s.user.select((u) => u.name);
+    expect(name()).toBe("a");
+    name("b");
+    expect(s.user().name).toBe("b");
+  });
+
   it("carries the SIGNAL_ACCESSOR symbol", () => {
     const s = store({ count: 0 }).build();
     const sym = Symbol.for("ilha.signalAccessor");

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -5,8 +5,13 @@
 // =============================================================================
 
 import { signal, computed, effect, setActiveSub } from "alien-signals";
+import type { SignalAccessor } from "ilha";
 
-import { capturePropertyPath, patchStateAtPath } from "./bind-path";
+import {
+  createStoreBindAccessor,
+  createStoreKeyAccessor,
+  stampSignalAccessor,
+} from "./bind-accessor";
 import type { StandardSchemaV1 } from "./form";
 import {
   assertStoreStateObject,
@@ -23,12 +28,11 @@ export { isStandardSchema, StoreValidationError, type StoreErrorSource } from ".
 
 export type SchemaState<S extends StandardSchemaV1> = StandardSchemaV1.InferOutput<S> & object;
 
-const SIGNAL_ACCESSOR = Symbol.for("ilha.signalAccessor");
+/** Read-write accessor for a state key — compatible with ilha `bind:*` (`SignalAccessor`). */
+export type StateAccessor<T> = SignalAccessor<T>;
 
-export type StoreBindable<S> = {
-  (): S;
-  (value: S): void;
-};
+/** Read-write field accessor from `.bind()` — compatible with ilha `bind:*`. */
+export type StoreBindable<S> = SignalAccessor<S>;
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -37,12 +41,6 @@ export type StoreBindable<S> = {
 export type Listener<T> = (state: T, prevState: T) => void;
 export type SliceListener<_T, S> = (slice: S, prevSlice: S) => void;
 export type Unsub = () => void;
-
-/** Read-write signal-shaped accessor for a state key. */
-export type StateAccessor<T> = {
-  (): T;
-  (value: T): void;
-};
 
 /** The reactive envelope for a derived value. Mirrors ilha core's `DerivedValue`. */
 export interface DerivedValue<T> {
@@ -201,7 +199,7 @@ function untrackRun<T>(fn: () => T): T {
 // `.value`, `.error` expose the envelope. Mirrors ilha core's accessor shape.
 function createDerivedAccessor<T>(read: () => DerivedValue<T>): DerivedAccessor<T> {
   const accessor = (() => read().value) as DerivedAccessor<T>;
-  (accessor as unknown as Record<symbol, boolean>)[SIGNAL_ACCESSOR] = true;
+  stampSignalAccessor(accessor);
   return new Proxy(accessor, {
     get(target, prop, receiver) {
       if (prop === "loading" || prop === "value" || prop === "error") {
@@ -504,14 +502,7 @@ function buildStore<
   }
 
   function bind<S>(selector: (state: TState) => S): StoreBindable<S> {
-    const path = capturePropertyPath(getState, selector);
-    const read = select(selector);
-    const accessor = ((...args: unknown[]): unknown => {
-      if (args.length === 0) return read();
-      setState(patchStateAtPath(stateSignal(), path, args[0]));
-    }) as StoreBindable<S>;
-    (accessor as unknown as Record<symbol, boolean>)[SIGNAL_ACCESSOR] = true;
-    return accessor;
+    return createStoreBindAccessor(getState, setState, selector, select(selector));
   }
 
   const builtins: StoreBuiltins<TState> = {
@@ -527,13 +518,15 @@ function buildStore<
   // --- cached accessors -----------------------------------------------------
   const stateAccessors = new Map<string, StateAccessor<unknown>>();
   for (const key of stateKeys) {
-    const accessor = ((...args: unknown[]): unknown => {
-      if (args.length === 0) return (stateSignal() as Record<string, unknown>)[key];
-      setState({ [key]: args[0] } as Partial<TState>);
-      return undefined;
-    }) as StateAccessor<unknown>;
-    (accessor as unknown as Record<symbol, boolean>)[SIGNAL_ACCESSOR] = true;
-    stateAccessors.set(key, accessor);
+    type Key = Extract<keyof TState, string>;
+    const k = key as Key;
+    const accessor = createStoreKeyAccessor<TState, Key>(
+      k,
+      () => (stateSignal() as TState)[k],
+      (value) => setState({ [k]: value } as unknown as Partial<TState>),
+      bind,
+    );
+    stateAccessors.set(key, accessor as StateAccessor<unknown>);
   }
 
   // --- derived (sync computed, or async envelope) ---------------------------

--- a/packages/store/src/public-types.ts
+++ b/packages/store/src/public-types.ts
@@ -1,0 +1,14 @@
+/**
+ * Compile-time check: store field accessors assign to ilha / Areia `bind:*` props.
+ */
+import type { SignalAccessor } from "ilha";
+
+import { store } from "./index";
+
+const s = store({ email: "" }).build();
+
+const _bindValue: SignalAccessor<string> | undefined = s.email;
+const _bindField: SignalAccessor<string> = s.bind((st) => st.email);
+
+void _bindValue;
+void _bindField;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined "Usage with Ilha Islands" section to clarify store accessor behavior in reactive contexts.

* **New Features**
  * Store state key accessors now support `.select()` for reactive nested property access.

* **Improvements**
  * Accessors can be used directly in reactive functions without extra wrappers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->