### PR TITLE
Fix/ilha astro scope filtering

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -17,7 +17,7 @@
     "@fontsource-variable/geist": "^5.3.0",
     "@fontsource-variable/geist-mono": "^5.3.0",
     "@iconify-json/ph": "^1.2.2",
-    "@ilha/astro": "^0.1.5",
+    "@ilha/astro": "^0.1.6",
     "areia": "^0.2.3",
     "astro": "^7.2.1",
     "astro-icon": "^1.1.5",

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -24,6 +24,16 @@ export default defineConfig({
 });
 ```
 
+When you use multiple JSX frameworks, restrict each integration to its own files:
+
+```ts
+export default defineConfig({
+  integrations: [ilha({ include: ["**/ilha/**"] })],
+});
+```
+
+You can also pass `exclude` globs. Files outside the filter remain available to other Astro JSX renderers.
+
 Then use any Ilha island as an Astro component, with a [client directive](https://docs.astro.build/en/reference/directives-reference/#client-directives) to control hydration:
 
 ```astro

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/astro",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Astro integration for Ilha islands",
   "keywords": [
     "astro-component",

--- a/packages/astro/src/index.test.ts
+++ b/packages/astro/src/index.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
+
+mock.module("virtual:@ilha/astro/options", () => ({
+  default: (id: string) => id.includes("/ilha/"),
+}));
 
 import ilha, { __ilhaJsxSlot, html } from "ilha";
 
 import hydrate from "./client";
-import ilhaIntegration, { getRenderer } from "./index";
+import ilhaIntegration, { getRenderer, getViteConfig } from "./index";
 import renderer from "./server";
 
 const Counter = ilha
@@ -38,6 +42,20 @@ describe("@ilha/astro integration", () => {
     });
   });
 
+  it("passes include/exclude patterns to the renderer filter", () => {
+    const plugin = getViteConfig({ include: ["**/ilha/**"], exclude: ["**/*.test.tsx"] })
+      .plugins[0];
+    const id = plugin.resolveId("virtual:@ilha/astro/options");
+    expect(id).toBe("\0virtual:@ilha/astro/options");
+    const module = plugin.load(id!);
+    const filter = new Function(module!.replace("export default", "return"))() as (
+      id: string,
+    ) => boolean;
+    expect(filter("/src/ilha/counter.tsx")).toBe(true);
+    expect(filter("/src/ilha/counter.test.tsx")).toBe(false);
+    expect(filter("/src/solid/counter.tsx")).toBe(false);
+  });
+
   it("points the renderer at the client/server entrypoints", () => {
     const r = getRenderer();
     expect(r.clientEntrypoint).toBe("@ilha/astro/client.js");
@@ -51,6 +69,15 @@ describe("@ilha/astro server renderer", () => {
     expect(await renderer.check(() => {}, {}, {})).toBe(false);
     expect(await renderer.check({}, {}, {})).toBe(false);
     expect(await renderer.check(null, {}, {})).toBe(false);
+  });
+
+  it("check() ignores components outside the configured paths", async () => {
+    expect(
+      await renderer.check(Counter, {}, {}, { componentUrl: "/src/solid/counter.tsx" } as never),
+    ).toBe(false);
+    expect(
+      await renderer.check(Counter, {}, {}, { componentUrl: "/src/ilha/counter.tsx" } as never),
+    ).toBe(true);
   });
 
   it("renderToStaticMarkup() returns the SSR-wrapped island markup", async () => {

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -1,5 +1,47 @@
 import type { AstroIntegration, AstroRenderer } from "astro";
 
+export interface IlhaIntegrationOptions {
+  include?: string | string[];
+  exclude?: string | string[];
+}
+
+const OPTIONS_MODULE = "virtual:@ilha/astro/options";
+
+function globToRegExp(pattern: string) {
+  let source = "^";
+  for (let i = 0; i < pattern.length; i++) {
+    const char = pattern[i];
+    if (char === "*") {
+      if (pattern[i + 1] === "*") {
+        i++;
+        if (pattern[i + 1] === "/") {
+          i++;
+          source += "(?:.*/)?";
+        } else source += ".*";
+      } else source += "[^/]*";
+    } else if (char === "?") source += "[^/]";
+    else source += char.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+  }
+  return new RegExp(`${source}$`);
+}
+
+function patternList(patterns?: string | string[]) {
+  return (typeof patterns === "string" ? [patterns] : (patterns ?? [])).map(globToRegExp).join(",");
+}
+
+function optionsPlugin(options: IlhaIntegrationOptions) {
+  return {
+    name: "@ilha/astro:options",
+    resolveId(id: string) {
+      return id === OPTIONS_MODULE ? `\0${OPTIONS_MODULE}` : undefined;
+    },
+    load(id: string) {
+      if (id !== `\0${OPTIONS_MODULE}`) return;
+      return `const include=[${patternList(options.include)}],exclude=[${patternList(options.exclude)}];export default id=>(!include.length||include.some(pattern=>pattern.test(id)))&&!exclude.some(pattern=>pattern.test(id));`;
+    },
+  };
+}
+
 export function getRenderer(): AstroRenderer {
   return {
     name: "@ilha/astro",
@@ -15,8 +57,9 @@ export function getRenderer(): AstroRenderer {
  *
  * `resolve.dedupe` + `optimizeDeps.exclude` keep a single module instance.
  */
-export function getViteConfig() {
+export function getViteConfig(options: IlhaIntegrationOptions = {}) {
   return {
+    plugins: [optionsPlugin(options)],
     resolve: {
       dedupe: ["ilha"],
     },
@@ -26,13 +69,13 @@ export function getViteConfig() {
   };
 }
 
-export default function ilhaIntegration(): AstroIntegration {
+export default function ilhaIntegration(options: IlhaIntegrationOptions = {}): AstroIntegration {
   return {
     name: "@ilha/astro",
     hooks: {
       "astro:config:setup": ({ addRenderer, updateConfig }) => {
         addRenderer(getRenderer());
-        updateConfig({ vite: getViteConfig() });
+        updateConfig({ vite: getViteConfig(options) });
       },
     },
   };

--- a/packages/astro/src/server.ts
+++ b/packages/astro/src/server.ts
@@ -6,6 +6,14 @@ import ilha, { raw } from "ilha";
 const ISLAND = Symbol.for("ilha.island");
 const RAW = Symbol.for("ilha.raw");
 
+let componentFilter: Promise<(id: string) => boolean> | undefined;
+
+function getComponentFilter() {
+  return (componentFilter ??= import("virtual:@ilha/astro/options")
+    .then(({ default: filter }) => filter)
+    .catch(() => () => true));
+}
+
 interface HydratableIsland {
   name?: string;
   hydratable(
@@ -159,7 +167,9 @@ async function check(
   Component: unknown,
   props: Record<string, unknown>,
   slots: Record<string, string>,
+  metadata?: AstroComponentMetadata,
 ): Promise<boolean> {
+  if (metadata?.componentUrl && !(await getComponentFilter())(metadata.componentUrl)) return false;
   if (isIsland(Component)) return true;
   if (typeof Component !== "function") return false;
   try {

--- a/packages/astro/src/virtual.d.ts
+++ b/packages/astro/src/virtual.d.ts
@@ -1,0 +1,4 @@
+declare module "virtual:@ilha/astro/options" {
+  const filter: (id: string) => boolean;
+  export default filter;
+}

--- a/packages/astro/tsconfig.build.json
+++ b/packages/astro/tsconfig.build.json
@@ -8,5 +8,5 @@
     "rootDir": "src",
     "types": ["@types/bun"]
   },
-  "include": ["src/index.ts", "src/server.ts", "src/client.ts"]
+  "include": ["src/index.ts", "src/server.ts", "src/client.ts", "src/virtual.d.ts"]
 }

--- a/packages/astro/tsdown.config.ts
+++ b/packages/astro/tsdown.config.ts
@@ -5,5 +5,5 @@ export default defineConfig({
   platform: "neutral",
   dts: false,
   minify: false,
-  external: ["ilha", "astro"],
+  external: ["ilha", "astro", "virtual:@ilha/astro/options"],
 });


### PR DESCRIPTION
Addresses #82 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `include` and `exclude` glob options to control which JSX components the Astro integration processes.
  * Components outside the configured paths are automatically excluded.

* **Documentation**
  * Updated usage guidance with examples for filtering components when multiple JSX frameworks are used.

* **Bug Fixes**
  * Improved component filtering behavior and handling when optional configuration is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->