### PR TITLE
feat(router): introduce client loaders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: Continuous Integration
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:
@@ -39,11 +41,13 @@ jobs:
         run: bun run lint
 
       - name: Publish preview packages
+        if: github.event_name != 'pull_request'
         run: |
           echo "gitdir: $(pwd)/.git" > packages/ilha/.git
           bunx pkg-pr-new publish './packages/*'
 
       - name: Upload package dist
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: lib-dist
@@ -54,6 +58,7 @@ jobs:
     name: Deploy docs
     runs-on: ubuntu-latest
     needs: build-test-publish
+    if: github.event_name != 'pull_request'
     permissions:
       pages: write
       id-token: write

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
-    "@ilha/router": "^0.7.1",
-    "@ilha/store": "^0.6.1",
+    "@ilha/router": "^0.8.0",
+    "@ilha/store": "^0.7.0",
     "areia": "^0.1.35",
     "dedent": "^1.7.2",
     "ilha": "^0.9.0",

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -11,8 +11,8 @@
   "dependencies": {
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
-    "@ilha/router": "^0.7.0",
-    "@ilha/store": "^0.6.0",
+    "@ilha/router": "^0.7.1",
+    "@ilha/store": "^0.6.1",
     "areia": "^0.1.35",
     "dedent": "^1.7.2",
     "ilha": "^0.9.0",

--- a/apps/website/src/pages/(content)/guide/libraries/router.mdx
+++ b/apps/website/src/pages/(content)/guide/libraries/router.mdx
@@ -113,6 +113,7 @@ pageRouter.hydrate(registry);
 | `notFound`               | `Island`            | —       | Custom 404 island rendered when no route matches (see [RouterView](#routerview))   |
 | `allowExternalRedirects` | `boolean`           | `false` | Allow loader `redirect()` to cross-origin URLs; blocked targets become a 500 error |
 | `loaderTimeout`          | `number`            | —       | Max loader runtime in ms — see [Loaders](#loaders)                                 |
+| `viewTransitions`        | `boolean`           | `false` | Wrap client view swaps in `document.startViewTransition()` when supported          |
 
 ### `.route(pattern, island, loader?)`
 
@@ -216,9 +217,17 @@ The loader receives a `LoaderContext`:
 }
 ```
 
-On the server, loaders run inside `.renderHydratable()`. You can also call **`.runLoader(url, request?)`** on the builder to execute a loader without rendering HTML. On the client, navigations fetch loader data from the `/__ilha/loader` endpoint before mounting the next island.
+On the server, loaders run inside `.renderHydratable()`. You can also call **`.runLoader(url, request?)`** on the builder to execute a loader without rendering HTML.
+
+A loader runs **wherever the router runs**. When the route was registered in the browser — a plain SPA via `.route(pattern, island, loader)`, hash mode, Electron, `file://` — client navigations execute the loader locally: no server or loader endpoint needed. Routes that only _mark_ a server loader (the SSR-split pages build) fetch from the `/__ilha/loader` endpoint instead. Locally-executed loaders receive a synthetic `Request` (no cookies or server context) — rely on `url`, `params`, and `signal`; `redirect()`s are checked against the same cross-origin policy as on the server.
+
+**`.clientLoader(pattern, loader)`** attaches a loader that runs in the browser on client navigations, instead of the endpoint fetch. The FS-routing codegen uses it for `clientLoad` exports; manual routers can call it directly. When a route has both, the client loader wins on client navigations and the server loader runs during SSR.
 
 With `router({ loaderTimeout })`, the loader is raced against its abort signal — even a loader that ignores `ctx.signal` is cut off when the timeout elapses (or the incoming request aborts) and surfaces as a `504` loader error. Pass `ctx.signal` to your fetches anyway so the underlying work is actually cancelled, not just abandoned.
+
+Loader `ctx.head(...)` contributions are applied on the server **and** on client navigations — `document.title` and managed meta/link tags stay in sync as users navigate.
+
+If a loader fails, the error renders through the route's `+error` boundary when one is registered (see [Error boundaries](#error-boundaries)) — on the server `renderResponse` returns the boundary's HTML with the error status, and client navigations mount the boundary island in the outlet. Without a boundary, a minimal inline `data-router-error` element renders instead.
 
 ### `redirect(to, status?)`
 
@@ -275,6 +284,29 @@ prefetch("/dashboard?tab=overview");
 `RouterLink` calls this automatically on `mouseenter` for links with the `data-prefetch` attribute.
 
 Prefetched entries are single-use and expire after ~30 seconds. If the navigation that would consume a prefetch is superseded mid-flight, the prefetched result is discarded rather than applied to the wrong view.
+
+### `navigating()`
+
+Reactive — `true` while a client navigation (loader fetch + view swap) is in flight. Read it inside any island render to drive a progress bar or spinner. Also available as `useRoute().navigating`.
+
+```ts
+import { navigating } from "@ilha/router";
+
+const Spinner = ilha.render(() =>
+  navigating() ? html`<div class="bar"></div>` : "",
+);
+```
+
+### `invalidate()`
+
+Re-runs the current route's loader and re-renders the view with fresh data — call it after a mutation. Resolves when the view has updated. No-op on the server or when no router is mounted.
+
+```ts
+import { invalidate } from "@ilha/router";
+
+await api.deleteItem(id);
+await invalidate(); // current page refetches and re-renders
+```
 
 ## Hash mode
 
@@ -539,9 +571,38 @@ export default ilha
   .render(({ input }) => <h1>{input.user.name}</h1>);
 ```
 
+### Client loaders — `clientLoad`
+
+Export a `clientLoad` function to run a loader **in the browser** on client navigations, instead of fetching from the loader endpoint. Use it for data that is fetchable from the client anyway (public APIs, your app's own REST endpoints) — it saves a server round-trip per navigation and works on static hosts with no loader endpoint at all.
+
+```tsx
+// src/pages/dashboard.tsx
+import { loader } from "@ilha/router";
+import ilha from "ilha";
+
+export const clientLoad = loader(async ({ signal }) => {
+  const stats = await fetch("/api/stats", { signal }).then(
+    (r) => r.json(),
+  );
+  return { stats };
+});
+
+export default ilha
+  .input<{ stats: Stats }>()
+  .render(({ input }) => <Dashboard stats={input.stats} />);
+```
+
+- `clientLoad` is **bundled into the client** — never put secrets, database clients, or server-only imports in it. Keep those in `load`, which stays server-only.
+- A page can export **both**: `load` runs during SSR (first paint), `clientLoad` runs on client navigations instead of the endpoint fetch. Make them return the same shape.
+- Layout `clientLoad`s compose with the page's — the page wins on key collision, mirroring server loaders.
+- With SSR + hydration, a `clientLoad`-only page is server-rendered without its data; the router runs `clientLoad` right after hydration and re-renders the route with the loaded props.
+- `clientLoad` receives a synthetic `Request` — rely on `url`, `params`, and `signal`, not cookies or headers.
+
 ### Error boundaries
 
 A `+error.tsx` catches rendering errors for pages in its directory. The nearest boundary wins. If it re-throws, the next outer boundary takes over. (`.ts` is also supported if you do not need JSX.)
+
+The nearest boundary also renders **loader errors** — `error(status, message)` or an unexpected throw in `load`/`clientLoad` — on both the server (with the proper HTTP status) and client navigations. Manual routers get the same via `.errorBoundary(pattern, handler)`.
 
 ```tsx
 // src/pages/+error.tsx

--- a/apps/website/src/pages/(content)/guide/libraries/store.mdx
+++ b/apps/website/src/pages/(content)/guide/libraries/store.mdx
@@ -368,7 +368,7 @@ Call the returned unsubscribe before `store.dispose()` for per-island stores.
 Stores are module-level singletons, so on a concurrent SSR server they must **not** be written during a render — request A's data would leak into request B. Instead, state travels the same way ilha island state does: serialized into the HTML, then seeded on the client.
 
 - **`dehydrate(storeOrState)`** → JSON string. On a concurrent server pass a **request-local object** (e.g. loader data), not the shared store. Passing the store itself is fine in non-concurrent contexts (prerendering, tests).
-- **`hydrate(store, raw)`** → parses with the same guards as ilha's island snapshots (size cap, depth cap, must-be-plain-object, prototype-polluting keys stripped) and merges via `setState` — middleware runs and schema stores validate, so corrupt payloads are rejected. Returns `true` when applied.
+- **`hydrate(store, raw)`** → parses with the same guards as ilha's island snapshots (size cap, depth cap, must-be-plain-object, prototype-polluting keys stripped) and merges via `setState` — middleware runs and schema stores validate, so corrupt payloads are rejected. Returns `true` when the snapshot passes the parse/guard checks and is handed to `setState` (schema validation may still reject the patch there), `false` when it is ignored.
 
 ```ts
 // server (inside the loader / request handler)

--- a/apps/website/src/pages/(content)/guide/libraries/store.mdx
+++ b/apps/website/src/pages/(content)/guide/libraries/store.mdx
@@ -28,10 +28,10 @@ Island [`.state()`](/guide/island/state) is **local** to one component. Use `@il
 
 ## Import paths
 
-| Import path        | Use it for                                                                                 |
-| ------------------ | ------------------------------------------------------------------------------------------ |
-| `@ilha/store`      | `store`, store types, subscriptions, `select`, `bind`, and `effectScope`                   |
-| `@ilha/store/form` | Form extraction, validation, issue-to-error mapping, `preventDefault` for `.on()` handlers |
+| Import path        | Use it for                                                                                                                 |
+| ------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `@ilha/store`      | `store`, store types, subscriptions, `select`, `bind`, `persist`, `dehydrate`/`hydrate`, `shallowEqual`, and `effectScope` |
+| `@ilha/store/form` | Form extraction, validation, issue-to-error mapping, `preventDefault` for `.on()` handlers                                 |
 
 ## Quick start
 
@@ -159,6 +159,17 @@ Registers a named mutation. `fn` may be sync or `async`. Return a `Partial` patc
 })
 ```
 
+Every action exposes a reactive **`.pending`** flag — `true` while any async invocation is in flight (sync actions never set it). Read it in a render for per-action loading UI:
+
+```ts
+ilha.render(
+  () =>
+    html`<button disabled=${() => s.save.pending}>
+      Save
+    </button>`,
+);
+```
+
 ### `.middleware(fn)`
 
 Intercepts every state mutation before it commits. Receives `(patch, ctx, next)`. Call `next(patch)` to continue or return early to block. Applies to accessor writes, `setState`, actions, and `bind` writes.
@@ -239,7 +250,7 @@ draftStore.dispose();
 
 Raw `TState` snapshots — no derived values, no actions. The initial state is deep-cloned at `.build()` time (falling back to a shallow copy for non-cloneable values like functions), so mutating the original object you passed to `store()` — or nested state later — can't corrupt `reset()` or `getInitialState()`.
 
-#### `store.subscribe(listener)` / `store.subscribe(selector, listener)`
+#### `store.subscribe(listener)` / `store.subscribe(selector, listener, options?)`
 
 Full-state and slice forms. Neither fires on initial subscription. Both return an unsubscribe function.
 
@@ -255,6 +266,8 @@ const unsub2 = s.subscribe(
 );
 unsub();
 ```
+
+Slice comparison defaults to `Object.is`, so an object-building selector (`s => ({ a: s.a, b: s.b })`) fires on every commit — it returns a fresh object each time. Pass `{ equal: shallowEqual }` (exported from `@ilha/store`) to compare one level deep instead.
 
 #### `store.select(selector)` — reactive read accessor
 
@@ -323,6 +336,60 @@ Both islands stay in sync. `CartBadge` re-renders only when `count` changes; `Ca
 Use `.select()` for ad-hoc projections not worth a named `.derived()`, and `.bind()` for two-way form fields.
 
 **Note:** `state.todos.select((t) => t[i].done)` in island templates is ilha’s nested [`.select()` for `bind:*`](/guide/island/render#nested-fields-with-select) — not `store.select()` on `@ilha/store`.
+
+## Persistence — `persist(store, key, options?)`
+
+Keeps a store in sync with `localStorage` (or any `getItem`/`setItem` backend):
+
+1. **Hydrates** on call: reads `key` and merges the stored patch via `setState` — middleware runs and schema stores validate, so corrupt or stale-shaped payloads are rejected instead of applied.
+2. **Writes through** on every commit.
+3. **Cross-tab sync**: mirrors writes from other tabs via `storage` events (default `localStorage` backend only; disable with `crossTab: false`).
+
+Returns an unsubscribe. No-op on the server.
+
+```ts
+import { store, persist } from "@ilha/store";
+
+const cartStore = store({ items: [] as string[] }).build();
+persist(cartStore, "cart");
+```
+
+| Option        | Default               | Description                                 |
+| ------------- | --------------------- | ------------------------------------------- |
+| `storage`     | `window.localStorage` | Any `{ getItem, setItem }` backend          |
+| `crossTab`    | `true`                | Apply `storage` events from other tabs      |
+| `serialize`   | `JSON.stringify`      | State → string                              |
+| `deserialize` | `JSON.parse`          | String → patch (validated on schema stores) |
+
+Call the returned unsubscribe before `store.dispose()` for per-island stores.
+
+## SSR — `dehydrate()` / `hydrate()`
+
+Stores are module-level singletons, so on a concurrent SSR server they must **not** be written during a render — request A's data would leak into request B. Instead, state travels the same way ilha island state does: serialized into the HTML, then seeded on the client.
+
+- **`dehydrate(storeOrState)`** → JSON string. On a concurrent server pass a **request-local object** (e.g. loader data), not the shared store. Passing the store itself is fine in non-concurrent contexts (prerendering, tests).
+- **`hydrate(store, raw)`** → parses with the same guards as ilha's island snapshots (size cap, depth cap, must-be-plain-object, prototype-polluting keys stripped) and merges via `setState` — middleware runs and schema stores validate, so corrupt payloads are rejected. Returns `true` when applied.
+
+```ts
+// server (inside the loader / request handler)
+const payload = dehydrate({ items: cartItems }); // request-local data
+// stamp into the shell, escaped for the embedding context:
+// <script type="application/json" id="cart-state">
+//   ${payload.replace(/</g, "\\u003c")}
+// </script>
+```
+
+```ts
+// client — page island's onMount (runs on hydration)
+import { hydrate } from "@ilha/store";
+
+ilha.onMount(() => {
+  hydrate(
+    cartStore,
+    document.getElementById("cart-state")?.textContent,
+  );
+});
+```
 
 ## Forms
 
@@ -453,6 +520,10 @@ import type {
   StoreBindable, // <S>: read/write accessor for bind:*
   Listener, // (state, prevState) => void
   SliceListener, // (slice, prevSlice) => void
+  SubscribeOptions, // { equal? } — selector-form subscribe options
+  ActionInvoker, // callable action with reactive .pending
+  PersistStorage, // { getItem, setItem } — persist() backend
+  PersistOptions, // { storage?, crossTab?, serialize?, deserialize? }
   Unsub, // () => void
 } from "@ilha/store";
 

--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
     },
     "packages/router": {
       "name": "@ilha/router",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "dependencies": {
         "rou3": "0.9.0",
         "unplugin": "3.3.0",
@@ -63,7 +63,7 @@
     },
     "packages/store": {
       "name": "@ilha/store",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "devDependencies": {
         "alien-signals": "3.2.1",
         "ilha": "0.9.0",

--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
     },
     "packages/router": {
       "name": "@ilha/router",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "rou3": "0.9.0",
         "unplugin": "3.3.0",
@@ -63,7 +63,7 @@
     },
     "packages/store": {
       "name": "@ilha/store",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "devDependencies": {
         "alien-signals": "3.2.1",
         "ilha": "0.9.0",

--- a/packages/ilha/README.md
+++ b/packages/ilha/README.md
@@ -768,7 +768,7 @@ const styles = css`
 
 ## JSX Runtime
 
-Prefer JSX over `html\`\``? `ilha` ships a JSX runtime (`ilha/jsx-runtime`) that produces the same XSS-safe output — JSX expressions evaluate to the same `RawHtml`values the`html` tag returns, so the two syntaxes are interchangeable and can be mixed freely.
+Prefer JSX over the `html` tag? `ilha` ships a JSX runtime (`ilha/jsx-runtime`) that produces the same XSS-safe output — JSX expressions evaluate to the same `RawHtml` values the `html` tag returns, so the two syntaxes are interchangeable and can be mixed freely.
 
 ### Setup
 
@@ -799,18 +799,18 @@ const Counter = ilha
   ));
 ```
 
-Interpolated children follow the same rules as `html\`\``— strings are escaped, signal accessors are auto-called, islands become hydration slots, arrays are flattened. Use`raw()`to opt out of escaping, and`<></>` (Fragment) to group siblings without a wrapper element.
+Interpolated children follow the same rules as the `html` tag — strings are escaped, signal accessors are auto-called, islands become hydration slots, arrays are flattened. Use `raw()` to opt out of escaping, and `<></>` (Fragment) to group siblings without a wrapper element.
 
 ### Attributes
 
-| Feature               | Behaviour                                                                                           |
-| --------------------- | --------------------------------------------------------------------------------------------------- |
-| `class` / `className` | Accepts a string, an array (`["a", cond && "b"]`), or an object (`{ active: isActive }`)            |
-| `htmlFor`             | Alias for `for`                                                                                     |
-| `style`               | Accepts a string or an object (`{ backgroundColor: "teal" }` → `background-color:teal`)             |
-| Boolean attributes    | `true` renders the bare attribute, `false`/`null`/`undefined` omit it                               |
-| `bind:*`              | Two-way bindings, same as in `html\`\``— pass a signal accessor:`<input bind:value={state.name} />` |
-| `key`                 | Keys a child island for reorder-safe rendering (same as `.key()`)                                   |
+| Feature               | Behaviour                                                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `class` / `className` | Accepts a string, an array (`["a", cond && "b"]`), or an object (`{ active: isActive }`)                           |
+| `htmlFor`             | Alias for `for`                                                                                                    |
+| `style`               | Accepts a string or an object (`{ backgroundColor: "teal" }` → `background-color:teal`)                            |
+| Boolean attributes    | `true` renders the bare attribute, `false`/`null`/`undefined` omit it                                              |
+| `bind:*`              | Two-way bindings, same as in `html` templates — pass a signal accessor: `<input bind:value={state.name} />`        |
+| `key`                 | Keys a child island for reorder-safe rendering (same as `.key()`). Keys must be non-empty and must not contain `:` |
 
 For safety, `on*` attributes (e.g. `onclick`) and `srcdoc` are stripped — attach event listeners with `.on()` instead — and URL attributes (`href`, `src`, `action`, …) with unsafe schemes like `javascript:` are dropped.
 

--- a/packages/ilha/README.md
+++ b/packages/ilha/README.md
@@ -766,6 +766,83 @@ const styles = css`
 
 ---
 
+## JSX Runtime
+
+Prefer JSX over `html\`\``? `ilha` ships a JSX runtime (`ilha/jsx-runtime`) that produces the same XSS-safe output — JSX expressions evaluate to the same `RawHtml`values the`html` tag returns, so the two syntaxes are interchangeable and can be mixed freely.
+
+### Setup
+
+Enable the automatic JSX transform in `tsconfig.json` (works with TypeScript, Bun, Vite, esbuild, etc.):
+
+```jsonc
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "ilha",
+  },
+}
+```
+
+### Usage
+
+```tsx
+import ilha from "ilha";
+
+const Counter = ilha
+  .state("count", 0)
+  .on("button@click", ({ state }) => state.count(state.count() + 1))
+  .render(({ state }) => (
+    <div>
+      <p>Count: {state.count}</p>
+      <button>Increment</button>
+    </div>
+  ));
+```
+
+Interpolated children follow the same rules as `html\`\``— strings are escaped, signal accessors are auto-called, islands become hydration slots, arrays are flattened. Use`raw()`to opt out of escaping, and`<></>` (Fragment) to group siblings without a wrapper element.
+
+### Attributes
+
+| Feature               | Behaviour                                                                                           |
+| --------------------- | --------------------------------------------------------------------------------------------------- |
+| `class` / `className` | Accepts a string, an array (`["a", cond && "b"]`), or an object (`{ active: isActive }`)            |
+| `htmlFor`             | Alias for `for`                                                                                     |
+| `style`               | Accepts a string or an object (`{ backgroundColor: "teal" }` → `background-color:teal`)             |
+| Boolean attributes    | `true` renders the bare attribute, `false`/`null`/`undefined` omit it                               |
+| `bind:*`              | Two-way bindings, same as in `html\`\``— pass a signal accessor:`<input bind:value={state.name} />` |
+| `key`                 | Keys a child island for reorder-safe rendering (same as `.key()`)                                   |
+
+For safety, `on*` attributes (e.g. `onclick`) and `srcdoc` are stripped — attach event listeners with `.on()` instead — and URL attributes (`href`, `src`, `action`, …) with unsafe schemes like `javascript:` are dropped.
+
+### Islands as components
+
+Islands are plain functions, so they compose as JSX components — props and keys work as you'd expect:
+
+```tsx
+const Badge = ilha
+  .input<{ label: string }>()
+  .render(({ input }) => <span class="badge">{input.label}</span>);
+
+const Card = ilha.render(() => (
+  <div class="card">
+    <Badge label="New" />
+    <p>Card content</p>
+  </div>
+));
+
+const List = ilha.render(() => (
+  <ul>
+    {items.map((item) => (
+      <li>
+        <Item key={item.id} name={item.name} />
+      </li>
+    ))}
+  </ul>
+));
+```
+
+---
+
 ## SSR + Hydration
 
 The recommended SSR + hydration pattern uses `.hydratable()` on the server and `ilha.mount()` on the client.

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -135,9 +135,18 @@ You can still register loaders, but they run on the client (via the loader endpo
 
 ## Core API
 
-### `router()`
+### `router(options?)`
 
 Creates a new router instance and **resets the route registry**. Always call `router()` fresh — never share instances across server requests.
+
+| Option                   | Type                | Default | Description                                                                               |
+| ------------------------ | ------------------- | ------- | ----------------------------------------------------------------------------------------- |
+| `mode`                   | `"spa" \| "static"` | `"spa"` | `"static"` disables client navigation — hydrate with `hydrateStatic()`                    |
+| `interceptLinks`         | `boolean`           | `true`  | Intercept internal `<a>` clicks for SPA navigation                                        |
+| `notFound`               | `Island`            | —       | Custom 404 island (SSR status 404; mounted with a full lifecycle in the browser)          |
+| `allowExternalRedirects` | `boolean`           | `false` | Allow loader `redirect()` to cross-origin URLs; blocked targets become a 500 error        |
+| `loaderTimeout`          | `number`            | —       | Abort + fail a loader after this many ms (enforced even if the loader ignores its signal) |
+| `viewTransitions`        | `boolean`           | `false` | Wrap client view swaps in `document.startViewTransition()` when supported                 |
 
 Returns a `RouterBuilder`.
 
@@ -147,7 +156,9 @@ Returns a `RouterBuilder`.
 
 Registers a route. Patterns are matched in **declaration order** — first match wins. Uses [rou3](https://github.com/h3js/rou3) for matching, the same engine as Nitro.
 
-The optional `loader` is a data-fetching function that runs before the page renders. Its return value is passed as input props to the island. On the client, loaders are fetched via the `/__ilha/loader` endpoint on navigation.
+The optional `loader` is a data-fetching function that runs before the page renders. Its return value is passed as input props to the island. The loader runs **wherever the router runs**: during SSR it executes on the server; when the route was registered in the browser (a plain SPA, hash mode, `file://`), client navigations execute it locally — no server or `/__ilha/loader` endpoint needed. Routes marked via `.markLoader()` (the SSR-split pages build) still fetch from the endpoint.
+
+A locally-executed loader receives a synthetic `Request` (no cookies or server context) — rely on `url`, `params`, and `signal`. Loader `redirect()`s are checked against the same cross-origin policy as on the server (`allowExternalRedirects`).
 
 ```ts
 import { loader } from "@ilha/router";
@@ -344,6 +355,35 @@ router().route("/user/:id", userPage).attachLoader("/user/:id", serverLoader);
 
 ---
 
+#### `.clientLoader(pattern, loader)` — runtime
+
+Attaches a loader that runs **in the browser** on client navigations, instead of fetching from the `/__ilha/loader` endpoint. Used by the FS-routing codegen for `clientLoad` exports; also available for manual routers. When a route has both a server loader and a client loader, the client loader wins on client navigations and the server loader runs during SSR. No-op (with a warning) if the pattern was never registered via `.route()`.
+
+```ts
+router()
+  .route("/dashboard", dashboardPage)
+  .clientLoader(
+    "/dashboard",
+    loader(async ({ signal }) => ({ stats: await fetchStats({ signal }) })),
+  );
+```
+
+---
+
+#### `.errorBoundary(pattern, handler)` — runtime
+
+Attaches the route's `+error` boundary so **loader** errors render through it — on the server (`renderResponse` returns the boundary's HTML with the error status) and on client navigations. Render errors are already handled by `wrapError` inside the island; this closes the gap for errors thrown before rendering starts. The FS-routing codegen wires the nearest `+error.ts` automatically; manual routers can call it directly. A throwing boundary falls back to the minimal inline error.
+
+```ts
+router()
+  .route("/user/:id", userPage, userLoader)
+  .errorBoundary("/user/:id", (err, route) =>
+    ilha.render(() => `<h1>${err.status ?? 500}</h1><p>${err.message}</p>`),
+  );
+```
+
+---
+
 ### `setHistoryMode(mode)` · `getHistoryMode()`
 
 Selects the history strategy used by the router. Defaults to `"history"` (HTML5 History API, reads/writes `location.pathname`). Set to `"hash"` to store the route in `location.hash` instead — see the [Hash mode](#hash-mode) section above for when to use it.
@@ -373,6 +413,31 @@ navigate("/about", { replace: true }); // replaces instead of pushing
 In hash mode, `navigate("/about")` writes `#/about` into `location.hash`. The argument is always the logical path — no need to prefix it with `#`.
 
 No-op on the server.
+
+---
+
+### `navigating()`
+
+Reactive — `true` while a client navigation (loader fetch + view swap) is in flight. Read it inside any island render to drive a progress bar or spinner; it re-renders when the state flips. Also available as `useRoute().navigating`.
+
+```ts
+import { navigating } from "@ilha/router";
+
+const Spinner = ilha.render(() => (navigating() ? `<div class="bar" />` : ""));
+```
+
+---
+
+### `invalidate()`
+
+Re-runs the current route's loader and re-renders the view with fresh data — call it after a mutation. Resolves when the view has updated. No-op on the server or when no router is mounted.
+
+```ts
+import { invalidate } from "@ilha/router";
+
+await api.deleteItem(id);
+await invalidate(); // current page refetches and re-renders
+```
 
 ---
 
@@ -893,6 +958,31 @@ export default defineLayout((children) => /* … */);
 ```
 
 Layout loaders are composed automatically — you do not need to call `composeLoaders()` manually.
+
+### Client loaders (`clientLoad`)
+
+A page or layout can export a `clientLoad` function that runs **in the browser** on client navigations, instead of fetching from the loader endpoint. Use it for data that is fetchable from the client anyway (public APIs, the app's own REST endpoints) — it saves a server round-trip per navigation, and it works on static hosts with no loader endpoint at all.
+
+```ts
+// src/pages/dashboard.ts
+import { loader } from "@ilha/router";
+import ilha from "ilha";
+
+export const clientLoad = loader(async ({ signal }) => {
+  const stats = await fetch("/api/stats", { signal }).then((r) => r.json());
+  return { stats };
+});
+
+export default ilha.input<{ stats: Stats }>().render(/* … */);
+```
+
+Rules and caveats:
+
+- `clientLoad` is bundled into the client — never put secrets, database clients, or server-only imports in it. Keep those in `load`, which stays server-only.
+- A page can export **both**: `load` runs during SSR (first paint), `clientLoad` runs on client navigations instead of the endpoint fetch. Make them return the same shape.
+- Layout `clientLoad`s compose with the page's, layouts first — the page wins on key collision, mirroring server loaders.
+- With SSR + hydration, a `clientLoad`-only page is server-rendered **without** its data; the router runs `clientLoad` on the client right after hydration and re-renders the route with the loaded props.
+- `clientLoad` receives a synthetic `Request` — rely on `url`, `params`, and `signal`, not cookies or headers.
 
 ### Error boundaries
 

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -1097,15 +1097,15 @@ Or use the one-liner: `pageRouter.hydrate(registry)`.
 
 On the **server**, loaders run inside `.renderHydratable()` / `.renderResponse()`. Their return value is serialized into `data-ilha-props` on the island element so the client can rehydrate without re-fetching.
 
-On the **client**, navigations fetch loader data from the `/__ilha/loader` endpoint before mounting the next island. The endpoint is served automatically by the Vite plugin (dev) and the Nitro adapter (production).
+On the **client**, navigations resolve loader data before mounting the next island. Routes with a loader registered in the browser — a manual `.route(path, island, loader)` or an FS-routing `clientLoad` export — run that loader locally, with no network round-trip. Routes with only a server loader (`markLoader()` / a `load` export) fetch from the `/__ilha/loader` endpoint, served automatically by the Vite plugin (dev) and the Nitro adapter (production).
 
 ```
 server                         client (navigation)
-────────────────────────────   ─────────────────────────────────────
-renderHydratable               GET /__ilha/loader?path=/user/42
-  → executeLoader(…)             → runLoader("/user/42")
-  → island.hydratable(props)     → fetchLoaderData("/user/42")
-  → data-ilha-props="{…}"        → mountRouteWithHydration(island, host, …)
+────────────────────────────   ─────────────────────────────────────────
+renderHydratable               local loader (clientLoad / .route loader)?
+  → executeLoader(…)             yes → runLocalLoader(…)      in-browser
+  → island.hydratable(props)     no  → fetchLoaderData(…)     GET /__ilha/loader?path=/user/42
+  → data-ilha-props="{…}"      → mountRouteWithHydration(island, host, …)
 ```
 
 ---

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/router",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A tiny SPA router for Ilha",
   "keywords": [
     "frontend",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/router",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "A tiny SPA router for Ilha",
   "keywords": [
     "frontend",

--- a/packages/router/src/codegen.test.ts
+++ b/packages/router/src/codegen.test.ts
@@ -991,6 +991,166 @@ describe("codegen — loader detection", () => {
 });
 
 // ─────────────────────────────────────────────
+// codegen — errorBoundary wiring (loader errors)
+// ─────────────────────────────────────────────
+
+describe("codegen — errorBoundary wiring", () => {
+  let pagesDir: string;
+  let outDir: string;
+  let root: string;
+
+  beforeEach(async () => {
+    root = await makeDir("error-boundaries");
+    pagesDir = join(root, "src/pages");
+    outDir = join(root, ".ilha");
+    await mkdir(pagesDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await removeDir(root);
+  });
+
+  async function runCodegen() {
+    await generate(pagesDir, outDir);
+    const paths = resolveGeneratedPaths(outDir);
+    return {
+      server: await readFile(paths.serverFile, "utf8"),
+      client: await readFile(paths.clientFile, "utf8"),
+    };
+  }
+
+  it("wires the +error boundary on both server and client route graphs", async () => {
+    await writePage(pagesDir, "index.ts", `export default null;`);
+    await writePage(pagesDir, "+error.ts", `export default null;`);
+    const { server, client } = await runCodegen();
+    expect(server).toContain(`.errorBoundary("/", _error0_0)`);
+    expect(client).toContain(`.errorBoundary("/", _error0_0)`);
+  });
+
+  it("uses the nearest boundary when several are in the chain", async () => {
+    await writePage(pagesDir, "+error.ts", `export default null;`);
+    await mkdir(join(pagesDir, "user"), { recursive: true });
+    await writePage(pagesDir, "user/+error.ts", `export default null;`);
+    await writePage(pagesDir, "user/settings.ts", `export default null;`);
+    const { server } = await runCodegen();
+    // errors chain is root→nearest; the nearest (index 1) wins
+    expect(server).toContain(`.errorBoundary("/user/settings", _error0_1)`);
+  });
+
+  it("emits no errorBoundary when there is no +error file", async () => {
+    await writePage(pagesDir, "index.ts", `export default null;`);
+    const { server, client } = await runCodegen();
+    expect(server).not.toContain("errorBoundary");
+    expect(client).not.toContain("errorBoundary");
+  });
+});
+
+// ─────────────────────────────────────────────
+// codegen — clientLoad (browser-executed loaders)
+// ─────────────────────────────────────────────
+
+describe("codegen — clientLoad detection", () => {
+  let pagesDir: string;
+  let outDir: string;
+  let root: string;
+
+  beforeEach(async () => {
+    root = await makeDir("client-loaders");
+    pagesDir = join(root, "src/pages");
+    outDir = join(root, ".ilha");
+    await mkdir(pagesDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await removeDir(root);
+  });
+
+  async function runCodegen(opts?: Parameters<typeof generate>[2]) {
+    await generate(pagesDir, outDir, opts);
+    const paths = resolveGeneratedPaths(outDir);
+    return {
+      server: await readFile(paths.serverFile, "utf8"),
+      client: await readFile(paths.clientFile, "utf8"),
+      loaders: await readFile(paths.loadersFile, "utf8").catch(() => ""),
+    };
+  }
+
+  it("wires a page clientLoad into the client file via ?client-loader", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const clientLoad = async () => ({}); export default null;`,
+    );
+    const { client } = await runCodegen();
+    expect(client).toContain("?client-loader");
+    expect(client).toContain(`import { clientLoad as _cl0 }`);
+    expect(client).toContain(`.clientLoader("/", _cl0)`);
+  });
+
+  it("does not wire clientLoad into the server file or loaders.ts", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const clientLoad = async () => ({}); export default null;`,
+    );
+    const { server, loaders } = await runCodegen();
+    expect(server).not.toContain("clientLoad");
+    expect(server).not.toContain(".markLoader");
+    expect(loaders).not.toContain("clientLoad");
+  });
+
+  it("composes layout clientLoads before the page clientLoad", async () => {
+    await writePage(
+      pagesDir,
+      "+layout.ts",
+      `export const clientLoad = async () => ({}); export default null;`,
+    );
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const clientLoad = async () => ({}); export default null;`,
+    );
+    const { client } = await runCodegen();
+    expect(client).toContain("composeLoaders([_cl0_l0, _cl0])");
+    expect(client).toContain(`import { composeLoaders, router,`);
+  });
+
+  it("a page with both load and clientLoad gets markLoader and clientLoader on the client", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const load = async () => ({});\nexport const clientLoad = async () => ({});\nexport default null;`,
+    );
+    const { client, loaders } = await runCodegen();
+    expect(client).toContain(`.markLoader("/")`);
+    expect(client).toContain(`.clientLoader("/", _cl0)`);
+    // server loader is still wired via loaders.ts
+    expect(loaders).toContain("attachLoader");
+  });
+
+  it("a clientLoad-only project does not mark loaders on the client route graph", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const clientLoad = async () => ({}); export default null;`,
+    );
+    const { client } = await runCodegen();
+    expect(client).not.toContain(".markLoader");
+  });
+
+  it("static mode emits no clientLoader wiring", async () => {
+    await writePage(
+      pagesDir,
+      "index.ts",
+      `export const clientLoad = async () => ({}); export default null;`,
+    );
+    const { client } = await runCodegen({ mode: "static" });
+    expect(client).not.toContain("clientLoader");
+    expect(client).not.toContain("?client-loader");
+  });
+});
+
+// ─────────────────────────────────────────────
 // codegen — loaders.ts structure
 // ─────────────────────────────────────────────
 

--- a/packages/router/src/codegen.ts
+++ b/packages/router/src/codegen.ts
@@ -63,7 +63,13 @@ async function detectLoaderExports(file: string): Promise<LoaderExports> {
       load: LOADER_EXPORT_RE.test(stripped),
       clientLoad: CLIENT_LOADER_EXPORT_RE.test(stripped),
     };
-  } catch {
+  } catch (err) {
+    // A missing file simply has no loaders; anything else (permissions,
+    // transient I/O) would silently drop `.markLoader`/`.clientLoader`
+    // wiring, so surface it.
+    if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+      console.warn(`[ilha-router] failed to read ${file} while detecting loader exports:`, err);
+    }
     return { load: false, clientLoad: false };
   }
 }

--- a/packages/router/src/codegen.ts
+++ b/packages/router/src/codegen.ts
@@ -19,6 +19,10 @@ interface PageEntry {
   hasLoader: boolean;
   /** Subset of `layouts` whose modules declare a `load` export. */
   loaderLayouts: string[];
+  /** True if the page module declares a `clientLoad` export (browser-executed loader). */
+  hasClientLoader: boolean;
+  /** Subset of `layouts` whose modules declare a `clientLoad` export. */
+  clientLoaderLayouts: string[];
 }
 
 // ─────────────────────────────────────────────
@@ -40,15 +44,27 @@ const EXCLUDED_RE = /\.(test|spec|d)\.(ts|tsx)$/;
  */
 const LOADER_EXPORT_RE = /^\s*export\s+(?:const|let|var|async\s+function|function)\s+load\b/m;
 
-async function hasLoaderExport(file: string): Promise<boolean> {
+/** Same shape for `clientLoad` — a loader executed in the browser on client navigations. */
+const CLIENT_LOADER_EXPORT_RE =
+  /^\s*export\s+(?:const|let|var|async\s+function|function)\s+clientLoad\b/m;
+
+interface LoaderExports {
+  load: boolean;
+  clientLoad: boolean;
+}
+
+async function detectLoaderExports(file: string): Promise<LoaderExports> {
   try {
     const src = await readFile(file, "utf8");
     // Strip single-line comments at the start of lines to avoid matching
     // commented-out loaders. Block comments are rare enough to skip.
     const stripped = src.replace(/^\s*\/\/.*$/gm, "");
-    return LOADER_EXPORT_RE.test(stripped);
+    return {
+      load: LOADER_EXPORT_RE.test(stripped),
+      clientLoad: CLIENT_LOADER_EXPORT_RE.test(stripped),
+    };
   } catch {
-    return false;
+    return { load: false, clientLoad: false };
   }
 }
 
@@ -179,11 +195,11 @@ async function scanPages(pagesDir: string): Promise<PageEntry[]> {
   const allSet = new Set(all);
   const pages = all.filter((f) => !basename(f).startsWith("+"));
 
-  const layoutLoaderCache = new Map<string, Promise<boolean>>();
-  const getLayoutHasLoader = (file: string): Promise<boolean> => {
+  const layoutLoaderCache = new Map<string, Promise<LoaderExports>>();
+  const getLayoutExports = (file: string): Promise<LoaderExports> => {
     let cached = layoutLoaderCache.get(file);
     if (!cached) {
-      cached = hasLoaderExport(file);
+      cached = detectLoaderExports(file);
       layoutLoaderCache.set(file, cached);
     }
     return cached;
@@ -194,19 +210,22 @@ async function scanPages(pagesDir: string): Promise<PageEntry[]> {
       const pattern = fileToPattern(pagesDir, file);
       const layouts = chainForFile(pagesDir, file, allSet, "+layout");
       const errors = chainForFile(pagesDir, file, allSet, "+error");
-      const [pageHasLoader, ...layoutFlags] = await Promise.all([
-        hasLoaderExport(file),
-        ...layouts.map(getLayoutHasLoader),
+      const [pageExports, ...layoutExports] = await Promise.all([
+        detectLoaderExports(file),
+        ...layouts.map(getLayoutExports),
       ]);
-      const loaderLayouts = layouts.filter((_, i) => layoutFlags[i]);
+      const loaderLayouts = layouts.filter((_, i) => layoutExports[i]!.load);
+      const clientLoaderLayouts = layouts.filter((_, i) => layoutExports[i]!.clientLoad);
       return {
         file,
         pattern,
         name: patternToName(pattern),
         layouts,
         errors,
-        hasLoader: pageHasLoader,
+        hasLoader: pageExports.load,
         loaderLayouts,
+        hasClientLoader: pageExports.clientLoad,
+        clientLoaderLayouts,
       };
     }),
   );
@@ -379,6 +398,13 @@ function buildServerFile(entries: PageEntry[], serverFile: string): string {
           ? `.markLoader(${JSON.stringify(entry.pattern)})`
           : ""),
     );
+    // Nearest +error boundary also handles *loader* errors (render errors are
+    // covered by the wrapError chain inside the island).
+    if (entry.errors.length > 0) {
+      routeLines.push(
+        `  .errorBoundary(${JSON.stringify(entry.pattern)}, _error${i}_${entry.errors.length - 1})`,
+      );
+    }
   }
 
   return [
@@ -415,6 +441,8 @@ function buildClientFile(
     return r.startsWith(".") ? r : `./${r}`;
   };
   const clientImport = (abs: string) => `${rel(abs)}?client`;
+  const clientLoaderImport = (abs: string) => `${rel(abs)}?client-loader`;
+  let needsComposeLoaders = false;
 
   const imports: string[] = isStatic
     ? [
@@ -460,7 +488,45 @@ function buildClientFile(
             ? `.markLoader(${JSON.stringify(entry.pattern)})`
             : ""),
       );
+
+      // Browser-executed loaders (`clientLoad`) — imported via the
+      // ?client-loader shim and attached so client navigations run them
+      // locally instead of calling the loader endpoint.
+      const clientLoaderIds: string[] = [];
+      for (const [j, layout] of entry.clientLoaderLayouts.entries()) {
+        const id = `_cl${i}_l${j}`;
+        imports.push(
+          `import { clientLoad as ${id} } from ${JSON.stringify(clientLoaderImport(layout))};`,
+        );
+        clientLoaderIds.push(id);
+      }
+      if (entry.hasClientLoader) {
+        const id = `_cl${i}`;
+        imports.push(
+          `import { clientLoad as ${id} } from ${JSON.stringify(clientLoaderImport(entry.file))};`,
+        );
+        clientLoaderIds.push(id);
+      }
+      if (clientLoaderIds.length > 0) {
+        const expr =
+          clientLoaderIds.length === 1
+            ? clientLoaderIds[0]
+            : `composeLoaders([${clientLoaderIds.join(", ")}])`;
+        if (clientLoaderIds.length > 1) needsComposeLoaders = true;
+        routeLines.push(`  .clientLoader(${JSON.stringify(entry.pattern)}, ${expr})`);
+      }
+
+      // Nearest +error boundary also handles *loader* errors on the client.
+      if (entry.errors.length > 0) {
+        routeLines.push(
+          `  .errorBoundary(${JSON.stringify(entry.pattern)}, _error${i}_${entry.errors.length - 1})`,
+        );
+      }
     }
+  }
+
+  if (needsComposeLoaders) {
+    imports[0] = imports[0]!.replace("{ router", "{ composeLoaders, router");
   }
 
   const routerExpr = isStatic

--- a/packages/router/src/index.test.ts
+++ b/packages/router/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from "bun:test";
 
 import ilha, { ISLAND_MOUNT_INTERNAL, mount as ilhaMount, html } from "ilha";
 import { jsx, jsxs } from "ilha/jsx-runtime";
@@ -25,6 +25,8 @@ import {
   prefetch,
   RouterLink,
   head,
+  navigating,
+  invalidate,
 } from "./index";
 
 // ─────────────────────────────────────────────
@@ -1800,6 +1802,324 @@ describe("route() backward compatibility", () => {
 });
 
 // ─────────────────────────────────────────────
+// SPA client loaders — local execution, no endpoint
+// ─────────────────────────────────────────────
+
+describe("SPA client loaders", () => {
+  let el: Element;
+  let unmount: (() => void) | null = null;
+  let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">>;
+
+  const flush = async () => {
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+  };
+
+  beforeEach(() => {
+    setLocation("/");
+    el = makeEl();
+    fetchSpy = (spyOn(globalThis, "fetch") as any).mockImplementation(async () => {
+      return new Response(JSON.stringify({ kind: "data", data: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+  });
+
+  afterEach(() => {
+    unmount?.();
+    unmount = null;
+    fetchSpy.mockRestore();
+    cleanup(el);
+    setLocation("/");
+  });
+
+  it("runs a .route() loader in the browser and passes its data to the island", async () => {
+    const GreetPage = ilha.render(({ input }: any) => `<p>hello:${input?.name ?? "nobody"}</p>`);
+    unmount = router()
+      .route("/", HomePage)
+      .route(
+        "/greet",
+        GreetPage,
+        loader(async ({ url }) => ({ name: url.searchParams.get("who") ?? "world" })),
+      )
+      .mount(el);
+
+    navigate("/greet?who=ada");
+    await flush();
+
+    expect(el.innerHTML).toContain("hello:ada");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("passes route params to the local loader", async () => {
+    const IdPage = ilha.render(({ input }: any) => `<p>id:${input?.id ?? "?"}</p>`);
+    unmount = router()
+      .route("/", HomePage)
+      .route(
+        "/item/:id",
+        IdPage,
+        loader(async ({ params }) => ({ id: params.id })),
+      )
+      .mount(el);
+
+    navigate("/item/42");
+    await flush();
+
+    expect(el.innerHTML).toContain("id:42");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it(".clientLoader() attaches a browser loader to a registered pattern", async () => {
+    const CPage = ilha.render(({ input }: any) => `<p>c:${input?.v ?? "?"}</p>`);
+    unmount = router()
+      .route("/", HomePage)
+      .route("/c", CPage)
+      .clientLoader(
+        "/c",
+        loader(async () => ({ v: "local" })),
+      )
+      .mount(el);
+
+    navigate("/c");
+    await flush();
+
+    expect(el.innerHTML).toContain("c:local");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it(".clientLoader() warns and is a no-op for unregistered patterns", () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    router()
+      .route("/", HomePage)
+      .clientLoader(
+        "/nope",
+        loader(async () => ({})),
+      );
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("client loader wins over a server loader on the same route", async () => {
+    const serverLoad = mock(async () => ({ v: "server" }));
+    const clientLoad = mock(async () => ({ v: "client" }));
+    const VPage = ilha.render(({ input }: any) => `<p>v:${input?.v ?? "?"}</p>`);
+    unmount = router()
+      .route("/", HomePage)
+      .route("/v", VPage, loader(serverLoad))
+      .clientLoader("/v", loader(clientLoad))
+      .mount(el);
+
+    navigate("/v");
+    await flush();
+
+    expect(el.innerHTML).toContain("v:client");
+    expect(serverLoad).not.toHaveBeenCalled();
+    expect(clientLoad).toHaveBeenCalledTimes(1);
+  });
+
+  it("follows a local loader redirect() on the client", async () => {
+    const FromPage = ilha.render(() => `<p>from</p>`);
+    unmount = router()
+      .route("/", HomePage)
+      .route(
+        "/from",
+        FromPage,
+        loader(async () => redirect("/about")),
+      )
+      .route("/about", AboutPage)
+      .mount(el);
+
+    navigate("/from");
+    await flush();
+
+    expect(routePath()).toBe("/about");
+    expect(el.innerHTML).toContain("about");
+  });
+
+  it("blocks a cross-origin local loader redirect by default", async () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const ExtPage = ilha.render(() => `<p>ext</p>`);
+    unmount = router()
+      .route("/", HomePage)
+      .route(
+        "/ext",
+        ExtPage,
+        loader(async () => redirect("https://evil.example/steal")),
+      )
+      .mount(el);
+
+    navigate("/ext");
+    await flush();
+
+    // The unsafe redirect is blocked — no navigation away, and the blocked
+    // target was reported.
+    expect(routePath()).toBe("/ext");
+    expect(warnSpy.mock.calls.flat().join(" ")).toContain("Blocked unsafe redirect");
+    warnSpy.mockRestore();
+  });
+});
+
+// ─────────────────────────────────────────────
+// navigating() / invalidate() / errorBoundary / loader head sync
+// ─────────────────────────────────────────────
+
+describe("navigation feedback + revalidation", () => {
+  let el: Element;
+  let unmount: (() => void) | null = null;
+
+  const flush = async () => {
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+  };
+
+  beforeEach(() => {
+    setLocation("/");
+    el = makeEl();
+  });
+
+  afterEach(() => {
+    unmount?.();
+    unmount = null;
+    cleanup(el);
+    setLocation("/");
+  });
+
+  it("navigating() is true while a client loader is in flight, false after", async () => {
+    let resolve!: () => void;
+    const gate = new Promise<void>((r) => (resolve = r));
+    const SlowPage = ilha.render(() => `<p>slow</p>`);
+    unmount = router()
+      .route("/", HomePage)
+      .route(
+        "/slow",
+        SlowPage,
+        loader(async () => {
+          await gate;
+          return {};
+        }),
+      )
+      .mount(el);
+
+    expect(navigating()).toBe(false);
+    navigate("/slow");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(navigating()).toBe(true);
+    resolve();
+    await flush();
+    expect(navigating()).toBe(false);
+    expect(el.innerHTML).toContain("slow");
+  });
+
+  it("useRoute() exposes navigating", () => {
+    expect(typeof useRoute().navigating).toBe("function");
+    expect(useRoute().navigating()).toBe(false);
+  });
+
+  it("invalidate() re-runs the current route's loader and re-renders", async () => {
+    let n = 0;
+    const CountPage = ilha.render(({ input }: any) => `<p>n:${input?.n ?? "?"}</p>`);
+    unmount = router()
+      .route("/", HomePage)
+      .route(
+        "/count",
+        CountPage,
+        loader(async () => ({ n: ++n })),
+      )
+      .mount(el);
+
+    navigate("/count");
+    await flush();
+    expect(el.innerHTML).toContain("n:1");
+
+    await invalidate();
+    await flush();
+    expect(el.innerHTML).toContain("n:2");
+  });
+
+  it("invalidate() resolves as a no-op when no router is mounted", async () => {
+    await expect(invalidate()).resolves.toBeUndefined();
+  });
+
+  it("loader head entries update document.title on client navigation", async () => {
+    document.title = "before";
+    const HeadPage = ilha.render(() => `<p>headpage</p>`);
+    unmount = router()
+      .route("/", HomePage)
+      .route(
+        "/headed",
+        HeadPage,
+        loader(async ({ head }) => {
+          head({ title: "After Nav" });
+          return {};
+        }),
+      )
+      .mount(el);
+
+    navigate("/headed");
+    await flush();
+    expect(document.title).toBe("After Nav");
+  });
+
+  it("a loader error renders through the route's errorBoundary on the client", async () => {
+    const FailPage = ilha.render(() => `<p>fail</p>`);
+    const boundary = (err: { status?: number; message: string }) =>
+      ilha.render(() => `<p>boundary:${err.status}:${err.message}</p>`);
+    unmount = router()
+      .route("/", HomePage)
+      .route(
+        "/fails",
+        FailPage,
+        loader(async () => error(500, "kaput")),
+      )
+      .errorBoundary("/fails", boundary)
+      .mount(el);
+
+    navigate("/fails");
+    await flush();
+    expect(el.innerHTML).toContain("boundary:500:kaput");
+  });
+
+  it("errorBoundary() warns for unregistered patterns", () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    router()
+      .route("/", HomePage)
+      .errorBoundary("/nope", () => HomePage);
+    expect(warnSpy.mock.calls.flat().join(" ")).toContain('errorBoundary("/nope"');
+    warnSpy.mockRestore();
+  });
+
+  it("a loader error renders through the errorBoundary during SSR renderResponse", async () => {
+    const FailPage = ilha.render(() => `<p>fail</p>`);
+    const boundary = (err: { status?: number; message: string }) =>
+      ilha.render(() => `<p>ssr-boundary:${err.status}</p>`);
+    const r = router()
+      .route(
+        "/fails",
+        FailPage,
+        loader(async () => error(503, "down")),
+      )
+      .errorBoundary("/fails", boundary);
+
+    const res = await r.renderResponse("http://localhost/fails", { fails: FailPage });
+    expect(res.kind).toBe("error");
+    if (res.kind === "error") {
+      expect(res.status).toBe(503);
+      expect(res.html).toContain("ssr-boundary:503");
+      expect(res.html).toContain('data-router-error="503"');
+    }
+  });
+
+  it("router({ viewTransitions: true }) works without startViewTransition support", async () => {
+    const VtPage = ilha.render(() => `<p>vt</p>`);
+    unmount = router({ viewTransitions: true }).route("/", HomePage).route("/vt", VtPage).mount(el);
+    navigate("/vt");
+    await flush();
+    expect(el.innerHTML).toContain("vt");
+  });
+});
+
+// ─────────────────────────────────────────────
 // prefetch() — opt-out when no loader registered
 // ─────────────────────────────────────────────
 
@@ -1835,12 +2155,10 @@ describe("prefetch()", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("fetches the loader endpoint when the route has a loader", () => {
-    router().route(
-      "/pf-fetch",
-      HomePage,
-      loader(async () => ({})),
-    );
+  it("fetches the loader endpoint when the route is marked as having a server loader", () => {
+    // markLoader simulates the SSR-split client graph: hasLoader without the
+    // loader function itself, so prefetch must go through the endpoint.
+    router().route("/pf-fetch", HomePage).markLoader("/pf-fetch");
     prefetch("/pf-fetch");
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const url = (fetchSpy.mock.calls[0] as any[])[0] as string;
@@ -1848,23 +2166,24 @@ describe("prefetch()", () => {
     expect(url).toContain("path=");
   });
 
+  it("runs a locally-registered loader instead of fetching the endpoint", async () => {
+    const load = mock(async () => ({ ok: true }));
+    router().route("/pf-local", HomePage, loader(load));
+    prefetch("/pf-local");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
   it("is idempotent — second call with same path does not fetch again", () => {
-    router().route(
-      "/pf-idem",
-      HomePage,
-      loader(async () => ({})),
-    );
+    router().route("/pf-idem", HomePage).markLoader("/pf-idem");
     prefetch("/pf-idem");
     prefetch("/pf-idem");
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
   it("encodes the path into the query string", () => {
-    router().route(
-      "/pf-enc/:id",
-      HomePage,
-      loader(async () => ({})),
-    );
+    router().route("/pf-enc/:id", HomePage).markLoader("/pf-enc/:id");
     prefetch("/pf-enc/abc?tab=reviews");
     const url = (fetchSpy.mock.calls[0] as any[])[0] as string;
     expect(url).toContain(encodeURIComponent("/pf-enc/abc?tab=reviews"));

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -650,6 +650,12 @@ export interface RouterOptions {
    * `ctx.signal` also aborts when the incoming `Request`'s signal aborts.
    */
   loaderTimeout?: number;
+  /**
+   * Wrap client-side view swaps in `document.startViewTransition()` when the
+   * browser supports it (falls back to an instant swap otherwise).
+   * Default: `false`.
+   */
+  viewTransitions?: boolean;
 }
 
 export interface HydratableRenderOptions extends Partial<Omit<HydratableOptions, "name">> {
@@ -707,6 +713,22 @@ export interface RouterBuilder {
    * was never registered via `.route()`.
    */
   attachLoader(pattern: string, loader: Loader<any>): RouterBuilder;
+  /**
+   * Attach a loader that runs **in the browser** on client navigations,
+   * instead of fetching from the loader endpoint. Used by the FS-routing
+   * codegen for `clientLoad` exports; also available for manual routers.
+   * When a route has both, the client loader wins on client navigations and
+   * the server loader runs during SSR. No-op if the pattern was never
+   * registered via `.route()`.
+   */
+  clientLoader(pattern: string, loader: Loader<any>): RouterBuilder;
+  /**
+   * Attach the route's nearest `+error` boundary so **loader** errors render
+   * through it (render errors are already handled by `wrapError` inside the
+   * island). Used by the FS-routing codegen; also available for manual
+   * routers. No-op if the pattern was never registered via `.route()`.
+   */
+  errorBoundary(pattern: string, handler: ErrorHandler): RouterBuilder;
   /**
    * Mark an already-registered route as having a server-side loader without
    * importing that loader into the client bundle. Used by FS-routing codegen
@@ -800,10 +822,83 @@ const prefetchCache = new Map<string, { promise: Promise<LoaderFetchResult>; exp
 const PREFETCH_TTL_MS = 30_000;
 
 type LoaderFetchResult =
-  | { kind: "data"; data: Record<string, unknown> }
+  | { kind: "data"; data: Record<string, unknown>; headEntries?: HeadInput[] }
   | { kind: "redirect"; to: string; status: number }
   | { kind: "error"; status: number; message: string }
   | { kind: "not-found" };
+
+// ─────────────────────────────────────────────
+// View transitions (opt-in via router({ viewTransitions: true }))
+// ─────────────────────────────────────────────
+
+/** Mirrors the last router's `viewTransitions` option (module-level like `_notFound`). */
+let _viewTransitions = false;
+
+/**
+ * Run a synchronous DOM mutation, wrapped in a view transition when enabled
+ * and supported (the callback runs async — after the browser snapshots the old
+ * view). Resolves with the mutation's result either way.
+ */
+async function withViewSwap<T>(mutate: () => T): Promise<T> {
+  const start = (
+    document as Document & {
+      startViewTransition?: (cb: () => void) => { updateCallbackDone?: Promise<void> };
+    }
+  ).startViewTransition?.bind(document);
+  if (!_viewTransitions || !start) return mutate();
+  let result!: T;
+  const vt = start(() => {
+    result = mutate();
+  });
+  await vt.updateCallbackDone?.catch(() => {});
+  return result;
+}
+
+/**
+ * Execute a loader registered in the browser (manual `.route(p, island, loader)`
+ * or FS-routing `clientLoad`) and map its result to the loader endpoint's wire
+ * shape, so all client mount paths handle both sources identically. Loader
+ * `head` contributions are dropped, matching the endpoint fetch path.
+ */
+async function runLocalLoader(
+  loader: Loader<any>,
+  matchParams: Record<string, string> | undefined,
+  pathWithSearch: string,
+  signal?: AbortSignal,
+): Promise<LoaderFetchResult> {
+  const url = new URL(pathWithSearch, location.origin);
+  const params = extractParams(matchParams);
+  const headEntries: HeadInput[] = [];
+  const result = await executeLoader(
+    loader,
+    url,
+    params,
+    defaultRequest(url),
+    signal ?? new AbortController().signal,
+    (input) => headEntries.push(input),
+  );
+  // A superseded navigation must not apply this result (executeLoader maps the
+  // abort race to an error result; surface it as an AbortError instead).
+  signal?.throwIfAborted();
+  if (result.kind === "redirect") {
+    // Same redirect policy as the server paths.
+    const safe = resolveRedirectTarget(result.to, url, _allowExternalRedirects);
+    if (!safe.ok) {
+      console.warn(
+        `[ilha-router] Blocked unsafe redirect target "${result.to}". ` +
+          `Set allowExternalRedirects: true to allow cross-origin redirects.`,
+      );
+      return { kind: "error", status: 500, message: "Unsafe redirect target" };
+    }
+    return { kind: "redirect", to: safe.to, status: result.status };
+  }
+  if (result.kind === "data") {
+    return headEntries.length > 0
+      ? { kind: "data", data: result.data, headEntries }
+      : { kind: "data", data: result.data };
+  }
+  return result;
+}
 
 async function fetchLoaderData(
   pathWithSearch: string,
@@ -828,6 +923,21 @@ async function fetchLoaderData(
         // Prefetch failed — fall through to a fresh fetch
       }
     }
+  }
+
+  // A loader registered in the browser runs locally — no server round-trip.
+  // SSR-split builds strip `loader` from the client route graph (only
+  // `hasLoader` survives), so they still fall through to the endpoint fetch.
+  const pathOnly = pathWithSearch.split("?")[0] ?? "";
+  const localMatch = findRoute(_rou3, "GET", pathOnly);
+  const localLoader = localMatch?.data?.clientLoader ?? localMatch?.data?.loader;
+  if (localLoader) {
+    return runLocalLoader(
+      localLoader,
+      localMatch?.params as Record<string, string> | undefined,
+      pathWithSearch,
+      signal,
+    );
   }
 
   const url = `${LOADER_ENDPOINT}?path=${encodeURIComponent(pathWithSearch)}`;
@@ -898,12 +1008,16 @@ async function mountRouteWithHydration(
 ): Promise<() => void> {
   if (!island) {
     if (_notFound) {
-      host.innerHTML = `<div data-router-view data-router-not-found>${_notFound.toString()}</div>`;
-      const nfHost = host.firstElementChild;
-      if (nfHost) return _notFound.mount(nfHost);
-      return () => {};
+      const nf = _notFound;
+      return withViewSwap(() => {
+        host.innerHTML = `<div data-router-view data-router-not-found>${nf.toString()}</div>`;
+        const nfHost = host.firstElementChild;
+        return nfHost ? nf.mount(nfHost) : () => {};
+      });
     }
-    host.innerHTML = `<div data-router-empty></div>`;
+    await withViewSwap(() => {
+      host.innerHTML = `<div data-router-empty></div>`;
+    });
     return () => {};
   }
 
@@ -923,22 +1037,35 @@ async function mountRouteWithHydration(
     return () => {};
   }
   if (loaderResult.kind === "error") {
-    // Render a minimal inline error. See renderResponse for why loader errors
-    // don't currently route through the page's +error.ts boundary.
+    // Route the loader error through the nearest `+error` boundary when one
+    // is registered; fall back to the minimal inline error div.
+    const boundary = clientMatch?.data?.errorHandler;
+    if (boundary) {
+      return withViewSwap(() =>
+        mountLoaderErrorBoundary(boundary, host, loaderResult.status, loaderResult.message),
+      );
+    }
     const escaped = String(loaderResult.message)
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
       .replace(/>/g, "&gt;");
-    host.innerHTML = `<div data-router-view data-router-error="${loaderResult.status}">${escaped}</div>`;
+    await withViewSwap(() => {
+      host.innerHTML = `<div data-router-view data-router-error="${loaderResult.status}">${escaped}</div>`;
+    });
     return () => {};
   }
   if (loaderResult.kind === "not-found") {
-    host.innerHTML = `<div data-router-empty></div>`;
+    await withViewSwap(() => {
+      host.innerHTML = `<div data-router-empty></div>`;
+    });
     return () => {};
   }
   props = loaderResult.data;
 
-  const headStore: HeadStore = { entries: [] };
+  // Seed with the loader's head contributions (loader first, render-time
+  // `head()` later — later entries win), so client navigations keep
+  // `document.title`/meta in sync just like SSR does.
+  const headStore: HeadStore = { entries: [...(loaderResult.headEntries ?? [])] };
 
   // If no registry provided, fall back to static rendering (no interactivity)
   if (!registry) {
@@ -946,8 +1073,10 @@ async function mountRouteWithHydration(
       "[ilha-router] No registry provided for client-side navigation. Island will not be interactive.",
     );
     const html = await withHeadStore(headStore, () => island.toString(props));
-    applyHeadEntriesToDocument(headStore.entries);
-    host.innerHTML = `<div data-router-view>${html}</div>`;
+    await withViewSwap(() => {
+      applyHeadEntriesToDocument(headStore.entries);
+      host.innerHTML = `<div data-router-view>${html}</div>`;
+    });
     return () => {};
   }
 
@@ -958,8 +1087,10 @@ async function mountRouteWithHydration(
   if (!name) {
     console.warn("[ilha-router] Island not found in registry for client-side navigation.");
     const html = await withHeadStore(headStore, () => island.toString(props));
-    applyHeadEntriesToDocument(headStore.entries);
-    host.innerHTML = `<div data-router-view>${html}</div>`;
+    await withViewSwap(() => {
+      applyHeadEntriesToDocument(headStore.entries);
+      host.innerHTML = `<div data-router-view>${html}</div>`;
+    });
     return () => {};
   }
 
@@ -967,16 +1098,42 @@ async function mountRouteWithHydration(
   const html = await withHeadStore(headStore, () =>
     island.hydratable(props, { name, as: "div", snapshot: true }),
   );
-  applyHeadEntriesToDocument(headStore.entries);
-  host.innerHTML = `<div data-router-view>${html}</div>`;
+  return withViewSwap(() => {
+    applyHeadEntriesToDocument(headStore.entries);
+    host.innerHTML = `<div data-router-view>${html}</div>`;
+    // Mount the island for interactivity
+    const islandHost = host.querySelector(`[data-ilha="${name}"]`);
+    return islandHost ? island.mount(islandHost) : () => {};
+  });
+}
 
-  // Mount the island for interactivity
-  const islandHost = host.querySelector(`[data-ilha="${name}"]`);
-  if (islandHost) {
-    return island.mount(islandHost);
+/** Render + mount a `+error` boundary island for a failed loader. */
+function mountLoaderErrorBoundary(
+  boundary: ErrorHandler,
+  host: Element,
+  status: number,
+  message: string,
+): () => void {
+  try {
+    const errorIsland = boundary(
+      { message, status },
+      {
+        path: routePath(),
+        params: routeParams(),
+        search: routeSearch(),
+        hash: routeHash(),
+      },
+    );
+    host.innerHTML = `<div data-router-view data-router-error="${status}">${errorIsland.toString()}</div>`;
+    const ehHost = host.firstElementChild;
+    return ehHost ? errorIsland.mount(ehHost) : () => {};
+  } catch (e) {
+    // A throwing boundary must not take down navigation — fall back to the
+    // minimal inline error.
+    console.error("[ilha-router] error boundary threw while rendering a loader error:", e);
+    host.innerHTML = `<div data-router-view data-router-error="${status}"></div>`;
+    return () => {};
   }
-
-  return () => {};
 }
 
 // ─────────────────────────────────────────────
@@ -1072,12 +1229,53 @@ export function routeHash(value?: string): string {
   return store ? store.hash : _routeHashSig();
 }
 
+// ─────────────────────────────────────────────
+// Navigation pending state
+// ─────────────────────────────────────────────
+
+// Count of in-flight client navigations (loader fetch + view swap). A counter
+// rather than a boolean so an overlapping navigation that supersedes another
+// doesn't clear the flag early.
+const _navigatingSig = context<number>("router.navigating", 0);
+
+/** Reactive: `true` while a client navigation (loader fetch + view swap) is in flight. */
+export function navigating(): boolean {
+  return _navigatingSig() > 0;
+}
+
+// Re-runs the active route's loader and re-renders the view. Registered by
+// the mounted router (SPA or hydrate mode); null when no router is mounted.
+let _revalidate: (() => Promise<void>) | null = null;
+
+/**
+ * Re-run the current route's loader and re-render the view with fresh data —
+ * e.g. after a mutation. Resolves when the view has updated. No-op on the
+ * server or when no router is mounted.
+ */
+export function invalidate(): Promise<void> {
+  if (!isBrowser || !_revalidate) return Promise.resolve();
+  return _revalidate();
+}
+
+/** Mark a navigation as started; returns an idempotent settle callback. */
+function beginNavigation(): () => void {
+  if (!isBrowser) return () => {};
+  _navigatingSig(_navigatingSig() + 1);
+  let done = false;
+  return () => {
+    if (done) return;
+    done = true;
+    _navigatingSig(Math.max(0, _navigatingSig() - 1));
+  };
+}
+
 export function useRoute() {
   return {
     path: routePath,
     params: routeParams,
     search: routeSearch,
     hash: routeHash,
+    navigating,
   };
 }
 
@@ -1105,6 +1303,10 @@ interface RouteData {
   /** The pattern this route was registered under — exact `isActive()` checks compare against it. */
   pattern: string;
   loader?: Loader<any>;
+  /** Loader that runs in the browser on client navigations (manual SPA builder or FS `clientLoad`). */
+  clientLoader?: Loader<any>;
+  /** Nearest `+error` boundary — renders loader errors instead of the bare inline error div. */
+  errorHandler?: ErrorHandler;
   hasLoader?: boolean;
 }
 
@@ -1423,6 +1625,10 @@ export function enableLinkInterception(
 /** Custom 404 island — set via `router({ notFound })`. Module-level because
  * RouterView is a module-level island (single active router per document). */
 let _notFound: Island<any, any> | null = null;
+
+/** Redirect policy for browser-executed loaders — mirrors the last router's
+ * `allowExternalRedirects` option (module-level for the same reason as `_notFound`). */
+let _allowExternalRedirects = false;
 
 export const RouterView = ilha.render((): string => {
   const island = activeIsland();
@@ -1923,6 +2129,8 @@ export function router(options: RouterOptions = {}): RouterBuilder {
 
   _rou3 = rou3;
   _notFound = notFound;
+  _allowExternalRedirects = allowExternalRedirects;
+  _viewTransitions = options.viewTransitions === true;
 
   let _navChangeCleanup: (() => void) | null = null;
   let _linkCleanup: (() => void) | null = null;
@@ -1954,6 +2162,35 @@ export function router(options: RouterOptions = {}): RouterBuilder {
         rec.loader = loader;
         rec.hasLoader = true;
       }
+      return builder;
+    },
+
+    clientLoader(pattern: string, loader: Loader<any>): RouterBuilder {
+      const data = patternToData.get(pattern);
+      if (!data) {
+        console.warn(
+          `[ilha-router] clientLoader("${pattern}", …): pattern was never registered via .route(). ` +
+            `The loader will be ignored.`,
+        );
+        return builder;
+      }
+      data.clientLoader = loader;
+      data.hasLoader = true;
+      const rec = records.find((r) => r.pattern === pattern);
+      if (rec) rec.hasLoader = true;
+      return builder;
+    },
+
+    errorBoundary(pattern: string, handler: ErrorHandler): RouterBuilder {
+      const data = patternToData.get(pattern);
+      if (!data) {
+        console.warn(
+          `[ilha-router] errorBoundary("${pattern}", …): pattern was never registered via .route(). ` +
+            `The boundary will be ignored.`,
+        );
+        return builder;
+      }
+      data.errorHandler = handler;
       return builder;
     },
 
@@ -2092,6 +2329,7 @@ export function router(options: RouterOptions = {}): RouterBuilder {
 
             queueMicrotask(async () => {
               if (thisNav !== navVersion) return;
+              const settle = beginNavigation();
               unmountView?.();
               unmountView = null;
               try {
@@ -2111,6 +2349,8 @@ export function router(options: RouterOptions = {}): RouterBuilder {
                 console.error("[ilha-router] navigation failed:", e);
                 viewHost.innerHTML = `<div data-router-view data-router-error="500"></div>`;
                 return;
+              } finally {
+                settle();
               }
               currentMountedIsland = current;
             });
@@ -2129,21 +2369,81 @@ export function router(options: RouterOptions = {}): RouterBuilder {
           const loc = getAdapter().readLocation();
           const pathWithSearch = loc.pathname + loc.search;
           const clientMatch = findRoute(_rou3, "GET", loc.pathname);
+          // A client-side loader can't run during SSR, so its data is missing
+          // from the server HTML — replace the SSR DOM with a full client
+          // render for the initial route.
+          if (clientMatch?.data?.clientLoader) {
+            const thisNav = ++navVersion;
+            const ac = new AbortController();
+            navAbort = ac;
+            try {
+              const um = await mountRouteWithHydration(
+                island,
+                viewHost,
+                pathWithSearch,
+                ac.signal,
+                registry,
+                reverseRegistry,
+              );
+              // A navigation that started while we awaited owns the view now.
+              if (thisNav === navVersion) unmountView = um;
+              else um();
+            } catch (e: any) {
+              if (e?.name !== "AbortError") {
+                console.error("[ilha-router] initial client loader render failed:", e);
+              }
+            }
+            return;
+          }
           const hasLoader = !!clientMatch?.data?.hasLoader;
           const loaderResult: LoaderFetchResult = hasLoader
             ? await fetchLoaderData(pathWithSearch)
             : { kind: "data", data: {} };
           if (loaderResult.kind === "redirect" || loaderResult.kind === "error") return;
           const props = loaderResult.kind === "data" ? loaderResult.data : {};
-          const headStore: HeadStore = { entries: [] };
+          const headStore: HeadStore = {
+            entries: [...(loaderResult.kind === "data" ? (loaderResult.headEntries ?? []) : [])],
+          };
           await withHeadStore(headStore, () => island.toString(props));
           if (!mounted) return;
           applyHeadEntriesToDocument(headStore.entries);
         })();
 
+        _revalidate = async () => {
+          const island = activeIsland();
+          const thisNav = ++navVersion;
+          navAbort?.abort();
+          const ac = new AbortController();
+          navAbort = ac;
+          const settle = beginNavigation();
+          try {
+            const loc = getAdapter().readLocation();
+            const um = await mountRouteWithHydration(
+              island,
+              viewHost,
+              loc.pathname + loc.search,
+              ac.signal,
+              registry,
+              reverseRegistry,
+            );
+            if (thisNav === navVersion) {
+              unmountView?.();
+              unmountView = um;
+              currentMountedIsland = island;
+            } else {
+              um();
+            }
+          } catch (e: any) {
+            if (e?.name !== "AbortError") console.error("[ilha-router] invalidate failed:", e);
+          } finally {
+            settle();
+          }
+        };
+
         return () => {
           mounted = false;
           ++navVersion;
+          _revalidate = null;
           navAbort?.abort();
           unmountNavHandler();
           navHost.remove();
@@ -2198,15 +2498,32 @@ export function router(options: RouterOptions = {}): RouterBuilder {
           clientRedirect(result.to);
           return;
         }
+        if (result.kind === "error") {
+          // Route the loader error through the nearest `+error` boundary when
+          // one is registered; otherwise keep the previous behavior (render
+          // the island with empty props).
+          const boundary = clientMatch?.data?.errorHandler;
+          if (boundary) {
+            unmountIsland = await withViewSwap(() =>
+              mountLoaderErrorBoundary(boundary, viewHost, result.status, result.message),
+            );
+            return;
+          }
+        }
         const props = result.kind === "data" ? result.data : {};
 
         // In SPA mode RouterView is already showing the island's no-props HTML.
-        // Re-render with props, morph, and mount for interactivity.
-        const headStore: HeadStore = { entries: [] };
+        // Re-render with props, morph, and mount for interactivity. Loader
+        // head entries seed the store so `document.title`/meta stay in sync.
+        const headStore: HeadStore = {
+          entries: [...(result.kind === "data" ? (result.headEntries ?? []) : [])],
+        };
         const html = await withHeadStore(headStore, () => island.toString(props));
-        applyHeadEntriesToDocument(headStore.entries);
-        viewHost.innerHTML = html;
-        unmountIsland = island.mount(viewHost, props);
+        unmountIsland = await withViewSwap(() => {
+          applyHeadEntriesToDocument(headStore.entries);
+          viewHost.innerHTML = html;
+          return island.mount(viewHost, props);
+        });
       }
 
       // Initial mount — no need to wait for a loader fetch since the first
@@ -2227,10 +2544,13 @@ export function router(options: RouterOptions = {}): RouterBuilder {
           const signal = navAbort.signal;
           queueMicrotask(() => {
             if (thisNav !== navVersion) return;
-            mountActiveIsland(current, signal).catch((e: unknown) => {
-              if ((e as { name?: string })?.name === "AbortError") return;
-              console.error("[ilha-router] navigation failed:", e);
-            });
+            const settle = beginNavigation();
+            mountActiveIsland(current, signal)
+              .catch((e: unknown) => {
+                if ((e as { name?: string })?.name === "AbortError") return;
+                console.error("[ilha-router] navigation failed:", e);
+              })
+              .finally(settle);
           });
         }
         return "";
@@ -2241,9 +2561,24 @@ export function router(options: RouterOptions = {}): RouterBuilder {
       host.appendChild(navHost);
       const unmountNavHandler = NavHandler.mount(navHost);
 
+      _revalidate = async () => {
+        ++navVersion;
+        navAbort?.abort();
+        navAbort = new AbortController();
+        const settle = beginNavigation();
+        try {
+          await mountActiveIsland(activeIsland(), navAbort.signal);
+        } catch (e: any) {
+          if (e?.name !== "AbortError") console.error("[ilha-router] invalidate failed:", e);
+        } finally {
+          settle();
+        }
+      };
+
       return () => {
         mounted = false;
         ++navVersion;
+        _revalidate = null;
         navAbort?.abort();
         unmountIsland?.();
         unmountNavHandler();
@@ -2347,7 +2682,13 @@ export function router(options: RouterOptions = {}): RouterBuilder {
         }
         if (result.kind !== "data") return result;
         if (headStore.entries.length === 0) return result;
-        return { ...result, head: serializeHead(headStore.entries) };
+        // `head` (serialized) feeds SSR shells; `headEntries` (raw POJOs) let
+        // client navigations apply loader head to the live document.
+        return {
+          ...result,
+          head: serializeHead(headStore.entries),
+          headEntries: headStore.entries,
+        };
       } finally {
         abort.done();
       }
@@ -2449,12 +2790,34 @@ export function router(options: RouterOptions = {}): RouterBuilder {
         }
       }
       if (result.kind === "error") {
-        // Loader errors render a minimal inline error page. The page's
-        // `+error.ts` boundary (applied via `wrapError` at codegen time)
-        // wraps the page island's *render*, not the loader — so loader
-        // errors cannot currently route through it. Host apps should
-        // inspect `response.status` and substitute their own error page
-        // if finer control is needed.
+        // Route the loader error through the route's `+error` boundary when
+        // one is registered (render errors are already covered by `wrapError`
+        // inside the island); fall back to a minimal inline error page.
+        const boundary = match.data.errorHandler;
+        if (boundary) {
+          try {
+            const errorIsland = boundary(
+              { message: result.message, status: result.status },
+              {
+                path: routePath(),
+                params: routeParams(),
+                search: routeSearch(),
+                hash: routeHash(),
+              },
+            );
+            const html = await withHeadStore(headStore, () => errorIsland.toString());
+            return {
+              kind: "error",
+              status: result.status,
+              message: result.message,
+              html: `<div data-router-view data-router-error="${result.status}">${html}</div>`,
+              head: serializeHead(headStore.entries),
+            };
+          } catch (e) {
+            console.error("[ilha-router] error boundary threw while rendering a loader error:", e);
+            // fall through to the inline error below
+          }
+        }
         const escapedMessage = String(result.message)
           .replace(/&/g, "&amp;")
           .replace(/</g, "&lt;")

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -847,10 +847,21 @@ async function withViewSwap<T>(mutate: () => T): Promise<T> {
   ).startViewTransition?.bind(document);
   if (!_viewTransitions || !start) return mutate();
   let result!: T;
+  let thrown: unknown;
+  let failed = false;
   const vt = start(() => {
-    result = mutate();
+    try {
+      result = mutate();
+    } catch (e) {
+      failed = true;
+      thrown = e;
+      throw e;
+    }
   });
+  // Swallow only the transition's own rejection mirror — the mutation error
+  // itself rethrows below so callers see it, matching the non-transition path.
   await vt.updateCallbackDone?.catch(() => {});
+  if (failed) throw thrown;
   return result;
 }
 
@@ -1045,10 +1056,7 @@ async function mountRouteWithHydration(
         mountLoaderErrorBoundary(boundary, host, loaderResult.status, loaderResult.message),
       );
     }
-    const escaped = String(loaderResult.message)
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;");
+    const escaped = escapeHtml(loaderResult.message);
     await withViewSwap(() => {
       host.innerHTML = `<div data-router-view data-router-error="${loaderResult.status}">${escaped}</div>`;
     });
@@ -1890,6 +1898,11 @@ function escapeHeadAttr(value: unknown): string {
   return String(value).replace(/[&<>"']/g, (c) => HEAD_ESC[c]!);
 }
 
+/** Escape text content for inline HTML (loader error messages etc.). */
+function escapeHtml(value: unknown): string {
+  return String(value).replace(/[&<>]/g, (c) => HEAD_ESC[c]!);
+}
+
 function serializeAttrs(attrs: Record<string, string>): string {
   return Object.entries(attrs)
     .map(([k, v]) => ` ${k}="${escapeHeadAttr(v)}"`)
@@ -2500,8 +2513,9 @@ export function router(options: RouterOptions = {}): RouterBuilder {
         }
         if (result.kind === "error") {
           // Route the loader error through the nearest `+error` boundary when
-          // one is registered; otherwise keep the previous behavior (render
-          // the island with empty props).
+          // one is registered; otherwise render the same inline error marker
+          // as `mountRouteWithHydration` instead of hiding the failure behind
+          // an island rendered with empty props.
           const boundary = clientMatch?.data?.errorHandler;
           if (boundary) {
             unmountIsland = await withViewSwap(() =>
@@ -2509,6 +2523,11 @@ export function router(options: RouterOptions = {}): RouterBuilder {
             );
             return;
           }
+          const escaped = escapeHtml(result.message);
+          await withViewSwap(() => {
+            viewHost.innerHTML = `<div data-router-error="${result.status}">${escaped}</div>`;
+          });
+          return;
         }
         const props = result.kind === "data" ? result.data : {};
 
@@ -2818,10 +2837,7 @@ export function router(options: RouterOptions = {}): RouterBuilder {
             // fall through to the inline error below
           }
         }
-        const escapedMessage = String(result.message)
-          .replace(/&/g, "&amp;")
-          .replace(/</g, "&lt;")
-          .replace(/>/g, "&gt;");
+        const escapedMessage = escapeHtml(result.message);
         const html = `<div data-router-view data-router-error="${result.status}">${escapedMessage}</div>`;
         return {
           kind: "error",

--- a/packages/router/src/plugin.test.ts
+++ b/packages/router/src/plugin.test.ts
@@ -139,6 +139,31 @@ describe("pages — ?client virtual module", () => {
     expect(result).toMatch(/export\s*\{\s*default\s*\}/);
     expect(result).not.toContain("*");
   });
+
+  it("resolveId handles ?client-loader like ?client", () => {
+    const p = plugin();
+    p.configResolved({ root: "/proj" });
+    const resolved = p.resolveId(
+      "../src/pages/index.ts?client-loader",
+      "/proj/.ilha/pages.client.ts",
+    );
+    expect(resolved).toBe("/proj/src/pages/index.ts?client-loader");
+  });
+
+  it("resolveId refuses ?client-loader ids outside the pages dir", () => {
+    const p = plugin();
+    p.configResolved({ root: "/proj" });
+    const escape = p.resolveId("../../../etc/passwd?client-loader", "/proj/.ilha/pages.client.ts");
+    expect(escape).toBeUndefined();
+  });
+
+  it("load(?client-loader) emits `export { clientLoad }` from the bare path", () => {
+    const p = plugin();
+    const result = p.load("/proj/src/pages/index.ts?client-loader");
+    expect(result).toMatch(/export\s*\{\s*clientLoad\s*\}/);
+    expect(result).toContain(`"/proj/src/pages/index.ts"`);
+    expect(result).not.toContain("default");
+  });
 });
 
 // ─────────────────────────────────────────────

--- a/packages/router/src/plugin.ts
+++ b/packages/router/src/plugin.ts
@@ -22,6 +22,9 @@ export const RESOLVED_VIRTUAL_IDS = [
 /** Query suffix used on page/layout imports in the client file. */
 export const CLIENT_QUERY = "?client";
 
+/** Query suffix that re-exports a page/layout's `clientLoad` for the browser bundle. */
+export const CLIENT_LOADER_QUERY = "?client-loader";
+
 /** Read & parse a package.json, returning null on any error. */
 function readJson(path: string): Record<string, unknown> | null {
   try {
@@ -184,16 +187,19 @@ export function resolvePagesId(state: PagesPluginState, id: string, importer?: s
   if (id === VIRTUAL_PAGES_CLIENT) return RESOLVED_PAGES_CLIENT;
   if (id === VIRTUAL_LOADERS) return RESOLVED_LOADERS;
 
-  if (id.endsWith(CLIENT_QUERY)) {
-    const bare = id.slice(0, -CLIENT_QUERY.length);
+  // ?client-loader must be checked first — its suffix would otherwise never
+  // match after the ?client branch, but keep the order explicit regardless.
+  for (const query of [CLIENT_LOADER_QUERY, CLIENT_QUERY]) {
+    if (!id.endsWith(query)) continue;
+    const bare = id.slice(0, -query.length);
     const resolved = importer ? resolve(importer.replace(/\?.*$/, ""), "..", bare) : resolve(bare);
-    // Only page-dir modules may be re-exported through the ?client shim —
-    // without this check any absolute path could be pulled into the module
-    // graph via a crafted `…?client` import.
+    // Only page-dir modules may be re-exported through the shim — without
+    // this check any absolute path could be pulled into the module graph via
+    // a crafted `…?client` / `…?client-loader` import.
     // Fail closed when pagesDir isn't configured yet — containment can't be
-    // checked, so nothing may pass through the ?client shim.
+    // checked, so nothing may pass through the shim.
     if (!state.pagesDir || !state.isUnderPagesDir(resolved)) return;
-    return resolved + CLIENT_QUERY;
+    return resolved + query;
   }
 }
 
@@ -209,6 +215,11 @@ export function loadPagesModule(state: PagesPluginState, id: string) {
   if (id === RESOLVED_LOADERS) {
     const spec = state.loadersFile.replace(/\.tsx?$/, "");
     return `import ${JSON.stringify(spec)};`;
+  }
+
+  if (id.endsWith(CLIENT_LOADER_QUERY)) {
+    const bare = id.slice(0, -CLIENT_LOADER_QUERY.length);
+    return `export { clientLoad } from ${JSON.stringify(bare)};`;
   }
 
   if (id.endsWith(CLIENT_QUERY)) {

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -169,6 +169,16 @@ Registers a named mutation. `fn` receives the props and a context object. Return
 | `ctx.getInitial()` | Read the initial state (e.g. for reset-style actions)        |
 | `ctx.set(patch)`   | Imperative write escape hatch for async / multi-step actions |
 
+Every action on the built store exposes a reactive **`.pending`** flag — `true` while any async invocation of that action is in flight (sync actions never set it). Read it in a render for per-action loading UI:
+
+```ts
+const s = store({ user: null as User | null })
+  .action("save", async (_, ctx) => ({ user: await api.save(ctx.get().user) }))
+  .build();
+
+ilha.render(() => html`<button disabled=${() => s.save.pending}>Save</button>`);
+```
+
 Actions may be **async**; return `Partial<TState>`, `void`, or `Promise` of either (e.g. `return void toast.error(...)` after `await`). Patches from returned promises are applied when the promise settles; sync returns still commit immediately. Use **`navigate()`** (or your app router) for client redirects after a successful action — do not `return redirect()` from `@ilha/router` loaders inside a store action (it throws and is reported as `source: "action"`).
 
 The returned patch is the primary write path. Use `ctx.set` for multi-step writes inside an async action — you can return nothing when all updates go through `ctx.set`:
@@ -257,7 +267,7 @@ draftStore.dispose();
 
 Raw `TState` snapshots — no derived values, no actions. `getInitialState()` is frozen at `.build()` time.
 
-#### `store.subscribe(listener)` / `store.subscribe(selector, listener)`
+#### `store.subscribe(listener)` / `store.subscribe(selector, listener, options?)`
 
 Full-state and slice forms. Neither fires on initial subscription. Both return an unsubscribe function.
 
@@ -265,6 +275,18 @@ Full-state and slice forms. Neither fires on initial subscription. Both return a
 const unsub = s.subscribe((state, prev) => console.log(state, prev));
 const unsub2 = s.subscribe((state) => state.count, (count, prev) => …);
 unsub();
+```
+
+Slice comparison defaults to `Object.is`, so an object-building selector (`s => ({ a: s.a, b: s.b })`) fires on every commit — it returns a fresh object each time. Pass `{ equal: shallowEqual }` to compare one level deep instead:
+
+```ts
+import { shallowEqual } from "@ilha/store";
+
+s.subscribe(
+  (st) => ({ a: st.a, b: st.b }),
+  (slice) => …,
+  { equal: shallowEqual },
+);
 ```
 
 #### `store.select(selector)` — reactive read accessor
@@ -341,6 +363,55 @@ ilha.render(
 ```
 
 ---
+
+## Persistence — `persist(store, key, options?)`
+
+Keeps a store in sync with `localStorage` (or any `getItem`/`setItem` backend):
+
+1. **Hydrates** on call: reads `key` and merges the stored patch via `setState` — middleware runs and schema stores validate, so corrupt or stale-shaped payloads are rejected instead of applied.
+2. **Writes through** on every commit.
+3. **Cross-tab sync**: mirrors writes from other tabs via `storage` events (default `localStorage` backend only; disable with `crossTab: false`).
+
+Returns an unsubscribe. No-op on the server.
+
+```ts
+import { store, persist } from "@ilha/store";
+
+const cartStore = store({ items: [] as string[] }).build();
+persist(cartStore, "cart");
+```
+
+| Option        | Default               | Description                                 |
+| ------------- | --------------------- | ------------------------------------------- |
+| `storage`     | `window.localStorage` | Any `{ getItem, setItem }` backend          |
+| `crossTab`    | `true`                | Apply `storage` events from other tabs      |
+| `serialize`   | `JSON.stringify`      | State → string                              |
+| `deserialize` | `JSON.parse`          | String → patch (validated on schema stores) |
+
+Call the returned unsubscribe before `store.dispose()` for per-island stores.
+
+## SSR — `dehydrate()` / `hydrate()`
+
+Stores are module-level singletons, so on a concurrent SSR server they must **not** be written during a render — request A's data would leak into request B. Instead, state travels the same way ilha island state does: serialized into the HTML, then seeded on the client.
+
+- **`dehydrate(storeOrState)`** → JSON string. On a concurrent server pass a **request-local object** (e.g. loader data), not the shared store. Passing the store itself is fine in non-concurrent contexts (prerendering, tests).
+- **`hydrate(store, raw)`** → parses with the same guards as ilha's island snapshots (size cap, depth cap, must-be-plain-object, prototype-polluting keys stripped) and merges via `setState` — middleware runs and schema stores validate, so corrupt payloads are rejected. Returns `true` when applied.
+
+```ts
+// server (inside the loader / request handler)
+const payload = dehydrate({ items: cartItems }); // request-local data
+// stamp into the shell, escaped for the embedding context:
+// <script type="application/json" id="cart-state">${payload.replace(/</g, "\\u003c")}</script>
+```
+
+```ts
+// client — page island's onMount (runs on hydration)
+import { hydrate } from "@ilha/store";
+
+ilha.onMount(() => {
+  hydrate(cartStore, document.getElementById("cart-state")?.textContent);
+});
+```
 
 ## Forms — `@ilha/store/form`
 

--- a/packages/store/README.md
+++ b/packages/store/README.md
@@ -395,7 +395,7 @@ Call the returned unsubscribe before `store.dispose()` for per-island stores.
 Stores are module-level singletons, so on a concurrent SSR server they must **not** be written during a render — request A's data would leak into request B. Instead, state travels the same way ilha island state does: serialized into the HTML, then seeded on the client.
 
 - **`dehydrate(storeOrState)`** → JSON string. On a concurrent server pass a **request-local object** (e.g. loader data), not the shared store. Passing the store itself is fine in non-concurrent contexts (prerendering, tests).
-- **`hydrate(store, raw)`** → parses with the same guards as ilha's island snapshots (size cap, depth cap, must-be-plain-object, prototype-polluting keys stripped) and merges via `setState` — middleware runs and schema stores validate, so corrupt payloads are rejected. Returns `true` when applied.
+- **`hydrate(store, raw)`** → parses with the same guards as ilha's island snapshots (size cap, depth cap, must-be-plain-object, prototype-polluting keys stripped) and merges via `setState` — middleware runs and schema stores validate, so corrupt payloads are rejected. Returns `true` when the snapshot passes the parse/guard checks and is handed to `setState` (schema validation may still reject the patch there), `false` when it is ignored.
 
 ```ts
 // server (inside the loader / request handler)

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/store",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Shared reactive store for Ilha islands.",
   "keywords": [
     "forms",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/store",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Shared reactive store for Ilha islands.",
   "keywords": [
     "forms",

--- a/packages/store/src/index.test.ts
+++ b/packages/store/src/index.test.ts
@@ -10,7 +10,15 @@ import ilha, { html } from "ilha";
 import { z } from "zod";
 
 import { setIn } from "./bind-path";
-import { store, effectScope, StoreValidationError } from "./index";
+import {
+  store,
+  effectScope,
+  persist,
+  dehydrate,
+  hydrate,
+  shallowEqual,
+  StoreValidationError,
+} from "./index";
 
 beforeEach(() => {
   document.body.innerHTML = "";
@@ -1189,6 +1197,274 @@ describe("bind()", () => {
     expect(() => setIn({}, ["a", "constructor", "x"], 1)).toThrow(/unsafe path segment/);
     expect(() => setIn({}, ["prototype"], 1)).toThrow(/unsafe path segment/);
     expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subscribe equality + shallowEqual
+// ---------------------------------------------------------------------------
+
+describe("subscribe() — equality option", () => {
+  it("shallowEqual compares one level deep", () => {
+    expect(shallowEqual({ a: 1 }, { a: 1 })).toBe(true);
+    expect(shallowEqual({ a: 1 }, { a: 2 })).toBe(false);
+    expect(shallowEqual([1, 2], [1, 2])).toBe(true);
+    expect(shallowEqual([1, 2], [1, 3])).toBe(false);
+    expect(shallowEqual([1], { 0: 1 })).toBe(false);
+    expect(shallowEqual(1, 1)).toBe(true);
+    expect(shallowEqual({ a: { x: 1 } }, { a: { x: 1 } })).toBe(false); // deep differs by ref
+  });
+
+  it("object-building selector with { equal: shallowEqual } skips equivalent slices", () => {
+    const listener = mock();
+    const s = store({ a: 1, b: 2, other: 0 }).build();
+    s.subscribe((st) => ({ a: st.a, b: st.b }), listener, { equal: shallowEqual });
+    s.other(1); // slice unchanged (but a fresh object every commit)
+    expect(listener).not.toHaveBeenCalled();
+    s.a(5);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({ a: 5, b: 2 }, { a: 1, b: 2 });
+  });
+
+  it("default equality is Object.is (object-building selector fires every commit)", () => {
+    const listener = mock();
+    const s = store({ a: 1, other: 0 }).build();
+    s.subscribe((st) => ({ a: st.a }), listener);
+    s.other(1);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// action .pending
+// ---------------------------------------------------------------------------
+
+describe("action .pending", () => {
+  it("is true while an async action is in flight and false after", async () => {
+    let resolve!: () => void;
+    const gate = new Promise<void>((r) => (resolve = r));
+    const s = store({ done: false })
+      .action("run", async () => {
+        await gate;
+        return { done: true };
+      })
+      .build();
+
+    expect(s.run.pending).toBe(false);
+    s.run();
+    expect(s.run.pending).toBe(true);
+    resolve();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(s.run.pending).toBe(false);
+    expect(s.done()).toBe(true);
+  });
+
+  it("stays true until the last overlapping invocation settles", async () => {
+    const resolvers: Array<() => void> = [];
+    const s = store({ n: 0 })
+      .action("run", async () => {
+        await new Promise<void>((r) => resolvers.push(r));
+      })
+      .build();
+    s.run();
+    s.run();
+    resolvers[0]!();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(s.run.pending).toBe(true);
+    resolvers[1]!();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(s.run.pending).toBe(false);
+  });
+
+  it("clears pending when the async action rejects (and reports the error)", async () => {
+    const errors: Error[] = [];
+    const s = store({ n: 0 })
+      .action("boom", async () => {
+        throw new Error("nope");
+      })
+      .onError((ctx) => errors.push(ctx.error))
+      .build();
+    s.boom();
+    expect(s.boom.pending).toBe(true);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(s.boom.pending).toBe(false);
+    expect(errors[0]?.message).toBe("nope");
+  });
+
+  it("sync actions never set pending", () => {
+    const s = store({ n: 0 })
+      .action("inc", (_, ctx) => ({ n: ctx.get().n + 1 }))
+      .build();
+    s.inc();
+    expect(s.inc.pending).toBe(false);
+  });
+
+  it("pending is reactive inside effects", async () => {
+    let resolve!: () => void;
+    const s = store({ n: 0 })
+      .action("run", async () => {
+        await new Promise<void>((r) => (resolve = r));
+      })
+      .build();
+    const seen: boolean[] = [];
+    const stop = effect(() => {
+      seen.push(s.run.pending);
+    });
+    s.run();
+    resolve();
+    await new Promise((r) => setTimeout(r, 0));
+    stop();
+    expect(seen).toEqual([false, true, false]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// persist()
+// ---------------------------------------------------------------------------
+
+describe("persist()", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("hydrates from storage on call", () => {
+    window.localStorage.setItem("p1", JSON.stringify({ count: 42 }));
+    const s = store({ count: 0 }).build();
+    const stop = persist(s, "p1");
+    expect(s.count()).toBe(42);
+    stop();
+  });
+
+  it("writes state on every commit", () => {
+    const s = store({ count: 0 }).build();
+    const stop = persist(s, "p2");
+    s.count(7);
+    expect(JSON.parse(window.localStorage.getItem("p2")!)).toEqual({ count: 7 });
+    stop();
+  });
+
+  it("unsubscribe stops writing", () => {
+    const s = store({ count: 0 }).build();
+    const stop = persist(s, "p3");
+    stop();
+    s.count(9);
+    expect(window.localStorage.getItem("p3")).toBeNull();
+  });
+
+  it("ignores corrupt payloads without crashing", () => {
+    const errSpy = mock();
+    const origError = console.error;
+    console.error = errSpy;
+    try {
+      window.localStorage.setItem("p4", "{not json");
+      const s = store({ count: 3 }).build();
+      const stop = persist(s, "p4");
+      expect(s.count()).toBe(3); // untouched
+      expect(errSpy).toHaveBeenCalled();
+      stop();
+    } finally {
+      console.error = origError;
+    }
+  });
+
+  it("schema stores reject invalid persisted payloads via validation", () => {
+    const Schema = z.object({ email: z.email().default("a@b.co") });
+    window.localStorage.setItem("p5", JSON.stringify({ email: "not-an-email" }));
+    const errors: unknown[] = [];
+    const s = store(Schema)
+      .onError((ctx) => errors.push(ctx.error))
+      .build();
+    const stop = persist(s, "p5");
+    expect(s.email()).toBe("a@b.co"); // rejected patch, state untouched
+    expect(errors).toHaveLength(1);
+    stop();
+  });
+
+  it("applies cross-tab storage events", () => {
+    const s = store({ count: 0 }).build();
+    const stop = persist(s, "p6");
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: "p6", newValue: JSON.stringify({ count: 11 }) }),
+    );
+    expect(s.count()).toBe(11);
+    stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dehydrate() / hydrate()
+// ---------------------------------------------------------------------------
+
+describe("dehydrate() / hydrate()", () => {
+  it("round-trips store state", () => {
+    const server = store({ count: 5, label: "x" }).build();
+    const raw = dehydrate(server);
+    const client = store({ count: 0, label: "" }).build();
+    expect(hydrate(client, raw)).toBe(true);
+    expect(client.getState()).toEqual({ count: 5, label: "x" });
+  });
+
+  it("dehydrate accepts a plain request-local state object", () => {
+    const raw = dehydrate({ count: 9 });
+    const s = store({ count: 0 }).build();
+    expect(hydrate(s, raw)).toBe(true);
+    expect(s.count()).toBe(9);
+  });
+
+  it("hydrate merges through setState — middleware runs", () => {
+    const seen: unknown[] = [];
+    const s = store({ count: 0 })
+      .middleware((patch, _ctx, next) => {
+        seen.push(patch);
+        next(patch);
+      })
+      .build();
+    hydrate(s, JSON.stringify({ count: 3 }));
+    expect(seen).toEqual([{ count: 3 }]);
+  });
+
+  it("schema stores reject invalid snapshots via validation", () => {
+    const Schema = z.object({ email: z.email().default("a@b.co") });
+    const errors: unknown[] = [];
+    const s = store(Schema)
+      .onError((ctx) => errors.push(ctx.error))
+      .build();
+    expect(hydrate(s, JSON.stringify({ email: "not-an-email" }))).toBe(true); // parsed fine…
+    expect(s.email()).toBe("a@b.co"); // …but the commit was rejected
+    expect(errors).toHaveLength(1);
+  });
+
+  it("rejects non-object, oversized, too-deep, and invalid-JSON payloads", () => {
+    const warnSpy = mock();
+    const origWarn = console.warn;
+    console.warn = warnSpy;
+    try {
+      const s = store({ count: 1 }).build();
+      expect(hydrate(s, "null")).toBe(false);
+      expect(hydrate(s, "[1,2]")).toBe(false);
+      expect(hydrate(s, "{oops")).toBe(false);
+      expect(hydrate(s, "x".repeat(256 * 1024 + 1))).toBe(false);
+      let deep = "1";
+      for (let i = 0; i < 40; i++) deep = `{"a":${deep}}`;
+      expect(hydrate(s, deep)).toBe(false);
+      expect(hydrate(s, null)).toBe(false);
+      expect(hydrate(s, "")).toBe(false);
+      expect(s.count()).toBe(1); // untouched throughout
+      expect(warnSpy).toHaveBeenCalledTimes(5); // null/"" are silent no-ops
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+
+  it("strips prototype-polluting keys from the payload", () => {
+    const s = store({ nested: { ok: true } }).build();
+    hydrate(s, '{"nested":{"ok":false,"__proto__":{"polluted":true}},"constructor":{"x":1}}');
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(s.getState().nested.ok).toBe(false);
+    expect(
+      "constructor" in s.getState() &&
+        Object.prototype.hasOwnProperty.call(s.getState(), "constructor"),
+    ).toBe(false);
   });
 });
 

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -43,6 +43,15 @@ export type Listener<T> = (state: T, prevState: T) => void;
 export type SliceListener<_T, S> = (slice: S, prevSlice: S) => void;
 export type Unsub = () => void;
 
+/** Options for the selector form of `subscribe`. */
+export interface SubscribeOptions<S> {
+  /**
+   * Slice equality — the listener fires only when this returns `false`.
+   * Default: `Object.is`. Pass `shallowEqual` for object-building selectors.
+   */
+  equal?: (a: S, b: S) => boolean;
+}
+
 /** The reactive envelope for a derived value. Mirrors ilha core's `DerivedValue`. */
 export interface DerivedValue<T> {
   loading: boolean;
@@ -140,11 +149,19 @@ type Middleware<TState> = (
 export type ActionsMap<A> = {
   [K in keyof A]: A[K] extends (props: infer P, get: any) => any
     ? [P] extends [undefined]
-      ? () => void
+      ? ActionInvoker
       : unknown extends P
-        ? () => void
-        : (props: P) => void
+        ? ActionInvoker
+        : ActionInvoker<P>
     : never;
+};
+
+/**
+ * A callable action on the built store. `.pending` is reactive — `true` while
+ * any async invocation of this action is in flight (sync actions never set it).
+ */
+export type ActionInvoker<P = never> = ([P] extends [never] ? () => void : (props: P) => void) & {
+  readonly pending: boolean;
 };
 
 /** Built-in methods present on every built store. */
@@ -154,7 +171,11 @@ export interface StoreBuiltins<TState extends object> {
   /** Reset to the initial state captured at `.build()` time. Routed through middleware. */
   reset(): void;
   subscribe(listener: Listener<TState>): Unsub;
-  subscribe<S>(selector: (state: TState) => S, listener: SliceListener<TState, S>): Unsub;
+  subscribe<S>(
+    selector: (state: TState) => S,
+    listener: SliceListener<TState, S>,
+    options?: SubscribeOptions<S>,
+  ): Unsub;
   select<S>(selector: (state: TState) => S): () => S;
   /**
    * Two-way field accessor for ilha `bind:*`. Property-path selectors only —
@@ -232,6 +253,20 @@ function isNoopPatch<T extends object>(prev: T, patch: Partial<T>): boolean {
     if (!Object.is((prev as Record<string, unknown>)[key], patch[key])) return false;
   }
   return true;
+}
+
+/**
+ * Shallow equality for selector slices: `Object.is` on primitives, own-key
+ * comparison one level deep for plain objects and arrays. Pass as the `equal`
+ * option to `subscribe(selector, listener, { equal: shallowEqual })` so
+ * object-building selectors (`s => ({ a: s.a, b: s.b })`) don't fire on every
+ * commit.
+ */
+export function shallowEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== "object" || a === null || typeof b !== "object" || b === null) return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  return shallowStateEqual(a as object, b as object);
 }
 
 function shallowStateEqual<T extends object>(a: T, b: T): boolean {
@@ -542,10 +577,15 @@ function buildStore<
   }
 
   function subscribe(listener: Listener<TState>): Unsub;
-  function subscribe<S>(selector: (state: TState) => S, listener: SliceListener<TState, S>): Unsub;
+  function subscribe<S>(
+    selector: (state: TState) => S,
+    listener: SliceListener<TState, S>,
+    options?: SubscribeOptions<S>,
+  ): Unsub;
   function subscribe<S>(
     listenerOrSelector: Listener<TState> | ((state: TState) => S),
     maybeListener?: SliceListener<TState, S>,
+    options?: SubscribeOptions<S>,
   ): Unsub {
     if (maybeListener === undefined) {
       const listener = listenerOrSelector as Listener<TState>;
@@ -565,6 +605,7 @@ function buildStore<
     }
 
     const selector = listenerOrSelector as (state: TState) => S;
+    const equal = options?.equal ?? Object.is;
     const sliceComputed = computed(() => selector(stateSignal()));
     let prevSlice = sliceComputed();
     let first = true;
@@ -575,7 +616,7 @@ function buildStore<
           first = false;
           return;
         }
-        if (!Object.is(currentSlice, prevSlice)) {
+        if (!equal(currentSlice, prevSlice)) {
           maybeListener(currentSlice, prevSlice);
           prevSlice = currentSlice;
         }
@@ -732,19 +773,35 @@ function buildStore<
   };
   const actionHandlers = new Map<string, (props?: unknown) => void>();
   for (const { key, fn } of cfg.actions) {
-    actionHandlers.set(key, (props?: unknown) => {
+    // Per-action pending counter (a count, not a boolean, so overlapping
+    // invocations don't clear the flag early). Exposed as `.pending` on the
+    // action — reactive, since the getter reads a signal.
+    const pendingSig = signal(0);
+    const handler = (props?: unknown) => {
       const ret = fn(props as never, actionCtx);
       const apply = (patch: Partial<TState> | void | undefined | null) => {
         if (patch != null) setState(patch);
       };
       if (ret != null && typeof (ret as Promise<unknown>).then === "function") {
-        void (ret as Promise<Partial<TState> | void>).then(apply).catch((reason: unknown) => {
-          reportStoreError(reason instanceof Error ? reason : new Error(String(reason)), "action");
-        });
+        untrackRun(() => pendingSig(pendingSig() + 1));
+        void (ret as Promise<Partial<TState> | void>)
+          .then(apply)
+          .catch((reason: unknown) => {
+            reportStoreError(
+              reason instanceof Error ? reason : new Error(String(reason)),
+              "action",
+            );
+          })
+          .finally(() => untrackRun(() => pendingSig(Math.max(0, pendingSig() - 1))));
       } else {
         apply(ret as Partial<TState> | void);
       }
+    };
+    Object.defineProperty(handler, "pending", {
+      get: () => pendingSig() > 0,
+      enumerable: false,
     });
+    actionHandlers.set(key, handler);
   }
 
   // --- proxy ----------------------------------------------------------------
@@ -819,3 +876,205 @@ export function store(initialOrSchema: object): StoreBuilder<object> {
 }
 
 export { effectScope } from "alien-signals";
+
+// ---------------------------------------------------------------------------
+// persist() — storage sync helper
+// ---------------------------------------------------------------------------
+
+/** Minimal storage surface — `localStorage`, `sessionStorage`, or a custom adapter. */
+export type PersistStorage = Pick<Storage, "getItem" | "setItem">;
+
+export interface PersistOptions<TState extends object> {
+  /** Storage backend. Default: `window.localStorage`. */
+  storage?: PersistStorage;
+  /**
+   * Mirror writes from other tabs via the window `storage` event. Only active
+   * for the default `localStorage` backend. Default: `true`.
+   */
+  crossTab?: boolean;
+  /** State → string. Default: `JSON.stringify`. */
+  serialize?: (state: TState) => string;
+  /** String → patch merged via `setState` (schema stores validate it). Default: `JSON.parse`. */
+  deserialize?: (raw: string) => Partial<TState>;
+}
+
+/**
+ * Keep a store in sync with persistent storage:
+ *
+ * 1. On call, reads `key` and merges the stored patch into the store
+ *    (through `setState`, so middleware runs and schema stores validate —
+ *    corrupt or stale-shaped payloads are rejected, not applied).
+ * 2. Subscribes to changes and writes the full state back on every commit.
+ * 3. Optionally mirrors writes from other tabs (`storage` events).
+ *
+ * No-op on the server (returns an inert unsubscribe). Call the returned
+ * unsubscribe to stop syncing (also do this before `store.dispose()`).
+ *
+ * ```ts
+ * const cartStore = store({ items: [] as string[] }).build();
+ * persist(cartStore, "cart");
+ * ```
+ */
+export function persist<TState extends object>(
+  store: Pick<StoreBuiltins<TState>, "getState" | "setState" | "subscribe">,
+  key: string,
+  options: PersistOptions<TState> = {},
+): Unsub {
+  if (typeof window === "undefined") return () => {};
+  const storage = options.storage ?? window.localStorage;
+  const serialize = options.serialize ?? (JSON.stringify as (state: TState) => string);
+  const deserialize = options.deserialize ?? ((raw: string) => JSON.parse(raw) as Partial<TState>);
+
+  const applyRaw = (raw: string | null) => {
+    if (raw == null) return;
+    try {
+      const patch = deserialize(raw);
+      if (patch !== null && typeof patch === "object" && !Array.isArray(patch)) {
+        store.setState(patch);
+      }
+    } catch (err) {
+      console.error(`[@ilha/store] persist("${key}"): failed to restore state`, err);
+    }
+  };
+
+  // 1. Hydrate from storage.
+  try {
+    applyRaw(storage.getItem(key));
+  } catch (err) {
+    console.error(`[@ilha/store] persist("${key}"): failed to read storage`, err);
+  }
+
+  // 2. Write-through on every commit.
+  const unsubStore = store.subscribe((state) => {
+    try {
+      storage.setItem(key, serialize(state));
+    } catch (err) {
+      console.error(`[@ilha/store] persist("${key}"): failed to write storage`, err);
+    }
+  });
+
+  // 3. Cross-tab sync (localStorage only — sessionStorage/custom backends
+  // don't emit cross-tab storage events).
+  let onStorage: ((e: StorageEvent) => void) | null = null;
+  if (options.crossTab !== false && storage === window.localStorage) {
+    onStorage = (e) => {
+      if (e.key !== key) return;
+      applyRaw(e.newValue);
+    };
+    window.addEventListener("storage", onStorage);
+  }
+
+  return () => {
+    unsubStore();
+    if (onStorage) window.removeEventListener("storage", onStorage);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// dehydrate() / hydrate() — SSR snapshot transfer
+//
+// Mirrors ilha core's island snapshot model (data-ilha-state + guarded parse):
+// state travels as serialized JSON stamped into the HTML, and the client seeds
+// the store from it on mount. Stores are NOT written during SSR — server data
+// flows loader → props; `dehydrate` serializes a request-local state object
+// (or the store itself in non-concurrent contexts like prerendering).
+// The parse guards below intentionally match ilha's `safeParseSnapshot`.
+// ---------------------------------------------------------------------------
+
+// Upper bound on a snapshot payload (chars). Matches ilha core's cap.
+const MAX_SNAPSHOT_CHARS = 256 * 1024;
+// Upper bound on nesting depth of a parsed snapshot. Matches ilha core's cap.
+const MAX_SNAPSHOT_DEPTH = 32;
+
+const UNSAFE_SNAPSHOT_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function exceedsMaxDepth(value: unknown, depth: number): boolean {
+  if (depth > MAX_SNAPSHOT_DEPTH) return true;
+  if (value === null || typeof value !== "object") return false;
+  if (Array.isArray(value)) {
+    for (const item of value) if (exceedsMaxDepth(item, depth + 1)) return true;
+    return false;
+  }
+  for (const key in value as Record<string, unknown>) {
+    if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+    if (exceedsMaxDepth((value as Record<string, unknown>)[key], depth + 1)) return true;
+  }
+  return false;
+}
+
+// JSON.parse creates __proto__ etc. as plain own properties — strip them at
+// the parse boundary before the payload flows into setState/deep merges.
+function stripUnsafeKeys(value: unknown): void {
+  if (value === null || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    for (const item of value) stripUnsafeKeys(item);
+    return;
+  }
+  for (const key of Object.getOwnPropertyNames(value)) {
+    if (UNSAFE_SNAPSHOT_KEYS.has(key)) {
+      delete (value as Record<string, unknown>)[key];
+    } else {
+      stripUnsafeKeys((value as Record<string, unknown>)[key]);
+    }
+  }
+}
+
+/**
+ * Serialize state for transfer into HTML (a JSON `<script>` block or data
+ * attribute — remember to escape for the embedding context). Accepts either a
+ * built store or a plain state object.
+ *
+ * On a **concurrent SSR server, pass a request-local object** (e.g. loader
+ * data), not the shared module-level store — stores must not be written
+ * during SSR. Passing the store itself is fine in non-concurrent contexts
+ * (prerendering, tests).
+ */
+export function dehydrate<TState extends object>(
+  storeOrState: Pick<StoreBuiltins<TState>, "getState"> | TState,
+): string {
+  const state =
+    typeof (storeOrState as Partial<StoreBuiltins<TState>>).getState === "function"
+      ? (storeOrState as StoreBuiltins<TState>).getState()
+      : (storeOrState as TState);
+  return JSON.stringify(state);
+}
+
+/**
+ * Seed a store from a dehydrated snapshot — call from the page island's
+ * `onMount` (which runs on hydration) with the payload stamped into the HTML.
+ *
+ * Parsing is guarded like ilha core's island snapshots: size cap, depth cap,
+ * must-be-plain-object, prototype-polluting keys stripped. The patch merges
+ * via `setState`, so middleware runs and schema stores validate — corrupt or
+ * stale-shaped payloads are rejected, not applied. Returns `true` when the
+ * snapshot was applied, `false` when it was ignored (with a console warning).
+ */
+export function hydrate<TState extends object>(
+  store: Pick<StoreBuiltins<TState>, "setState">,
+  raw: string | null | undefined,
+): boolean {
+  if (raw == null || raw === "") return false;
+  const warn = (msg: string) => console.warn(`[@ilha/store] hydrate: ${msg}`);
+  if (raw.length > MAX_SNAPSHOT_CHARS) {
+    warn(`snapshot exceeds ${MAX_SNAPSHOT_CHARS} chars — ignored.`);
+    return false;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    warn("invalid JSON — snapshot ignored.");
+    return false;
+  }
+  if (exceedsMaxDepth(parsed, 1)) {
+    warn(`snapshot nesting exceeds depth ${MAX_SNAPSHOT_DEPTH} — ignored.`);
+    return false;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    warn("snapshot is not an object — ignored.");
+    return false;
+  }
+  stripUnsafeKeys(parsed);
+  store.setState(parsed as Partial<TState>);
+  return true;
+}

--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1047,7 +1047,10 @@ export function dehydrate<TState extends object>(
  * must-be-plain-object, prototype-polluting keys stripped. The patch merges
  * via `setState`, so middleware runs and schema stores validate — corrupt or
  * stale-shaped payloads are rejected, not applied. Returns `true` when the
- * snapshot was applied, `false` when it was ignored (with a console warning).
+ * snapshot passed the parse/guard checks and was handed to `setState`,
+ * `false` when it was ignored (with a console warning). A `true` return does
+ * not guarantee the state changed — a schema store's validation may still
+ * reject the patch inside `setState`.
  */
 export function hydrate<TState extends object>(
   store: Pick<StoreBuiltins<TState>, "setState">,

--- a/templates/elysia/package.json
+++ b/templates/elysia/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@elysiajs/static": "^1.4.10",
-    "@ilha/router": "^0.7.1",
-    "@ilha/store": "^0.6.1",
+    "@ilha/router": "^0.8.0",
+    "@ilha/store": "^0.7.0",
     "areia": "^0.1.35",
     "elysia": "^1.4.29",
     "ilha": "^0.9.0",

--- a/templates/elysia/package.json
+++ b/templates/elysia/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@elysiajs/static": "^1.4.10",
-    "@ilha/router": "^0.7.0",
-    "@ilha/store": "^0.6.0",
+    "@ilha/router": "^0.7.1",
+    "@ilha/store": "^0.6.1",
     "areia": "^0.1.35",
     "elysia": "^1.4.29",
     "ilha": "^0.9.0",

--- a/templates/hono/package.json
+++ b/templates/hono/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.8",
-    "@ilha/router": "^0.7.1",
-    "@ilha/store": "^0.6.1",
+    "@ilha/router": "^0.8.0",
+    "@ilha/store": "^0.7.0",
     "areia": "^0.1.35",
     "hono": "^4.12.28",
     "ilha": "^0.9.0",

--- a/templates/hono/package.json
+++ b/templates/hono/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "@hono/node-server": "^2.0.8",
-    "@ilha/router": "^0.7.0",
-    "@ilha/store": "^0.6.0",
+    "@ilha/router": "^0.7.1",
+    "@ilha/store": "^0.6.1",
     "areia": "^0.1.35",
     "hono": "^4.12.28",
     "ilha": "^0.9.0",

--- a/templates/nitro/package.json
+++ b/templates/nitro/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.7.0",
-    "@ilha/store": "^0.6.0",
+    "@ilha/router": "^0.7.1",
+    "@ilha/store": "^0.6.1",
     "areia": "^0.1.35",
     "ilha": "^0.9.0",
     "nitro": "^3.0.260610-beta",

--- a/templates/nitro/package.json
+++ b/templates/nitro/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.7.1",
-    "@ilha/store": "^0.6.1",
+    "@ilha/router": "^0.8.0",
+    "@ilha/store": "^0.7.0",
     "areia": "^0.1.35",
     "ilha": "^0.9.0",
     "nitro": "^3.0.260610-beta",

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.7.1",
-    "@ilha/store": "^0.6.1",
+    "@ilha/router": "^0.8.0",
+    "@ilha/store": "^0.7.0",
     "areia": "^0.1.35",
     "ilha": "^0.9.0",
     "quando": "^0.1.6"

--- a/templates/vite/package.json
+++ b/templates/vite/package.json
@@ -9,8 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.7.0",
-    "@ilha/store": "^0.6.0",
+    "@ilha/router": "^0.7.1",
+    "@ilha/store": "^0.6.1",
     "areia": "^0.1.35",
     "ilha": "^0.9.0",
     "quando": "^0.1.6"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-executed route loaders (`clientLoad` / `clientLoader`), route navigation state (`navigating()`), route revalidation (`invalidate()`), and optional view transitions.
  * Improved route loader error handling via `+error` error boundaries.
  * Store actions now expose reactive async `.pending`, plus `persist()` and `dehydrate()`/`hydrate()` for persistence and SSR hydration.

* **Documentation**
  * Expanded router and store guides with detailed loader/error/persistence behavior, and added JSX runtime documentation.

* **Chores**
  * Updated website templates and package versions to the latest router/store patch releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->