### PR TITLE
fix(router): fix prop passing to server islands

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -60,7 +60,7 @@
     },
     "packages/router": {
       "name": "@ilha/router",
-      "version": "0.10.1",
+      "version": "0.10.3",
       "dependencies": {
         "unplugin": "3.3.0",
       },

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/router",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "A tiny SPA router for Ilha",
   "keywords": [
     "frontend",

--- a/packages/router/src/plugin.ts
+++ b/packages/router/src/plugin.ts
@@ -24,6 +24,7 @@ import {
   FrameError,
   getFrameGuard,
   isSafeFramePath,
+  parseFrameProps,
   renderServerIsland,
   setFrameAuth,
   setFrameGuard,
@@ -617,7 +618,9 @@ const pagesFactory: UnpluginFactory<IlhaPagesOptions | undefined> = (options = {
             const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
               id?: string;
               path?: string;
+              props?: unknown;
             };
+            const incomingProps = parseFrameProps(body.props);
             const target = serverIslands.get(body.id ?? "");
             if (!target) throw new Error("unknown island");
             // Route context for server pages: render at the client's current
@@ -662,6 +665,7 @@ const pagesFactory: UnpluginFactory<IlhaPagesOptions | undefined> = (options = {
               request,
               (r, fn) => runWithIslandRequest(r, fn),
               (entries) => (head = entries),
+              incomingProps,
             );
             const env = frameEnvelope(200, { html: String(html), head });
             res.statusCode = env.status;

--- a/packages/router/src/server-island.ts
+++ b/packages/router/src/server-island.ts
@@ -41,8 +41,8 @@ export interface ServerIslandWiring {
   /** Action key → client transport. Event payloads are not serializable;
    * handlers receive `undefined` and should read island state instead. */
   actions?: Record<string, (payload?: unknown) => unknown>;
-  /** Frame transport: re-renders the island from server-owned state. */
-  frame?: () => unknown;
+  /** Frame transport: re-renders the island with the latest parent props. */
+  frame?: (props?: Record<string, unknown>) => unknown;
   /** RPC transport for the module's `loader.client` export — invoked once
    * when the view hydrates. Side-effect loader on server pages. */
   clientLoader?: () => unknown;
@@ -83,6 +83,7 @@ function hydrateServerIsland(
   host: Element,
   id: string,
   wiring: ServerIslandWiring,
+  props?: Record<string, unknown>,
 ): ServerIslandHandle {
   const controller = new AbortController();
   const cleanups: Array<() => void> = [];
@@ -104,13 +105,15 @@ function hydrateServerIsland(
   // Serialized repaint queue — frames must apply in push order even when
   // several arrive back-to-back.
   const frame = wiring.frame;
+  let currentProps = props;
   let repaintChain: Promise<void> = Promise.resolve();
   const scheduleRepaint = (): void => {
     if (!frame || controller.signal.aborted) return;
+    const sent = currentProps;
     repaintChain = repaintChain
       .then(async () => {
         if (controller.signal.aborted || !host.isConnected) return;
-        const html = await frame();
+        const html = await frame(sent);
         if (controller.signal.aborted || typeof html !== "string") return;
         morph(host, html);
         syncChildren();
@@ -292,9 +295,10 @@ function hydrateServerIsland(
       for (const cleanup of cleanups) cleanup();
       cleanups.length = 0;
     },
-    // Props updates cannot repaint server-rendered markup client-side — the
-    // render function never ships. Content changes arrive via frames instead.
-    updateProps: () => {},
+    updateProps: (next) => {
+      currentProps = next;
+      scheduleRepaint();
+    },
   };
 }
 
@@ -315,7 +319,7 @@ interface IslandCallShape {
 
 export type ServerIslandCallable = Record<symbol, unknown> &
   ((props?: Record<string, unknown>) => string) & {
-    mount: (host: Element) => () => void;
+    mount: (host: Element, props?: Record<string, unknown>) => () => void;
     toString: () => string;
     key: (slotKey: string) => (props?: Record<string, unknown>) => IslandCallShape;
   };
@@ -366,11 +370,14 @@ export function __ilhaServerIsland(
   // for ilha's mount machinery to discover.
   (island as unknown as Record<symbol, unknown>)[ISLAND_MOUNT_INTERNAL] = (
     host: Element,
-  ): ServerIslandHandle => hydrateServerIsland(host, id, wiring);
+    mountProps?: Record<string, unknown>,
+  ): ServerIslandHandle => hydrateServerIsland(host, id, wiring, mountProps);
 
   // SAFETY: `.mount` mirrors the core island method surface on the proxy.
-  (island as unknown as Record<string, unknown>).mount = (host: Element): (() => void) =>
-    hydrateServerIsland(host, id, wiring).unmount;
+  (island as unknown as Record<string, unknown>).mount = (
+    host: Element,
+    mountProps?: Record<string, unknown>,
+  ): (() => void) => hydrateServerIsland(host, id, wiring, mountProps).unmount;
 
   return island;
 }

--- a/packages/router/src/server-islands.test.ts
+++ b/packages/router/src/server-islands.test.ts
@@ -132,7 +132,7 @@ describe("generateServerIslandModule", () => {
     const id = serverIslandPublicId("/abs/tasks.server.ts", "T");
     expect(code).toContain(`export const T = __ilhaServerIsland("${id}", "div"`);
     expect(code).toContain(
-      `JSON.stringify({ id: "${id}", path: location.pathname + location.search })`,
+      `JSON.stringify({ id: "${id}", path: location.pathname + location.search, props })`,
     );
     expect(code).not.toContain("#T");
     expect(code).not.toContain("state })");
@@ -324,6 +324,48 @@ describe("__ilhaServerIsland nested client islands", () => {
     expect(actions).toEqual(["task-1"]);
     expect(slot.getAttribute("data-mounted")).toBe("false");
     expect(updates).toContain(false);
+    unmount();
+  });
+});
+
+describe("__ilhaServerIsland parent props", () => {
+  it("re-fetches a frame when the parent updates props", async () => {
+    const seen: unknown[] = [];
+    const Island = __ilhaServerIsland("opaque", "div", {
+      frame: (props) => {
+        seen.push(props);
+        return `<p>Hello, ${String(props?.name ?? "")}!</p>`;
+      },
+    });
+    const host = document.createElement("div");
+    host.innerHTML = `<p>Hello, !</p>`;
+    document.body.appendChild(host);
+    const handle = (Island as unknown as Record<symbol, Function>)[
+      Symbol.for("ilha.islandMountInternal")
+    ](host, { name: "" });
+    handle.updateProps({ name: "Ada" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(seen).toEqual([{ name: "Ada" }]);
+    expect(host.textContent).toBe("Hello, Ada!");
+    handle.unmount();
+  });
+
+  it("mount(host, props) bootstraps the first frame with those props", async () => {
+    const seen: unknown[] = [];
+    const Island = __ilhaServerIsland("opaque", "div", {
+      frame: (props) => {
+        seen.push(props);
+        return `<p>Hello, ${String(props?.name ?? "")}!</p>`;
+      },
+    });
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const unmount = Island.mount(host, { name: "Ada" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(seen).toEqual([{ name: "Ada" }]);
+    expect(host.textContent).toBe("Hello, Ada!");
     unmount();
   });
 });

--- a/packages/router/src/server-islands.ts
+++ b/packages/router/src/server-islands.ts
@@ -327,7 +327,7 @@ export function generateServerIslandModule(spec: string, scan: ServerModuleScan)
     }
     const id = serverIslandPublicId(spec, island.name);
     wiring.push(
-      `frame: () => fetch("/__ilha/frame", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ id: ${JSON.stringify(id)}, path: location.pathname + location.search }) }).then((r) => { if (!r.ok) throw new Error("frame failed"); return r.json(); }).then((j) => { if (j.redirect) { location.assign(j.redirect); throw new Error("frame redirected"); } __ilhaApplyHead(j.head); return j.html; })`,
+      `frame: (props) => fetch("/__ilha/frame", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ id: ${JSON.stringify(id)}, path: location.pathname + location.search, props }) }).then((r) => { if (!r.ok) throw new Error("frame failed"); return r.json(); }).then((j) => { if (j.redirect) { location.assign(j.redirect); throw new Error("frame redirected"); } __ilhaApplyHead(j.head); return j.html; })`,
     );
     // `loader.client` on server pages executes over RPC when the view
     // hydrates — the module's code never ships to the browser.

--- a/packages/router/src/ssr.test.ts
+++ b/packages/router/src/ssr.test.ts
@@ -18,6 +18,7 @@ import {
   getServerIslandEntry,
   isTrustedOrigin,
   registerServerIsland,
+  parseFrameProps,
   renderServerIsland,
   setFrameAuth,
   setFrameGuard,
@@ -234,6 +235,41 @@ describe("@ilha/router/ssr", () => {
     setFrameGuard(() => blocked);
     const res2 = await handleFrame(new Request("http://localhost/__ilha/loader?path=/data"));
     expect(res2?.status).toBe(403);
+  });
+
+  test("nested island frames render with parent props", async () => {
+    registerServerIsland(
+      "greet",
+      () => (props?: { name?: string }) => `Hello, ${props?.name ?? ""}!`,
+    );
+    const html = await renderServerIsland(
+      "greet",
+      new Request("http://localhost/"),
+      (_r, fn) => fn(),
+      undefined,
+      { name: "Ada" },
+    );
+    expect(html).toBe("Hello, Ada!");
+  });
+
+  test("frame POST applies parent props", async () => {
+    openFrames();
+    registerServerIsland(
+      "greet-http",
+      () => (props?: { name?: string }) => `Hello, ${props?.name ?? ""}!`,
+    );
+    const res = await handleFrame(
+      post(JSON.stringify({ id: "greet-http", props: { name: "Ada" } })),
+    );
+    expect(res?.status).toBe(200);
+    expect((await res!.json()).html).toBe("Hello, Ada!");
+  });
+
+  test("parseFrameProps rejects non-objects", () => {
+    expect(parseFrameProps(undefined)).toBeUndefined();
+    expect(parseFrameProps(null)).toBeUndefined();
+    expect(() => parseFrameProps([])).toThrow();
+    expect(() => parseFrameProps("x")).toThrow();
   });
 
   test("registry lookup round-trips", () => {

--- a/packages/router/src/ssr.ts
+++ b/packages/router/src/ssr.ts
@@ -350,10 +350,11 @@ export async function renderServerIsland(
   request: Request,
   runWithScope: <T>(request: Request, fn: () => T) => T | Promise<T>,
   onHead?: (entries: HeadInput[]) => void,
+  incomingProps?: Record<string, unknown>,
 ): Promise<string> {
   const entry = registry().get(id);
   if (!entry) throw new FrameError(400, "unknown island");
-  let props: unknown;
+  let props: unknown = incomingProps;
   if (entry.load) {
     let url: URL;
     try {
@@ -410,6 +411,13 @@ export const LOADER_ENDPOINT = "/__ilha/loader";
 
 /** Max request body size — matches the dev middleware cap. */
 export const MAX_BODY = 16 * 1024;
+
+/** Parent-island props on a frame POST. Missing is fine; anything else is 400. */
+export function parseFrameProps(value: unknown): Record<string, unknown> | undefined {
+  if (value == null) return undefined;
+  if (typeof value !== "object" || Array.isArray(value)) throw new FrameError(400, "frame failed");
+  return value as Record<string, unknown>;
+}
 
 export function json(status: number, body: Record<string, unknown>): Response {
   const env = frameEnvelope(status, body);
@@ -570,11 +578,13 @@ async function ssr(request: Request): Promise<Response | undefined> {
 
   let id: string;
   let path = "/";
+  let incomingProps: Record<string, unknown> | undefined;
   try {
     const text = await readBodyBounded(request, MAX_BODY);
     if (text === null) return json(413, { error: "frame failed" });
-    const body = JSON.parse(text) as { id?: unknown; path?: unknown };
+    const body = JSON.parse(text) as { id?: unknown; path?: unknown; props?: unknown };
     id = String(body.id ?? "");
+    incomingProps = parseFrameProps(body.props);
     // Route context for server pages: the frame renders as if requested at
     // the client's current URL. Only path+search are honored — never a full
     // foreign origin. Backslash is rejected too: WHATWG URLs treat `\` as
@@ -633,6 +643,7 @@ async function ssr(request: Request): Promise<Response | undefined> {
       scoped,
       (scopedRequest, fn) => Promise.resolve(runWithIslandRequest(scopedRequest, fn)),
       (entries) => (head = entries),
+      incomingProps,
     );
     return json(200, { html, head });
   } catch (error) {

--- a/templates/oxide-spa/package.json
+++ b/templates/oxide-spa/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/server.js"
   },
   "dependencies": {
-    "@ilha/router": "^0.10.2",
+    "@ilha/router": "^0.10.3",
     "areia": "^0.3.1",
     "ilha": "^0.12.1",
     "tacho": "^0.5.0"

--- a/templates/vite-spa/package.json
+++ b/templates/vite-spa/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.10.2",
+    "@ilha/router": "^0.10.3",
     "areia": "^0.3.1",
     "ilha": "^0.12.1"
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Server-rendered islands now receive updated parent properties during mounting and subsequent updates.
  - Updating island properties automatically refreshes the rendered content.
  - Initial island properties are supported during bootstrap rendering.

- **Bug Fixes**
  - Added validation for frame properties, returning a clear error for invalid values.
  - Improved nested island rendering and property propagation across frame requests.

- **Chores**
  - Updated the router package and SPA templates to version 0.10.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->