### PR TITLE
chore(ilha): upgrade server islands protocol

### DIFF
--- a/apps/website/docs/guide/recipes/testing.mdx
+++ b/apps/website/docs/guide/recipes/testing.mdx
@@ -52,7 +52,7 @@ test("renders the count", async () => {
 });
 ```
 
-`renderToString` needs a DOM. In Node, ilha registers happy-dom automatically when `document` is missing — the preload above covers browser-only APIs your component touches at import time.
+`renderToString` builds HTML without a DOM. Preload happy-dom only when a test mounts into real nodes or touches browser-only APIs at import time.
 
 ## Mount and simulate events
 

--- a/apps/website/docs/guide/recipes/testing.mdx
+++ b/apps/website/docs/guide/recipes/testing.mdx
@@ -3,32 +3,11 @@ title: Test components
 description: Render components in tests with renderToString, mount them with happy-dom, and assert updates.
 ---
 
-Test components with Bun's runner plus happy-dom. No browser, no emulator.
-
-## Setup
-
-Install happy-dom's global registrator and preload it:
-
-```package-install
-bun add -d @happy-dom/global-registrator
-```
-
-```toml
-# bunfig.toml
-[test]
-preload = "./happydom.ts"
-```
-
-```ts twoslash
-// happydom.ts
-import { GlobalRegistrator } from "@happy-dom/global-registrator";
-
-GlobalRegistrator.register();
-```
+Test components with Bun's runner. Use `renderToString` for HTML assertions. Add happy-dom only when you mount into real nodes.
 
 ## Render to HTML
 
-`renderToString` is async — it waits until in-flight work is idle:
+`renderToString` builds HTML without a DOM. It is async — it waits until in-flight work is idle:
 
 ```tsx twoslash
 import { atom, renderToString } from "ilha";
@@ -52,9 +31,26 @@ test("renders the count", async () => {
 });
 ```
 
-`renderToString` builds HTML without a DOM. Preload happy-dom only when a test mounts into real nodes or touches browser-only APIs at import time.
-
 ## Mount and simulate events
+
+Mount and event tests need a DOM. Install happy-dom's global registrator and preload it when you mount into real nodes or touch browser-only APIs at import time:
+
+```package-install
+bun add -d @happy-dom/global-registrator
+```
+
+```toml
+# bunfig.toml
+[test]
+preload = "./happydom.ts"
+```
+
+```ts twoslash
+// happydom.ts
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+GlobalRegistrator.register();
+```
 
 For behavior, mount into a detached element and dispatch events:
 
@@ -94,7 +90,7 @@ The short sleeps let microtasks paint. `unmount()` stops streams and listeners �
 
 ## Hydration round-trip
 
-Render, inject, then hydrate to verify a snapshot restores:
+Render, inject, then hydrate to verify a snapshot restores. This path also needs the happy-dom preload above:
 
 ```tsx twoslash
 import { atom, mount, renderToString } from "ilha";

--- a/apps/website/docs/guide/ui/render.mdx
+++ b/apps/website/docs/guide/ui/render.mdx
@@ -51,7 +51,7 @@ Default output looks like:
 
 Pass `{ markers: false }` when a host already exists (for example a frame target).
 
-`renderToString` needs a DOM. In Node, ilha registers happy-dom when `document` is missing.
+`renderToString` builds HTML without a DOM. It runs in Node, Bun, and edge runtimes with no polyfill.
 
 ## Mount
 

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -28,7 +28,7 @@
     "blume": "^1.5.3",
     "daisyui": "^5.7.22",
     "effect": "^4.0.0-rc.112",
-    "oxidejs": "^0.2.4",
+    "oxidejs": "^0.3.0",
     "tailwindcss": "^4.3.3",
     "tw-animate-css": "^1.4.0",
     "vite": "^8.2.2"

--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "blume": "^1.5.3",
         "daisyui": "^5.7.22",
         "effect": "^4.0.0-rc.112",
-        "oxidejs": "^0.2.4",
+        "oxidejs": "^0.3.0",
         "tailwindcss": "^4.3.3",
         "tw-animate-css": "^1.4.0",
         "vite": "^8.2.2",
@@ -42,23 +42,21 @@
     },
     "packages/astro": {
       "name": "@ilha/astro",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "devDependencies": {
         "astro": "^7.2.9",
-        "ilha": "0.14.1",
+        "ilha": "0.14.2",
       },
       "peerDependencies": {
         "astro": "^7.2.9",
-        "ilha": "^0.14.1",
+        "ilha": "^0.14.2",
       },
     },
     "packages/ilha": {
       "name": "ilha",
-      "version": "0.14.1",
-      "dependencies": {
-        "@happy-dom/global-registrator": "^20.11.2",
-      },
+      "version": "0.14.2",
       "devDependencies": {
+        "@happy-dom/global-registrator": "^20.11.2",
         "effect": "^4.0.0-rc.112",
       },
       "peerDependencies": {
@@ -67,33 +65,37 @@
     },
     "packages/router": {
       "name": "@ilha/router",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "dependencies": {
-        "effect": "^4.0.0-rc.112",
+        "effect": "4.0.0-rc.112",
         "unplugin": "3.3.0",
       },
       "devDependencies": {
-        "ilha": "0.14.1",
+        "ilha": "^0.14.2",
+        "oxidejs": "^0.3.0",
         "vite": "^8.2.2",
       },
       "peerDependencies": {
-        "ilha": ">=0.14.1",
+        "ilha": ">=0.14.2",
+        "oxidejs": ">=0.3.0",
       },
+      "optionalPeers": [
+        "oxidejs",
+      ],
     },
     "templates/oxide-spa": {
       "name": "@ilha/template-oxide-spa",
       "version": "0.0.0",
       "dependencies": {
-        "@ilha/router": "workspace:*",
+        "@ilha/router": "^0.11.2",
         "effect": "^4.0.0-rc.112",
-        "ilha": "workspace:*",
-        "tacho": "^0.6.1",
+        "ilha": "^0.14.2",
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.3",
         "@types/node": "^24",
         "daisyui": "^5.7.22",
-        "oxidejs": "^0.2.4",
+        "oxidejs": "^0.3.0",
         "tailwindcss": "^4.3.3",
         "typescript": "^7.0.2",
         "vite": "^8.2.2",
@@ -103,9 +105,9 @@
       "name": "@ilha/template-vite-spa",
       "version": "0.0.0",
       "dependencies": {
-        "@ilha/router": "workspace:*",
+        "@ilha/router": "^0.11.2",
         "effect": "^4.0.0-rc.112",
-        "ilha": "workspace:*",
+        "ilha": "^0.14.2",
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.3.3",
@@ -120,11 +122,11 @@
     "blume@1.5.3": "patches/blume@1.5.3.patch",
   },
   "packages": {
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.69", "", { "dependencies": { "@ai-sdk/provider": "4.0.9", "@ai-sdk/provider-utils": "5.0.34", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-W5MMdyqsaziQy/A4kxlK74iEQ+NuO6OaszH32cEQpUgBW0o15S2fAdP0aYSH2/5lrVZSMXLQLCzuMkRGHBua3A=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.72", "", { "dependencies": { "@ai-sdk/provider": "4.0.10", "@ai-sdk/provider-utils": "5.0.36", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iNNgagJ0+Ow1kdOFSyKPRk8kTh7qwhLZPLFdbXw4KMbMMF7JLzWlBSkyMSjh6U4O6D4D+76xj0HGws4JTLNeYA=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@4.0.9", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-XnGXPWiBIfqjsVEud5pOaVneRByJQOu2sYNwlSVJTPCvakdCDkVuYKKfNuStkIpMUYl7JIkBZGBx+B5YfNeVjA=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@4.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-fX2ENAc7iDpZ+Wp4+Rk06Usn/Ys7dI9uAkGv0jlF6XVrW13NkRWx5Ou+U6lIM2E1fTLkCs16GGrUAaVvroag7A=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.34", "", { "dependencies": { "@ai-sdk/provider": "4.0.9", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-tRBdgRcys/4d8wyQdOdyYScq1AxfMdMd0hIlwolxJKVIbBwXUgClZuQT0VIsz4e7pylY8FE6utYCCZ494UAMJQ=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.36", "", { "dependencies": { "@ai-sdk/provider": "4.0.10", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.29.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-MFXBn6XDyf37PNQAge/HTatPJE8Vmg/g/w4WPtjSV53jq8FKAzoaN5+43hsdQa9bqgN+/13jxug9ChvsG+godQ=="],
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
@@ -154,25 +156,25 @@
 
     "@astrojs/compiler-rs": ["@astrojs/compiler-rs@0.4.0", "", { "dependencies": { "@astrojs/compiler-binding": "0.4.0" } }, "sha512-koVikeon1kreEy+/JzLQRy3vzHHQVOjycs4degg4vFufKApZOwMZvSSAEztYNhmcQVfNVsVZZI4cEge3cexAbQ=="],
 
-    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.4", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.3.0", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA=="],
+    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.11.0", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.3.0", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-3rzxJ+xbo0+8YyqOzLziIN32wmsHdCjEVz2sGOpRxJ+Ben/KiLph4ItxBy1abEL+E8fkRzqjg0rfXmaHJGw9JA=="],
 
-    "@astrojs/language-server": ["@astrojs/language-server@2.16.15", "", { "dependencies": { "@astrojs/compiler": "^2.13.1", "@astrojs/yaml2ts": "^0.2.4", "@jridgewell/sourcemap-codec": "^1.5.5", "@volar/kit": "~2.4.28", "@volar/language-core": "~2.4.28", "@volar/language-server": "~2.4.28", "@volar/language-service": "~2.4.28", "muggle-string": "^0.4.1", "tinyglobby": "^0.2.16", "volar-service-css": "0.0.71", "volar-service-emmet": "0.0.71", "volar-service-html": "0.0.71", "volar-service-prettier": "0.0.71", "volar-service-typescript": "0.0.71", "volar-service-typescript-twoslash-queries": "0.0.71", "volar-service-yaml": "0.0.71", "vscode-html-languageservice": "^5.6.2", "vscode-uri": "^3.1.0" }, "peerDependencies": { "prettier": "^3.0.0", "prettier-plugin-astro": ">=0.11.0" }, "optionalPeers": ["prettier", "prettier-plugin-astro"], "bin": { "astro-ls": "./bin/nodeServer.js" } }, "sha512-hy7nMT1YGDAaRi9Q/SgywovZ8ThBgaRniMUaIT2/lBkFlJyolLjVxDGkhn3qT+zFUQ7GC/yrEBjsb7Xnj+yeaA=="],
+    "@astrojs/language-server": ["@astrojs/language-server@2.16.16", "", { "dependencies": { "@astrojs/compiler": "^2.13.1", "@astrojs/yaml2ts": "^0.2.4", "@jridgewell/sourcemap-codec": "^1.5.5", "@volar/kit": "~2.4.28", "@volar/language-core": "~2.4.28", "@volar/language-server": "~2.4.28", "@volar/language-service": "~2.4.28", "muggle-string": "^0.4.1", "tinyglobby": "^0.2.16", "volar-service-css": "0.0.71", "volar-service-emmet": "0.0.71", "volar-service-html": "0.0.71", "volar-service-prettier": "0.0.71", "volar-service-typescript": "0.0.71", "volar-service-typescript-twoslash-queries": "0.0.71", "volar-service-yaml": "0.0.71", "vscode-html-languageservice": "^5.6.2", "vscode-uri": "^3.1.0" }, "peerDependencies": { "prettier": "^3.0.0", "prettier-plugin-astro": ">=0.11.0" }, "optionalPeers": ["prettier", "prettier-plugin-astro"], "bin": { "astro-ls": "./bin/nodeServer.js" } }, "sha512-KuS17AOOqH/M5mHXPmKvtp8L+NNteARC7Xjf395+9R9dtJOBndqdStwU4V+OKzYZpgZ+hliV13knzx/oMtFl7Q=="],
 
     "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.2.4", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.4", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-MvspGMynWKAjTe4/lTUdmBPHIFKNVLTCF6UlyWGogTGzNrTvjD+D4n48k7h8swxsEPKHK2TwxkZO7uoaCv1Pow=="],
 
-    "@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.3.8", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.4", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "satteri": "^0.10.3" } }, "sha512-n8ItpFTCmlDsVR5+rwDmehSf+jFCYLWmZiisZNGuF7xILqYhsVeBfcha4qgS2Seq3fAc9Tm58ZVrvqFQ6RQgRQ=="],
+    "@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.4.0", "", { "dependencies": { "@astrojs/internal-helpers": "0.11.0", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "satteri": "^0.10.3" } }, "sha512-wykOOW9KsUVcZweOpY/CeXpdKcCKZy6fQbdcteWFuI75+sQCiqxYM7VKsGa5b+aGl3cYQscFY37rsbbyal5MRw=="],
 
     "@astrojs/mdx": ["@astrojs/mdx@7.0.8", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.4", "@astrojs/markdown-remark": "7.2.4", "@mdx-js/mdx": "^3.1.1", "acorn": "^8.16.0", "es-module-lexer": "^2.0.0", "estree-util-visit": "^2.0.0", "hast-util-to-html": "^9.0.5", "piccolore": "^0.1.3", "rehype-raw": "^7.0.0", "remark-gfm": "^4.0.1", "remark-smartypants": "^3.0.2", "source-map": "^0.7.6", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "@astrojs/markdown-satteri": "^0.3.1", "astro": "^7.0.0" }, "optionalPeers": ["@astrojs/markdown-satteri"] }, "sha512-RNuwq2ccTSi7NX9YqlR0noaWoVdOrZuJvdfWXotAzdhMVB0b0zEMLnNU+xar7le0GwTMlTObD/QAu8jeHA/3nA=="],
 
-    "@astrojs/node": ["@astrojs/node@11.1.4", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.4", "send": "^1.2.1", "server-destroy": "^1.0.1" }, "peerDependencies": { "astro": "^7.2.1" } }, "sha512-R5tNIHm5ihyEYa0w1mLlfwLpwF1ArRmzHD/is5PUHYRY43G1Xm0k3D2HRJXgjey8/7+1DvDMJLUeBxXwgAyNDg=="],
+    "@astrojs/node": ["@astrojs/node@11.1.5", "", { "dependencies": { "@astrojs/internal-helpers": "0.11.0", "send": "^1.2.1", "server-destroy": "^1.0.1" }, "peerDependencies": { "astro": "^7.2.1" } }, "sha512-CgA+LmG4UWqHxg/Vdc5MdxjjJNZSjKYQQx4uEUwnbj+1ZD2CYumJI3OWg2twsVdj2FlYsB5yvmCC54Re+OK+UQ=="],
 
     "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
 
-    "@astrojs/react": ["@astrojs/react@6.0.4", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.4", "@vitejs/plugin-react": "^5.2.0", "devalue": "^5.8.1", "ultrahtml": "^1.6.0", "vite": "^8.0.13" }, "peerDependencies": { "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0", "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0" } }, "sha512-0PDs0gM00vbUnw84Dh+YaxYaZzlppyzJub0J8wOO8/8AG4gV8L8X1ttiRp8cbSBGiWcu3UuspCaqIDO31ta8Uw=="],
+    "@astrojs/react": ["@astrojs/react@6.0.5", "", { "dependencies": { "@astrojs/internal-helpers": "0.11.0", "@vitejs/plugin-react": "^5.2.0", "devalue": "^5.8.1", "ultrahtml": "^1.6.0", "vite": "^8.0.13" }, "peerDependencies": { "@types/react": "^17.0.50 || ^18.0.21 || ^19.0.0", "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0", "react": "^17.0.2 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0" } }, "sha512-LiXkrO6mLxZ4dbUcLqiuasDd24fmO776NWPJZFUwu6fKP9rmxF3lt9BGo96d2M3B4/Ayy2YYe85evn5lETnokw=="],
 
     "@astrojs/telemetry": ["@astrojs/telemetry@3.3.3", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "package-manager-detector": "^1.6.0" } }, "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ=="],
 
-    "@astrojs/vercel": ["@astrojs/vercel@11.0.8", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.4", "@vercel/analytics": "^1.6.1", "@vercel/functions": "^3.4.3", "@vercel/nft": "^1.3.2", "@vercel/routing-utils": "^5.3.3", "esbuild": "^0.28.0", "tinyglobby": "^0.2.15" }, "peerDependencies": { "astro": "^7.0.0" } }, "sha512-ZOlWI7qkt69BJI6b/upCOOSMGvzChvnRFRYdNhiky3fn4D6ecQXaTV2UTkJqAG6lc6ORY6mb+81bo5p3SL22Xg=="],
+    "@astrojs/vercel": ["@astrojs/vercel@11.0.9", "", { "dependencies": { "@astrojs/internal-helpers": "0.11.0", "@vercel/analytics": "^2.0.1", "@vercel/functions": "^3.7.5", "@vercel/nft": "^1.10.2", "@vercel/routing-utils": "^6.4.0", "esbuild": "^0.28.0", "tinyglobby": "^0.2.15" }, "peerDependencies": { "astro": "^7.0.0" } }, "sha512-IUjcybXFrqFE8VEuJa+byoMd70qABGF/9jOglbTf5tbChov199pLO3fyWCNskxYgJjxmY/P058tH8st0o3lJGQ=="],
 
     "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.4", "", { "dependencies": { "yaml": "^2.8.3" } }, "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A=="],
 
@@ -326,7 +328,7 @@
 
     "@fontsource-variable/geist-mono": ["@fontsource-variable/geist-mono@5.3.0", "", {}, "sha512-vBbuwDEo9AkrqADMXOrlAR3DFcJi4/JxeuU43FoiQERnNwsfXNnvxvReZG02cQKmyk4DZkZdBZX3oTDvy2zBAw=="],
 
-    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.12.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.12.0" } }, "sha512-BUE55Rew3oMwBzwCwmUnV+Oxk51V3xolM39Ts6kGiBXNELjujiESwk9qc99JRr6cVrj3OTd9MJ5zQ2fpn+jy6g=="],
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.13.1", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.13.1" } }, "sha512-++oy0RegDCvcPk5P48kNCmA/mPoTx8/BKscBAQc0lh62Aiqzf6+P336FkNpoIPbmrkxq8UtVRbetvCNBrRIDYw=="],
 
     "@hono/node-server": ["@hono/node-server@2.1.1", "", { "peerDependencies": { "hono": "^4" } }, "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg=="],
 
@@ -448,7 +450,7 @@
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
-    "@oxc-project/types": ["@oxc-project/types@0.147.0", "", {}, "sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg=="],
+    "@oxc-project/types": ["@oxc-project/types@0.148.0", "", {}, "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A=="],
 
     "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.63.0", "", { "os": "android", "cpu": "arm" }, "sha512-YmRth4ZPGgEXcgmkhvANbC9uD67dxmSobW7DQuyt5tOBOKvPnIpk5SVHBj88E+7wMNRI2FhqaDbOhQFBix+b8A=="],
 
@@ -488,43 +490,43 @@
 
     "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.63.0", "", { "os": "win32", "cpu": "x64" }, "sha512-sgsHCQy432OTQH4Ikk3tZptp3GqwnhwUDuY0loBH41zyHWfMZY9v8Dy78wsnSofHejvFozZGgJgBB1A0LQRwMQ=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.80.0", "", { "os": "android", "cpu": "arm" }, "sha512-RM3Plj+biQpxa5d1GOOX6ciDlcUROmm4OZ/pLTpitkQt2mJv4jhtY4cbgaetOm5UKWZe05/TGQ6o1Vl8EOHkrA=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.81.0", "", { "os": "android", "cpu": "arm" }, "sha512-IcCRsXiedJoJopY6mpZUBEeVFsUrutmrG7dZ87zMuKJlhg70Ora9bBl1WcCxZQtyI10YpnVdEso5oCg7YcfSHw=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.80.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YlO5JEf0Yr2bUUlu8O8daVcUxtcGGbcSmyV7E7nSbJbfAdxTE0PFPwgnIlw7wXJaTYjb+qs5hI5q3jxUkI7cAw=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.81.0", "", { "os": "android", "cpu": "arm64" }, "sha512-GRrIPyTGVhx3L3h+0T5xT2A0jFAcdPv4+IfuXpGDLIdl6XeYhgg/zw72A5ILZoUgRqZuM8F1y+V/gfDriXSxzQ=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.80.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BULDOyO3AhsmdWfQeIUCykDt3dd7XZBGLhp1eIh56skRv01O+cNjNPwXMIbeW1x4+pxcln5if72wcRgViVo7PA=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.81.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-qNQ9tXRgLuKbqSV1S2h9h4KPHjbovO7RRR2/enUOtHzTkFZ7B9X5zqqHJua8dRyc7dBy7Aoyq5pqTSLFVcAzGQ=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.80.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-YJ4JzLw7N5TDSQFlA0hAQGHvnDZgyypm1yunObVWcWiF9KM7eGCJKYKLgTC2Fi/57OdnBhbj4OkzPGdFQJ6HyA=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.81.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-q0QTm32jWga2Gv4j7IaVZN0jYMi9UV73sWVgFtDA4iIfqwMCLLZ3ve+9KwfYtsaKZSgQhmPaogeZWqDZpcY1Pw=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.80.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-AYUIk5QnL0s8oWAYsREZwkRYy1SupJTXALo93J1TgzHywxQtdM99FecRMQ87MXEdPQ0j1TmEpeeq3fGNkpvMqg=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.81.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-/+8wVWDXEC7wHVAhOc59Fw/SkMc1arLkFD8iQCaSsmzenK1X4doFqquL9H1wrtGUzaiycVqkf/sSpcILK6W1UA=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.80.0", "", { "os": "linux", "cpu": "arm" }, "sha512-9hBZVANupQ89W9dXyE0n8doCyaW5pDyGn3y6XlIMPZ+rIKuyqkr3SNUXmVJIhuvUq0NBU3RBiSXXE69l4XI6KA=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.81.0", "", { "os": "linux", "cpu": "arm" }, "sha512-4xt422FEgioRq9hAL4Tq7fujGUWnc8z1BJ+Oi8RN8vB8axaP+sdK6a2xdlcQCCYnJg9QMuMFS0AucuIFx/EacA=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.80.0", "", { "os": "linux", "cpu": "arm" }, "sha512-SvS2uKqzY+pbfuvAHzH4338R6Zwo805GAwrIMVvK1KxoOWCIjZUdfzTCvilD7z6JK91v011+zYMryabhDo2AsQ=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.81.0", "", { "os": "linux", "cpu": "arm" }, "sha512-u3vna8KdGplH4DRCW9K54D68fcMo7IxVrkCJWwXnIhwtBdnDnYrmzOUA/XjmBlPpcLsgw9Z5BNdY4za9+Dj+MQ=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.80.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tCLadyqRVL3pQTRPNg7cjXKvcvS4fbyXeQHhKk5BTJ1oftQln5/yIIWbu/Xom/DX41zv2P9QGt6+D/TtQVtY3A=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.81.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-3j9k+gsYsE7nv71GWotXsqsa2l9/aJenD7dVHNt/CBvsb0SgRjSMnHFeP59IXUAl1wvVFhqGl2wJNMwWU3UBlA=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.80.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-XfpCNRlOPcLlJl4Bn/FUhjqlR6BVavEykERBf/MV7YA9VZDa5g5znVqYhyviMafcxS9Pe/i/kPvHNO0U6svEHQ=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.81.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-k5iAp3dNxW0/uDCBY+WSm8jKB2szu7SkEQZdgRRpDXvuDd69vvDcqhB3A/pWCfCwXyenjNjFn9Td1fVoyAc+Yg=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.80.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3I4yMwcFG9NeO8ioY6JBBuKsIm5GL/x7MATt1S4tVWaxPu5HcJ+XnLUbcVBTxG8q2Wu56HSj+NmXQiVYb1lp6A=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.81.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-TFqLja3uYmVSte6nof9GWrex9Z8WgdZrNiLC6Te5rXGDqXB2y4j/26iFhwosXiAFqDhE9JJVuuCkDKLwptTn1g=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.80.0", "", { "os": "linux", "cpu": "none" }, "sha512-E1wAKymkpe1/E8helzBKdm81OBOF+ezxRyXRMEuik3ZpWDER5CPOKZwF66RsdwW98uwZv8UTFremUQtC1CzdJA=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.81.0", "", { "os": "linux", "cpu": "none" }, "sha512-UEcySvGS0NOVo7h7n7CYyJL9+6gFAh7Zc/ToDXVScFvzHSTIxtzkMVU30rmQ6+nQ1LF+UdiRDdJajpDu+OylLg=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.80.0", "", { "os": "linux", "cpu": "none" }, "sha512-+gLRGD4sIo3+VA++iham5UxD9tKSoJ/VOrROCEXIcknrYtQg6iIQgvjN0cpiRF7N6UYC7pJbvHJlDnMge5LRpQ=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.81.0", "", { "os": "linux", "cpu": "none" }, "sha512-H+diDbhD00+wI1IRP8Kz88x/lat+DgtoBJzoTthS16xkTJGNaEkfb8gzmd1rzc/2uDQQMl7GNl+JFUacVeWxIA=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.80.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-aR0PrzHj9leW3NmzBAAP4EzdoBNoJcs9sjnIQPIwyRnBGYrRbXUIpEB5Q39AqK3PLY5JK5uEhDQDiUa1QSAstw=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.81.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-8znJ/5TekjOKg1j1Acho4PJMdiAHLtlcXuWEiipOhAMV6rQcXdmDdXCbheyDczN6TjBwiNfjcP81k4AthrKRzw=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.80.0", "", { "os": "linux", "cpu": "x64" }, "sha512-vSVh5cSo3Xxs6ghBCcFJlpbkbENzDog1qXtoXLa/HC3aCrR4XO76GZbXmQoCPHnu99nQpdCeC3H9tdNICfDh7A=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.81.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Q2Wj70yFsvn5QjlmifFzbj4H+kJy53bwqc41o1fzoM7MpLV1NIbhg/LpWXRfC6KOkSAdUx1Wd8VJsdPmhp/HRA=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.80.0", "", { "os": "linux", "cpu": "x64" }, "sha512-FfzBXpNQ8u7/ZI/p8bl73MeZ508Ax3hxWp3SiJpEFiC+BB9XcXy5FAZHTLKDPSzrUpxQZSZJAVdDmuJp/+HDBQ=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.81.0", "", { "os": "linux", "cpu": "x64" }, "sha512-cPInHp/ddEe5qkyK2IiyQ8Q3Mp2oLLEhhsGgTK2oZx4L6+llGam1H1yBvJZ7qHfOXj8N3hxBS8sj4tO+gtFlIg=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.80.0", "", { "os": "none", "cpu": "arm64" }, "sha512-zMzbkumtmprCgRwoYNzcB3iC39fXdJIMLMU33KdCjEGLlJGOEt1+LwQ4LF8ndLzAEKVz4BR0y3V6Xrkk3Nm3yA=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.81.0", "", { "os": "none", "cpu": "arm64" }, "sha512-0CQxSX4ajqm07AHBf5U33qQzXKdd7wtq/oTL/7vpY6RNNuxrRi8W4bqUV1Jyu/vj+9KmxQyDhxfeVX1nQL6kfg=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.80.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-ib6iRcrXsk4t1fm3iKcwksyWh1ZkZXC/2mEzakl0ai2+6HZunf1WWMZ/xP9EJAvw9g9K4UVTC3NF/+G2qLrbTQ=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.81.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-l0hbeISm9673hVrrQU8j/p2M7YH9Ouoj7p7E/QM55NTrKVLP+P3PF8hLu+OY+x0VtGRW+ggiQKZqmdYps9H+TA=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.80.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-xhRWBMpLxZvgKAH6+DJZmpP+W8Y8UdQOSU1JfxSWNXsaBaRGW77j+1hCuNHlzj7OH4SPN8fYd1q0o2qrDtoVyw=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.81.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-ksqPP5jbFXcYreEQ7zdJh06rJQBymCTyGRCdaXjfcf2aG4f8KxUWY5wcgYHmaTK+FJ4bPG5sUAdOX+6trnH1JA=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.80.0", "", { "os": "win32", "cpu": "x64" }, "sha512-yAnO7lwBYQnz2pcfBPIGQQZWIX5zd5R/1aAKIF3oE+TVj7IhoHcROjOkz3sRDngzqhfPKfFaXqug5j5rE5dn6Q=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.81.0", "", { "os": "win32", "cpu": "x64" }, "sha512-IZuUCwGw9emG5JtCp+fYGB+Z4OWEoeEcM8R5BA1pYw63/ieYFVdcU2ylxTpHbVHSenZnsYE+ZZ20uHAJszQ4cA=="],
 
     "@pagefind/darwin-arm64": ["@pagefind/darwin-arm64@1.5.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ=="],
 
@@ -548,35 +550,35 @@
 
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
-    "@rolldown/binding-android-arm-eabi": ["@rolldown/binding-android-arm-eabi@1.2.6", "", { "os": "android", "cpu": "arm" }, "sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ=="],
+    "@rolldown/binding-android-arm-eabi": ["@rolldown/binding-android-arm-eabi@1.2.7", "", { "os": "android", "cpu": "arm" }, "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ=="],
 
-    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.6", "", { "os": "android", "cpu": "arm64" }, "sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q=="],
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.7", "", { "os": "android", "cpu": "arm64" }, "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw=="],
 
-    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA=="],
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw=="],
 
-    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q=="],
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ=="],
 
-    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA=="],
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA=="],
 
-    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.6", "", { "os": "linux", "cpu": "arm" }, "sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w=="],
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.7", "", { "os": "linux", "cpu": "arm" }, "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ=="],
 
-    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg=="],
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg=="],
 
-    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw=="],
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q=="],
 
-    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.6", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ=="],
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg=="],
 
-    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.6", "", { "os": "linux", "cpu": "s390x" }, "sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA=="],
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw=="],
 
-    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w=="],
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.7", "", { "os": "linux", "cpu": "x64" }, "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA=="],
 
-    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.6", "", { "os": "linux", "cpu": "x64" }, "sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ=="],
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.7", "", { "os": "linux", "cpu": "x64" }, "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw=="],
 
-    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.6", "", { "os": "none", "cpu": "arm64" }, "sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg=="],
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.7", "", { "os": "none", "cpu": "arm64" }, "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w=="],
 
-    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A=="],
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw=="],
 
-    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ=="],
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.7", "", { "os": "win32", "cpu": "x64" }, "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
@@ -690,27 +692,27 @@
 
     "@tailwindcss/vite": ["@tailwindcss/vite@4.3.3", "", { "dependencies": { "@tailwindcss/node": "4.3.3", "@tailwindcss/oxide": "4.3.3", "tailwindcss": "4.3.3" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw=="],
 
-    "@takumi-rs/core": ["@takumi-rs/core@2.13.3", "", { "dependencies": { "@takumi-rs/helpers": "2.13.3" }, "optionalDependencies": { "@takumi-rs/core-darwin-arm64": "2.13.3", "@takumi-rs/core-darwin-x64": "2.13.3", "@takumi-rs/core-linux-arm64-gnu": "2.13.3", "@takumi-rs/core-linux-arm64-musl": "2.13.3", "@takumi-rs/core-linux-x64-gnu": "2.13.3", "@takumi-rs/core-linux-x64-musl": "2.13.3", "@takumi-rs/core-win32-arm64-msvc": "2.13.3", "@takumi-rs/core-win32-x64-msvc": "2.13.3" }, "peerDependencies": { "csstype": "*" }, "optionalPeers": ["csstype"] }, "sha512-b0xSv0e4N7MrG3GoSl12Ewj3UB/JoTB6GwfX/7i1jYKlnGV66+a+9NrSzCxfjcPeUBaSPIzaxQ+C6L1256ClIA=="],
+    "@takumi-rs/core": ["@takumi-rs/core@2.13.4", "", { "dependencies": { "@takumi-rs/helpers": "2.13.4" }, "optionalDependencies": { "@takumi-rs/core-darwin-arm64": "2.13.4", "@takumi-rs/core-darwin-x64": "2.13.4", "@takumi-rs/core-linux-arm64-gnu": "2.13.4", "@takumi-rs/core-linux-arm64-musl": "2.13.4", "@takumi-rs/core-linux-x64-gnu": "2.13.4", "@takumi-rs/core-linux-x64-musl": "2.13.4", "@takumi-rs/core-win32-arm64-msvc": "2.13.4", "@takumi-rs/core-win32-x64-msvc": "2.13.4" }, "peerDependencies": { "csstype": "*" }, "optionalPeers": ["csstype"] }, "sha512-YL+2FoGdEZ27jf2SBLvPEdO7/FaALyJv1vEZrN7GVT9RDMgOVZvhpiYIdvWX1BJLDdix9uDgG9M+BCmJWHLIgA=="],
 
-    "@takumi-rs/core-darwin-arm64": ["@takumi-rs/core-darwin-arm64@2.13.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tjaSLf6rSryeT/QNXkgBzzViBiad4BK5fS6drnYyWkIlbX+vc02Pmd/ZGtKuKWDJ6M7rk+kX+ymnTyzqozPlSQ=="],
+    "@takumi-rs/core-darwin-arm64": ["@takumi-rs/core-darwin-arm64@2.13.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-znfETB7y3x+nLmbVv7tn4rULaQNpaCQ+Ei69UiR/egNKw/3mAdTcnGKi1ba10/BCnIKKFoYTnD/+c/rX/KOE5g=="],
 
-    "@takumi-rs/core-darwin-x64": ["@takumi-rs/core-darwin-x64@2.13.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-3UuW4Jh+8clca2UHyTftHu4GgPUs57Go//A5KYXzJMBNh0/Z5DDqtukGXWhgDztWCRxfxC/MD9G4z3ExN8FwIA=="],
+    "@takumi-rs/core-darwin-x64": ["@takumi-rs/core-darwin-x64@2.13.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-YHdOCtyq0fekME3Y76aglwvr1xliDYUkt827cIiNKasVwLyVYp7c2oA2vtOy60AVWSsNaeQZfio/A1+n1yEQvg=="],
 
-    "@takumi-rs/core-linux-arm64-gnu": ["@takumi-rs/core-linux-arm64-gnu@2.13.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-SMOUHOWA3ZrrOcdzMjBMf/P2ZlSLaYx/AYzgFQqocDKKJHg5PMPq12d0oc855KLgeCP5qF3RO57v1C28VallUQ=="],
+    "@takumi-rs/core-linux-arm64-gnu": ["@takumi-rs/core-linux-arm64-gnu@2.13.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-enCLLvXIbC/uP84/2MEGnSxtmpiW/WXWxG3EMaGo2Yuukg817N0EOqxR0/pNn5JtSqqYsFjaLSLM7lODyKsz/g=="],
 
-    "@takumi-rs/core-linux-arm64-musl": ["@takumi-rs/core-linux-arm64-musl@2.13.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-Ncq2dbrWr9fsL8Cb4bWwBwYx7gXFy+AaMUx4zU7I0nxBkereCtNC4UMc3RY09OElPfwv1qpKtWYB6A+CJQRW5w=="],
+    "@takumi-rs/core-linux-arm64-musl": ["@takumi-rs/core-linux-arm64-musl@2.13.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-PjYuEqZnzOLeltGd33asZyXNFueo/tWhIemuK1EOawMbFIv7ItZ+IPfizEppjiT/9aubbYgAPo7B1RsqJMcjOw=="],
 
-    "@takumi-rs/core-linux-x64-gnu": ["@takumi-rs/core-linux-x64-gnu@2.13.3", "", { "os": "linux", "cpu": "x64" }, "sha512-0K9kKFxDKnSs1R62MZiu2J/kRabkGQ8W8TN/t0fX9/lGS2Lv76aMZ/EYIZFf0wPSazy/706ybavBU05l+gH5zw=="],
+    "@takumi-rs/core-linux-x64-gnu": ["@takumi-rs/core-linux-x64-gnu@2.13.4", "", { "os": "linux", "cpu": "x64" }, "sha512-FslEpRoWcLMpNRKLN6lr9o8GZ412h0FgZMa2fuBNXJaXYN0L6W7RctrTZa+mWo2Wt8V4V4DKwCqYEZwPCkyQ3g=="],
 
-    "@takumi-rs/core-linux-x64-musl": ["@takumi-rs/core-linux-x64-musl@2.13.3", "", { "os": "linux", "cpu": "x64" }, "sha512-+c7SAdhZe3kgVmyATrwkPmWJEn+taDeV3eLnVjziSF92hhpVrKbe3DTEzCCvyqvoZ8e0C0ibC44Npe1A4FORug=="],
+    "@takumi-rs/core-linux-x64-musl": ["@takumi-rs/core-linux-x64-musl@2.13.4", "", { "os": "linux", "cpu": "x64" }, "sha512-OYCHAE+5kycXvpPVh0xEZbt6A7OSJAKhteJLqStuZUOSp3fkGVTiUIfvcfCgCcLo3vdfE8aOX5SZTqCPkGMQbg=="],
 
-    "@takumi-rs/core-win32-arm64-msvc": ["@takumi-rs/core-win32-arm64-msvc@2.13.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-jFv8+DT3Rz+9xeduDoMKNGHNB+ZHEwBloJh9iTU6waiaArwG2WoJ0JF2KRoDPECdvk52W9IR+HelbDtR/WIHoQ=="],
+    "@takumi-rs/core-win32-arm64-msvc": ["@takumi-rs/core-win32-arm64-msvc@2.13.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-bAG2fEEmmfqUTaAERLmUYalpwXCiyNIkZXC/pGUZyFK55YDW2usAoaj7zEJY7JDDvmkNC98y57rTvFy6lW6IAQ=="],
 
-    "@takumi-rs/core-win32-x64-msvc": ["@takumi-rs/core-win32-x64-msvc@2.13.3", "", { "os": "win32", "cpu": "x64" }, "sha512-NehYZvabxyMHCEEKaJGbcq3oLpbQE+Gmo6TcOwmxbBG0k1bR6Q9uka+cqgQWKqA3D7uipBOXrDcir5HqjqvUuQ=="],
+    "@takumi-rs/core-win32-x64-msvc": ["@takumi-rs/core-win32-x64-msvc@2.13.4", "", { "os": "win32", "cpu": "x64" }, "sha512-qyj4BPv6d0wuYfm9qL730X6py6v5agXc6M7D5nYQrBFFZ8kYFMyBwrHOjeOgWeqbzDwJ/x8TzBqGrryIm88LQA=="],
 
-    "@takumi-rs/helpers": ["@takumi-rs/helpers@2.13.3", "", { "peerDependencies": { "preact": "^10.0.0", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["preact", "react"] }, "sha512-9ojGETH+sJuszHra6llslChQ0TD8v5MvsTbfkJiIwvxT+ekGOaafi7HEqpqY7diAsYnGE/sBhRyuUIQ6IbvusA=="],
+    "@takumi-rs/helpers": ["@takumi-rs/helpers@2.13.4", "", { "peerDependencies": { "preact": "^10.0.0", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["preact", "react"] }, "sha512-5F60HDcr9FelxiUhgSGMt4C1g3Nt8S9LbTlp43YyhmmZeUnsodiaiansnFc2poR/pCDS232S8fLXCsPj7btwxQ=="],
 
-    "@takumi-rs/wasm": ["@takumi-rs/wasm@2.13.3", "", { "dependencies": { "@takumi-rs/helpers": "2.13.3" }, "peerDependencies": { "csstype": "*" }, "optionalPeers": ["csstype"] }, "sha512-ev37eFGozTbram8nmf0APE7afZpBMIDLdVUXmzQ5sP0SDuKzDUHV5WOhwbWWA8p0P664EgQ/UV8K8nOyEiqC7g=="],
+    "@takumi-rs/wasm": ["@takumi-rs/wasm@2.13.4", "", { "dependencies": { "@takumi-rs/helpers": "2.13.4" }, "peerDependencies": { "csstype": "*" }, "optionalPeers": ["csstype"] }, "sha512-7up81a03RkcTmMk0kMdRqVyr17ZY/ZsGMLRYP/M3XzcHFNU/01wDBvysk5/FbAgCIg8GD+lNZOyEpwjWrM5rAg=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
@@ -882,7 +884,7 @@
 
     "@vercel/oidc": ["@vercel/oidc@3.8.5", "", { "dependencies": { "@vercel/cli-config": "0.2.4", "@vercel/cli-exec": "1.0.1", "jose": "^5.9.6" } }, "sha512-RwXYtnt6za+5UO4IaLywN/6B95AlLqynPRUWRJxeJ/qufwkcLUbZNUxYtzT0uMpuraWhlNcGqPNGkTnZr4BGBw=="],
 
-    "@vercel/routing-utils": ["@vercel/routing-utils@5.3.3", "", { "dependencies": { "path-to-regexp": "6.1.0", "path-to-regexp-updated": "npm:path-to-regexp@6.3.0" }, "optionalDependencies": { "ajv": "^6.12.3" } }, "sha512-KYm2sLNUD48gDScv8ob4ejc3Gww2jcJyW80hTdYlenAPz/5BQar1Gyh38xrUuZ532TUwSb5mV1uRbAuiykq0EQ=="],
+    "@vercel/routing-utils": ["@vercel/routing-utils@6.5.0", "", { "dependencies": { "path-to-regexp": "6.1.0", "path-to-regexp-updated": "npm:path-to-regexp@6.3.0" }, "optionalDependencies": { "ajv": "^6.12.3" } }, "sha512-2PXgATJyJYEaIuDEhljZ+sfOfJEsBl6OEzD+jHhy6NAb0k2mHdbTjcK3zTBNnYq0nebrXpq5ZGiwOxBFoUwB3A=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
@@ -968,7 +970,7 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "ai": ["ai@7.0.85", "", { "dependencies": { "@ai-sdk/gateway": "4.0.69", "@ai-sdk/provider": "4.0.9", "@ai-sdk/provider-utils": "5.0.34" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HVtPz0qLbTUad+QBnWWReIUmwk+U4PcRENMx+9PsHGVoinoc5CLDiVjNR+VBXTKOSaNgce8kSU/Rtbb4kjZsSw=="],
+    "ai": ["ai@7.0.90", "", { "dependencies": { "@ai-sdk/gateway": "4.0.72", "@ai-sdk/provider": "4.0.10", "@ai-sdk/provider-utils": "5.0.36" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-cvG7Od3DPlnnljkIXP1CQ8wABOfDqV1uBFWemBjGupiqcQD8O9SSg5m4FL+GiMA47NN7dxIJnaw8/uowwN+D2g=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -1004,7 +1006,7 @@
 
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
 
-    "astro": ["astro@7.2.9", "", { "dependencies": { "@astrojs/compiler-rs": "^0.4.0", "@astrojs/internal-helpers": "0.10.4", "@astrojs/markdown-satteri": "0.3.8", "@astrojs/telemetry": "3.3.3", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^2.0.1", "devalue": "^5.8.1", "diff": "^9.0.0", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "find-proc": "0.1.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.3.0", "jsonc-parser": "^3.3.1", "magic-string": "^1.0.0", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^1.0.1", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.5", "unstorage": "^1.17.5", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.35.4" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.4" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-o5nZFo/bieF6rp4x9sQSLhI7GO7Bahpld38Y4LvX27nFoxNiuttjI+Hea81w5ksORLHgdPUlQpU9obPz5QRa8g=="],
+    "astro": ["astro@7.2.10", "", { "dependencies": { "@astrojs/compiler-rs": "^0.4.0", "@astrojs/internal-helpers": "0.11.0", "@astrojs/markdown-satteri": "0.4.0", "@astrojs/telemetry": "3.3.3", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^2.0.1", "devalue": "^5.8.1", "diff": "^9.0.0", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "find-proc": "0.1.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.3.0", "jsonc-parser": "^3.3.1", "magic-string": "^1.0.0", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^1.0.1", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.5", "unstorage": "^1.17.5", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.35.4" }, "peerDependencies": { "@astrojs/markdown-remark": "^7.3.0" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-uPtD+nK6kQXugyq4kiMPwj9OI3Sae6HSerA5X+fuv2CPaDwxmokFPPFlGRKIAXH0QAKu+zot2q6yrLG61wFmqg=="],
 
     "astro-icon": ["astro-icon@1.2.0", "", { "dependencies": { "@iconify/tools": "^5.0.12", "@iconify/types": "^2.0.0", "@iconify/utils": "^3.1.4" } }, "sha512-0848V2WZuTPhqGSqLeZimLJZ5wmamMtWYzvA2kvg8s2DrUPZ3/nrTcHJWN0eJHt62jy7uvNxgTNiUJGIr7JNxg=="],
 
@@ -1124,6 +1126,8 @@
 
     "csso": ["csso@5.0.5", "", { "dependencies": { "css-tree": "~2.2.0" } }, "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ=="],
 
+    "cssom": ["cssom@0.5.0", "", {}, "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "cytoscape": ["cytoscape@3.34.2", "", {}, "sha512-Cm2jaj1X/PBNlzV9yH8zcfGOxO7U+CJ/+mxSBVPSchLaugdp4jtlGx5qaHtPRZ6tgiZ5P+o1XoRfJA+ba6KM3g=="],
@@ -1198,7 +1202,7 @@
 
     "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
 
-    "daisyui": ["daisyui@5.7.22", "", {}, "sha512-pYii+2NCN0+OIL6Lpuc054LK0QJeNv+GRK9UzN1GRmjdYhYO6WFl0QLoj5oPcitPD7o+okiiI0SKFkn641TxmA=="],
+    "daisyui": ["daisyui@5.7.27", "", {}, "sha512-Je10yYK7UFJYyLSQrIxhFmpwX+86gXdNTnfNkA1jlev7j9oz3QrqioEQ6/0JYOvYPs5NYH4aaJ+X35/N80G/xg=="],
 
     "data-view-buffer": ["data-view-buffer@1.0.2", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-data-view": "^1.0.2" } }, "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ=="],
 
@@ -1264,7 +1268,7 @@
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.417", "", {}, "sha512-4T+DTDWuMPM4aHlHwWdAVCVWwp7LDilnhzkj+c/Lbj91XSQrLuOmZSLtS9Q4iIqjlPUbPOnC624zDVVHCHaolQ=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.420", "", {}, "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA=="],
 
     "emmet": ["emmet@2.4.11", "", { "dependencies": { "@emmetio/abbreviation": "^2.3.3", "@emmetio/css-abbreviation": "^2.1.8" } }, "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ=="],
 
@@ -1362,7 +1366,7 @@
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
-    "fast-uri": ["fast-uri@3.1.6", "", {}, "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q=="],
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.2", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q=="],
 
@@ -1440,7 +1444,7 @@
 
     "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
 
-    "happy-dom": ["happy-dom@20.12.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-7uMYJu2SEwwL8vVcKp0C0lnt6d2LSGGe+T+oY79PiCJNNSgFpbxW8n5KuzpDQvrU4mt+fYiK1+Jy7Z2v39YR6g=="],
+    "happy-dom": ["happy-dom@20.13.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-hoh0Sq+2vSDi8CJaFnLBLAlEK7/vrRmUiim30PwFj9aiVwqF/Z+6cCpmt9gNuQgu+PHjNC4O2PhjxA9Nr+UlBQ=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -1486,7 +1490,7 @@
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
-    "htmlparser2": ["htmlparser2@7.2.0", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.2", "domutils": "^2.8.0", "entities": "^3.0.1" } }, "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog=="],
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
     "http-cache-semantics": ["http-cache-semantics@4.2.0", "", {}, "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ=="],
 
@@ -1667,6 +1671,8 @@
     "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
+
+    "linkedom": ["linkedom@0.18.13", "", { "dependencies": { "css-select": "^7.0.0", "cssom": "^0.5.0", "html-escaper": "^3.0.3", "htmlparser2": "^10.1.0", "uhyphen": "^0.2.0" }, "peerDependencies": { "canvas": ">= 2" }, "optionalPeers": ["canvas"] }, "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw=="],
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
@@ -1904,9 +1910,9 @@
 
     "oxfmt": ["oxfmt@0.63.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.63.0", "@oxfmt/binding-android-arm64": "0.63.0", "@oxfmt/binding-darwin-arm64": "0.63.0", "@oxfmt/binding-darwin-x64": "0.63.0", "@oxfmt/binding-freebsd-x64": "0.63.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.63.0", "@oxfmt/binding-linux-arm-musleabihf": "0.63.0", "@oxfmt/binding-linux-arm64-gnu": "0.63.0", "@oxfmt/binding-linux-arm64-musl": "0.63.0", "@oxfmt/binding-linux-ppc64-gnu": "0.63.0", "@oxfmt/binding-linux-riscv64-gnu": "0.63.0", "@oxfmt/binding-linux-riscv64-musl": "0.63.0", "@oxfmt/binding-linux-s390x-gnu": "0.63.0", "@oxfmt/binding-linux-x64-gnu": "0.63.0", "@oxfmt/binding-linux-x64-musl": "0.63.0", "@oxfmt/binding-openharmony-arm64": "0.63.0", "@oxfmt/binding-win32-arm64-msvc": "0.63.0", "@oxfmt/binding-win32-ia32-msvc": "0.63.0", "@oxfmt/binding-win32-x64-msvc": "0.63.0" }, "peerDependencies": { "svelte": "^5.0.0", "vite-plus": "*" }, "optionalPeers": ["svelte", "vite-plus"], "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-kgdDwv35wvVf6554U2Ab8Jnd0zTM+TsEQWwaB70RAjK3gICFAFGO+2Hd3Be27GMoXj3XRL9IKSNRVl7KBQL6iw=="],
 
-    "oxidejs": ["oxidejs@0.2.4", "", { "dependencies": { "unplugin": "^3.3.0" }, "peerDependencies": { "@rsbuild/core": "*", "crossws": "*", "tacho": "*", "vite": "*" }, "optionalPeers": ["@rsbuild/core", "crossws", "tacho", "vite"] }, "sha512-4EGN2WH72e7eyMnnSGS7dL7DRRxEFmYVB44cY1TeuKTgSIp2TrvN6CkC1w5o6QZEFn0uQI2kgnQHaCjGcOZbWg=="],
+    "oxidejs": ["oxidejs@0.3.0", "", { "dependencies": { "effect": "~4.0.0-rc.112", "linkedom": "^0.18.13", "unplugin": "^3.3.0" }, "peerDependencies": { "@rsbuild/core": "*", "crossws": "*", "vite": "*" }, "optionalPeers": ["@rsbuild/core", "crossws", "vite"] }, "sha512-tK92pHIHqD1ik6rxe9j8ezXfc2fT/sUKySlHXSkiBxJ9ApBQbfHGiQdNWGSSnuYQlkJlqK2/wpmEOYZg5GHvKg=="],
 
-    "oxlint": ["oxlint@1.80.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.80.0", "@oxlint/binding-android-arm64": "1.80.0", "@oxlint/binding-darwin-arm64": "1.80.0", "@oxlint/binding-darwin-x64": "1.80.0", "@oxlint/binding-freebsd-x64": "1.80.0", "@oxlint/binding-linux-arm-gnueabihf": "1.80.0", "@oxlint/binding-linux-arm-musleabihf": "1.80.0", "@oxlint/binding-linux-arm64-gnu": "1.80.0", "@oxlint/binding-linux-arm64-musl": "1.80.0", "@oxlint/binding-linux-ppc64-gnu": "1.80.0", "@oxlint/binding-linux-riscv64-gnu": "1.80.0", "@oxlint/binding-linux-riscv64-musl": "1.80.0", "@oxlint/binding-linux-s390x-gnu": "1.80.0", "@oxlint/binding-linux-x64-gnu": "1.80.0", "@oxlint/binding-linux-x64-musl": "1.80.0", "@oxlint/binding-openharmony-arm64": "1.80.0", "@oxlint/binding-win32-arm64-msvc": "1.80.0", "@oxlint/binding-win32-ia32-msvc": "1.80.0", "@oxlint/binding-win32-x64-msvc": "1.80.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-5nTiSps4qdbCWLbxzuO00alHkEO2exR9YMN/ig6QXWrLsYSG0KaObOAM+l6oU2LcKPWoSAGYbkZIGEu1ViiWKA=="],
+    "oxlint": ["oxlint@1.81.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.81.0", "@oxlint/binding-android-arm64": "1.81.0", "@oxlint/binding-darwin-arm64": "1.81.0", "@oxlint/binding-darwin-x64": "1.81.0", "@oxlint/binding-freebsd-x64": "1.81.0", "@oxlint/binding-linux-arm-gnueabihf": "1.81.0", "@oxlint/binding-linux-arm-musleabihf": "1.81.0", "@oxlint/binding-linux-arm64-gnu": "1.81.0", "@oxlint/binding-linux-arm64-musl": "1.81.0", "@oxlint/binding-linux-ppc64-gnu": "1.81.0", "@oxlint/binding-linux-riscv64-gnu": "1.81.0", "@oxlint/binding-linux-riscv64-musl": "1.81.0", "@oxlint/binding-linux-s390x-gnu": "1.81.0", "@oxlint/binding-linux-x64-gnu": "1.81.0", "@oxlint/binding-linux-x64-musl": "1.81.0", "@oxlint/binding-openharmony-arm64": "1.81.0", "@oxlint/binding-win32-arm64-msvc": "1.81.0", "@oxlint/binding-win32-ia32-msvc": "1.81.0", "@oxlint/binding-win32-x64-msvc": "1.81.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-HyrJYqeoOCL0iqaLEzGewGT48ZX99P3hxYh8udAF9RGGIghSamkXE4ClUyBpEDNqasamThgmlPbuMOe7SAZmHg=="],
 
     "p-limit": ["p-limit@7.3.2", "", { "dependencies": { "yocto-queue": "^1.2.1" } }, "sha512-Ll0w3fU24vYpXoZmjjZIee6bJQDgG0oAyo1PdmFYI8UDwJJddaHAypxIH9avUu+t+lSsAwKVsb1jDCMIIChliw=="],
 
@@ -1914,7 +1920,7 @@
 
     "p-queue": ["p-queue@9.3.3", "", { "dependencies": { "eventemitter3": "^5.0.4", "p-timeout": "^7.0.0" } }, "sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA=="],
 
-    "p-retry": ["p-retry@8.0.0", "", { "dependencies": { "is-network-error": "^1.3.0" } }, "sha512-kFVqH1HxOHp8LupNsOys7bSV09VYTRLxarH/mokO4Rqhk6wGi70E0jh4VzvVGXfEVNggHoHLAMWsQqHyU1Ey9A=="],
+    "p-retry": ["p-retry@8.0.1", "", { "dependencies": { "is-network-error": "^1.3.0" } }, "sha512-NAigyu8hfvJe7MsS18mnc4is0MZtau3QMdBklaJKK23oBQb6occO3UPM3vHmTckW8KhfyjMZaUOqdTFEYliHgg=="],
 
     "p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
 
@@ -2072,7 +2078,7 @@
 
     "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
 
-    "rolldown": ["rolldown@1.2.6", "", { "dependencies": { "@oxc-project/types": "=0.147.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm-eabi": "1.2.6", "@rolldown/binding-android-arm64": "1.2.6", "@rolldown/binding-darwin-arm64": "1.2.6", "@rolldown/binding-darwin-x64": "1.2.6", "@rolldown/binding-freebsd-x64": "1.2.6", "@rolldown/binding-linux-arm-gnueabihf": "1.2.6", "@rolldown/binding-linux-arm64-gnu": "1.2.6", "@rolldown/binding-linux-arm64-musl": "1.2.6", "@rolldown/binding-linux-ppc64-gnu": "1.2.6", "@rolldown/binding-linux-s390x-gnu": "1.2.6", "@rolldown/binding-linux-x64-gnu": "1.2.6", "@rolldown/binding-linux-x64-musl": "1.2.6", "@rolldown/binding-openharmony-arm64": "1.2.6", "@rolldown/binding-win32-arm64-msvc": "1.2.6", "@rolldown/binding-win32-x64-msvc": "1.2.6" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA=="],
+    "rolldown": ["rolldown@1.2.7", "", { "dependencies": { "@oxc-project/types": "=0.148.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm-eabi": "1.2.7", "@rolldown/binding-android-arm64": "1.2.7", "@rolldown/binding-darwin-arm64": "1.2.7", "@rolldown/binding-darwin-x64": "1.2.7", "@rolldown/binding-freebsd-x64": "1.2.7", "@rolldown/binding-linux-arm-gnueabihf": "1.2.7", "@rolldown/binding-linux-arm64-gnu": "1.2.7", "@rolldown/binding-linux-arm64-musl": "1.2.7", "@rolldown/binding-linux-ppc64-gnu": "1.2.7", "@rolldown/binding-linux-s390x-gnu": "1.2.7", "@rolldown/binding-linux-x64-gnu": "1.2.7", "@rolldown/binding-linux-x64-musl": "1.2.7", "@rolldown/binding-openharmony-arm64": "1.2.7", "@rolldown/binding-win32-arm64-msvc": "1.2.7", "@rolldown/binding-win32-x64-msvc": "1.2.7" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig=="],
 
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.27.14", "", { "dependencies": { "dts-resolver": "^3.0.0", "get-tsconfig": "5.0.0-beta.5", "obug": "^2.1.4", "yuku-ast": "^0.8.0", "yuku-codegen": "^0.8.0", "yuku-parser": "^0.8.0" }, "peerDependencies": { "@typescript/native-preview": "*", "@volar/typescript": "~2.4.0", "rolldown": "^1.0.0", "typescript": "^5.0.0 || ^6.0.0 || ~7.0.0", "vue-tsc": "~3.2.0 || ~3.3.0" }, "optionalPeers": ["@typescript/native-preview", "@volar/typescript", "typescript", "vue-tsc"] }, "sha512-ZvuDDwoIpRK9RPxDXratCpklFO9QZZWndf/sd0VBFb4LEj0jj07UcHK9OCh7V4XiFz2Z89ziyBC2K6tJiDjrbw=="],
 
@@ -2190,13 +2196,11 @@
 
     "svgo": ["svgo@4.1.0", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^6.0.0", "css-tree": "^3.0.1", "css-what": "^7.0.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "1.6.1" }, "bin": { "svgo": "bin/svgo.js" } }, "sha512-bkxnTg1kSU0guhIBmibA6UUhrQmPVA1XsQLN+ylCd+UWzbnLkySOcXpyk1mrl05f+pcaCx2eHb+sp6BgMZWX+Q=="],
 
-    "tacho": ["tacho@0.6.1", "", { "peerDependencies": { "crossws": "^0.4.0" }, "optionalPeers": ["crossws"] }, "sha512-wxsPS//PgxoBuqbG06T2PCWhUQLgPsh0oOSUtn6uI0omVWIZPY58ooCPqdwrA9GNCiZKbVPfE4FLz2trxTGcag=="],
-
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
     "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
-    "takumi-js": ["takumi-js@2.13.3", "", { "dependencies": { "@takumi-rs/core": "2.13.3", "@takumi-rs/helpers": "2.13.3", "@takumi-rs/wasm": "2.13.3" } }, "sha512-qjqYWO95JYYS06gJQ/eocG+KA3iLbdsauc8zlVGPwFtcMCFeBcSsIigXY+uA+AyUQKWfR67WHK6anSU8shNT9w=="],
+    "takumi-js": ["takumi-js@2.13.4", "", { "dependencies": { "@takumi-rs/core": "2.13.4", "@takumi-rs/helpers": "2.13.4", "@takumi-rs/wasm": "2.13.4" } }, "sha512-xx06TDftLcIWIy80a8QGNvj8AFJYiDp4bjayZVRJN2hiRFeZjzc7fszp56CrsD6xvimayoSOwovJQwpOJGagMQ=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
@@ -2253,6 +2257,8 @@
     "typescript-auto-import-cache": ["typescript-auto-import-cache@0.3.6", "", { "dependencies": { "semver": "^7.3.8" } }, "sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ=="],
 
     "ufo": ["ufo@1.6.4", "", {}, "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA=="],
+
+    "uhyphen": ["uhyphen@0.2.0", "", {}, "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="],
 
     "ultrahtml": ["ultrahtml@1.7.0", "", {}, "sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g=="],
 
@@ -2430,9 +2436,11 @@
 
     "@astrojs/check/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
+    "@astrojs/markdown-remark/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.4", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.3.0", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA=="],
+
     "@astrojs/markdown-satteri/satteri": ["satteri@0.10.5", "", { "dependencies": { "@types/estree-jsx": "^1.0.5", "@types/hast": "^3.0.5", "@types/mdast": "^4.0.4", "@types/unist": "^3.0.3" }, "optionalDependencies": { "@bruits/satteri-darwin-arm64": "0.10.5", "@bruits/satteri-darwin-x64": "0.10.5", "@bruits/satteri-linux-arm64-gnu": "0.10.5", "@bruits/satteri-linux-arm64-musl": "0.10.5", "@bruits/satteri-linux-x64-gnu": "0.10.5", "@bruits/satteri-linux-x64-musl": "0.10.5", "@bruits/satteri-wasm32-wasi": "0.10.5", "@bruits/satteri-win32-arm64-msvc": "0.10.5", "@bruits/satteri-win32-x64-msvc": "0.10.5" } }, "sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ=="],
 
-    "@astrojs/vercel/@vercel/analytics": ["@vercel/analytics@1.6.1", "", { "peerDependencies": { "@remix-run/react": "^2", "@sveltejs/kit": "^1 || ^2", "next": ">= 13", "react": "^18 || ^19 || ^19.0.0-rc", "svelte": ">= 4", "vue": "^3", "vue-router": "^4" }, "optionalPeers": ["@remix-run/react", "@sveltejs/kit", "next", "react", "svelte", "vue", "vue-router"] }, "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg=="],
+    "@astrojs/mdx/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.4", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.3.0", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA=="],
 
     "@asyncapi/converter/js-yaml": ["js-yaml@3.15.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w=="],
 
@@ -2452,7 +2460,7 @@
 
     "@emnapi/wasi-threads/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@happy-dom/global-registrator/@types/node": ["@types/node@26.4.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+    "@happy-dom/global-registrator/@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
     "@ilha/template-oxide-spa/typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
@@ -2518,9 +2526,9 @@
 
     "@tybys/wasm-util/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@types/es-aggregate-error/@types/node": ["@types/node@26.4.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+    "@types/es-aggregate-error/@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
-    "@types/ws/@types/node": ["@types/node@26.4.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+    "@types/ws/@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
     "@vercel/cli-config/zod": ["zod@4.1.11", "", {}, "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg=="],
 
@@ -2536,13 +2544,15 @@
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "blume/@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.3.8", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.4", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "satteri": "^0.10.3" } }, "sha512-n8ItpFTCmlDsVR5+rwDmehSf+jFCYLWmZiisZNGuF7xILqYhsVeBfcha4qgS2Seq3fAc9Tm58ZVrvqFQ6RQgRQ=="],
+
     "blume/get-tsconfig": ["get-tsconfig@4.14.3", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-++QEw4DIY7WGoukz+/+A/8dGYPT9l9yIadnmSgZ8Rjr3YVSVDipQSO9CdnJo9ePqFqUUqh+wk9uIaoiAwsiPkA=="],
 
     "body-parser/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
 
-    "buffer-image-size/@types/node": ["@types/node@26.4.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+    "buffer-image-size/@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
-    "bun-types/@types/node": ["@types/node@26.4.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+    "bun-types/@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
     "cliui/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
@@ -2566,6 +2576,8 @@
 
     "epub-gen-memory/css-select": ["css-select@4.3.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.0.1", "domhandler": "^4.3.1", "domutils": "^2.8.0", "nth-check": "^2.0.1" } }, "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ=="],
 
+    "epub-gen-memory/htmlparser2": ["htmlparser2@7.2.0", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.2", "domutils": "^2.8.0", "entities": "^3.0.1" } }, "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog=="],
+
     "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
@@ -2574,11 +2586,15 @@
 
     "gray-matter/js-yaml": ["js-yaml@3.15.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w=="],
 
-    "happy-dom/@types/node": ["@types/node@26.4.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
+    "happy-dom/@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
-    "htmlparser2/entities": ["entities@3.0.1", "", {}, "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="],
+    "htmlparser2/domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "htmlparser2/domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "katex/commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
+
+    "linkedom/css-select": ["css-select@7.0.0", "", { "dependencies": { "boolbase": "^2.0.0", "css-what": "^8.0.0", "domhandler": "^6.0.1", "domutils": "^4.0.2", "nth-check": "^3.0.1" } }, "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g=="],
 
     "mermaid/katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
 
@@ -2676,6 +2692,10 @@
 
     "@vercel/routing-utils/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
+    "blume/@astrojs/markdown-satteri/@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.4", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.3.0", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA=="],
+
+    "blume/@astrojs/markdown-satteri/satteri": ["satteri@0.10.5", "", { "dependencies": { "@types/estree-jsx": "^1.0.5", "@types/hast": "^3.0.5", "@types/mdast": "^4.0.4", "@types/unist": "^3.0.3" }, "optionalDependencies": { "@bruits/satteri-darwin-arm64": "0.10.5", "@bruits/satteri-darwin-x64": "0.10.5", "@bruits/satteri-linux-arm64-gnu": "0.10.5", "@bruits/satteri-linux-arm64-musl": "0.10.5", "@bruits/satteri-linux-x64-gnu": "0.10.5", "@bruits/satteri-linux-x64-musl": "0.10.5", "@bruits/satteri-wasm32-wasi": "0.10.5", "@bruits/satteri-win32-arm64-msvc": "0.10.5", "@bruits/satteri-win32-x64-msvc": "0.10.5" } }, "sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ=="],
+
     "buffer-image-size/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
@@ -2692,11 +2712,25 @@
 
     "epub-gen-memory/css-select/css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
 
+    "epub-gen-memory/htmlparser2/entities": ["entities@3.0.1", "", {}, "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="],
+
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.1.4", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg=="],
 
     "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "happy-dom/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "htmlparser2/domutils/dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "linkedom/css-select/boolbase": ["boolbase@2.0.0", "", {}, "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA=="],
+
+    "linkedom/css-select/css-what": ["css-what@8.0.0", "", {}, "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw=="],
+
+    "linkedom/css-select/domhandler": ["domhandler@6.0.1", "", { "dependencies": { "domelementtype": "^3.0.0" } }, "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg=="],
+
+    "linkedom/css-select/domutils": ["domutils@4.0.2", "", { "dependencies": { "dom-serializer": "^3.0.0", "domelementtype": "^3.0.0", "domhandler": "^6.0.0" } }, "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA=="],
+
+    "linkedom/css-select/nth-check": ["nth-check@3.0.1", "", { "dependencies": { "boolbase": "^2.0.0" } }, "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ=="],
 
     "mermaid/katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
@@ -2712,11 +2746,39 @@
 
     "@stoplight/spectral-core/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-darwin-arm64": ["@bruits/satteri-darwin-arm64@0.10.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-27KTVl4TJkVahMy/ohyA7qd4938G5UNneFUz/PsScYfpIhj0IVAS23mpcJXdPF44sa6nva198lmV/cKIb2YPyA=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-darwin-x64": ["@bruits/satteri-darwin-x64@0.10.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-IjnLe3nKspq6qaeqGgjT7MT8VrTV74yWRlaag7ZdNsI8TDAYZ0iPxMCo+9KQZHUk5EyVB+reBI/PFWL5KuFw9Q=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-linux-arm64-gnu": ["@bruits/satteri-linux-arm64-gnu@0.10.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-glkYXZCJywjP13v67eAyAMSJdF+ncvEbYvgi/wOtffL9tQ27lr/zsyzUfgs+ovjJ9d8JNQKiXeiArJcX8PJL9w=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-linux-arm64-musl": ["@bruits/satteri-linux-arm64-musl@0.10.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-yWdgG1g17Nh2QyGVlFUxGRa3FEFwiMcpZEyMNWkbM3deC94cmVc+/i9OuyFpdKuWo3GkgoCtYVOoxk1uCnCZIA=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-linux-x64-gnu": ["@bruits/satteri-linux-x64-gnu@0.10.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FVaLoPT1fBgGl0J+AYebyyXJYBachGl8Oyyrf1lye4RTqCB4S0Gwkj1uM9RJyThUOvx5VUmAT1CnNh1SFHA+kw=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-linux-x64-musl": ["@bruits/satteri-linux-x64-musl@0.10.5", "", { "os": "linux", "cpu": "x64" }, "sha512-EHpVAx2bqW3GINHTKkljtxVfQmVDGWIuwOYOP5YghTj+0PkBa2o8oKPRtQ9Kbsr1Fye8jtUcDjhwj2jMNugZKg=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-wasm32-wasi": ["@bruits/satteri-wasm32-wasi@0.10.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.2.3" }, "cpu": "none" }, "sha512-ypz8c/Zmipxp4IoeDa228Gstv6TLzVmNs3yC6wKCoNSOjx1iwpgzu87Y3hTkXFdwChVGU85qeUDuOIarGUZQLw=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-win32-arm64-msvc": ["@bruits/satteri-win32-arm64-msvc@0.10.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-siTV88nb0LRqNpkL2gXboqCwVdq95sLtzMHS1/3eONV2gLbB3NAK46wmSMvCO/yquBvI2lvaFIfd8P12ecsxBw=="],
+
+    "blume/@astrojs/markdown-satteri/satteri/@bruits/satteri-win32-x64-msvc": ["@bruits/satteri-win32-x64-msvc@0.10.5", "", { "os": "win32", "cpu": "x64" }, "sha512-C3IfPvfvMXmlzBxaMPKFS1XiuV9pu2mC7YqkPk7PSvTgPZ8gbdASIpHpztDLvTTQjqZ0z1Ol8tK5X+V6XXC0wQ=="],
+
     "css-select/domutils/dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "htmlparser2/domutils/dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "linkedom/css-select/domhandler/domelementtype": ["domelementtype@3.0.0", "", {}, "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg=="],
+
+    "linkedom/css-select/domutils/dom-serializer": ["dom-serializer@3.1.1", "", { "dependencies": { "domelementtype": "^3.0.0", "domhandler": "^6.0.0", "entities": "^8.0.0" } }, "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw=="],
+
+    "linkedom/css-select/domutils/domelementtype": ["domelementtype@3.0.0", "", {}, "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg=="],
+
     "node-html-parser/css-select/domutils/dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "linkedom/css-select/domutils/dom-serializer/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "node-html-parser/css-select/domutils/dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
   }

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/astro",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Astro integration for Ilha islands",
   "keywords": [
     "astro-component",
@@ -55,10 +55,10 @@
   },
   "devDependencies": {
     "astro": "^7.2.9",
-    "ilha": "0.14.1"
+    "ilha": "0.14.2"
   },
   "peerDependencies": {
     "astro": "^7.2.9",
-    "ilha": "^0.14.1"
+    "ilha": "^0.14.2"
   }
 }

--- a/packages/ilha/README.md
+++ b/packages/ilha/README.md
@@ -117,7 +117,7 @@ if (host) mount(host, Counter, { hydrate: true });
 | `timeout`        | none    | Serialize after this many ms   |
 | `captureActions` | `false` | Probe handlers for server RPCs |
 
-In Node, `renderToString` registers happy-dom when `document` is missing.
+`renderToString` builds HTML without a DOM — no polyfill in Node, Bun, or edge runtimes.
 
 ---
 

--- a/packages/ilha/package.json
+++ b/packages/ilha/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ilha",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Generator-first island UI on Effect",
   "keywords": [
     "effect",
@@ -62,10 +62,8 @@
     "cleanup": "rimraf dist node_modules",
     "test": "bun test"
   },
-  "dependencies": {
-    "@happy-dom/global-registrator": "^20.11.2"
-  },
   "devDependencies": {
+    "@happy-dom/global-registrator": "^20.11.2",
     "effect": "^4.0.0-rc.112"
   },
   "peerDependencies": {

--- a/packages/ilha/src/atom.ts
+++ b/packages/ilha/src/atom.ts
@@ -67,6 +67,19 @@ export function beginPrimitiveFrame(fiber: FiberLocal): void {
   }
   fiber.primitiveI = 0;
   fiber.watchI = 0;
+  const islandFrame = (fiber.islandFrame ??= { i: 0, slots: [] });
+  const usedIslands = islandFrame.i;
+  if (usedIslands < islandFrame.slots.length) {
+    for (let j = usedIslands; j < islandFrame.slots.length; j++) {
+      const slot = islandFrame.slots[j];
+      if (slot) {
+        slot.unmount?.();
+        islandFrame.slots[j] = undefined;
+      }
+    }
+    islandFrame.slots.length = usedIslands;
+  }
+  islandFrame.i = 0;
 }
 
 function readTracked(atom: Atom.Atom<unknown>, registry: AtomRegistry): unknown {

--- a/packages/ilha/src/mount.ts
+++ b/packages/ilha/src/mount.ts
@@ -1,6 +1,8 @@
 import { paint, paintError } from "./paint.ts";
 import { closeFiber, makeFiber, makeRuntime } from "./runtime.ts";
 import { decodeSnapshot, encodeSnapshot } from "./snapshot.ts";
+import { escapeAttr } from "./ssr-dom.ts";
+import { attachSsr } from "./ssr-paint.ts";
 import { runSetup } from "./start.ts";
 import type { Component, IlhaRuntime } from "./types.ts";
 
@@ -15,17 +17,6 @@ export type MountOptions = {
   hydrate?: boolean;
   onError?: (error: unknown) => void;
 };
-
-// SAFETY: escapes values embedded in double-quoted HTML attributes only
-// (`data-ilha-state`, `data-ilha-actions`). Do not reuse for single-quoted or
-// unquoted attribute contexts without a different escaper.
-function escapeAttr(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
 
 function readHydrate(el: Element): unknown[] | undefined {
   const host = el.hasAttribute("data-ilha") ? el : el.querySelector("[data-ilha]");
@@ -43,12 +34,10 @@ function readHydrate(el: Element): unknown[] | undefined {
 function attach(
   el: Element,
   fn: Component,
-  opts?: MountOptions & { ssr?: boolean; ssrCapture?: boolean },
+  opts?: MountOptions,
 ): { unmount: () => void; ready: Promise<void>; runtime: IlhaRuntime } {
   if (!opts?.hydrate) el.innerHTML = "";
   const runtime = makeRuntime({
-    ssr: opts?.ssr,
-    ssrCapture: opts?.ssrCapture,
     hydrate: opts?.hydrate ? readHydrate(el) : undefined,
   });
   let resolve!: () => void;
@@ -82,30 +71,17 @@ export function mount(el: Element, fn: Component, opts?: MountOptions): () => vo
   return attach(el, fn, opts).unmount;
 }
 
-let domReady: Promise<void> | undefined;
-
-function ensureDocument(): Promise<void> {
-  if (typeof globalThis.document !== "undefined") return Promise.resolve();
-  domReady ??= import("@happy-dom/global-registrator").then(({ GlobalRegistrator }) => {
-    if (typeof globalThis.document === "undefined") GlobalRegistrator.register();
-  });
-  return domReady;
-}
-
 export async function renderToString(fn: Component, opts?: RenderToStringOptions): Promise<string> {
-  await ensureDocument();
   const snapshot = opts?.snapshot !== false;
   const markers = opts?.markers !== false;
-  const el = document.createElement("div");
-  const { unmount, ready, runtime } = attach(el, fn, {
-    ssr: true,
+  const { unmount, ready, runtime, root } = attachSsr(fn, {
     ssrCapture: opts?.captureActions === true,
   });
   if (opts?.timeout == null) await ready;
   else {
     await Promise.race([ready, new Promise<void>((r) => setTimeout(r, opts.timeout))]);
   }
-  let inner = el.innerHTML;
+  let inner = root.innerHTML;
   const actions = runtime.ssrActions;
   if (Object.keys(actions).length > 0) {
     inner = `<template data-ilha-actions="${escapeAttr(JSON.stringify(actions))}"></template>${inner}`;

--- a/packages/ilha/src/paint.ts
+++ b/packages/ilha/src/paint.ts
@@ -118,6 +118,8 @@ function unwrap(value: unknown, keep: View | undefined): View | typeof KEEP {
 
 function paintHole(fiber: FiberLocal, view: View | typeof KEEP): void {
   if (view === KEEP) return;
+  const frame = (fiber.islandFrame ??= { i: 0, slots: [] });
+  frame.i = 0;
   const list = Array.isArray(view) ? view : null;
   if (list && list.length > 0 && list.every((v) => isVNode(v) && v.key != null)) {
     keyedPaintHole(fiber, list as import("./types.ts").VNode[]);
@@ -322,7 +324,7 @@ function materialize(view: View, fiber: FiberLocal): Node[] {
       const props = { ...view.props, children: view.children };
       const type = view.type as ((p: Record<string, unknown>) => unknown) & Record<symbol, unknown>;
       if (type[ISLAND] === true) {
-        const frame = fiber.islandFrame!;
+        const frame = (fiber.islandFrame ??= { i: 0, slots: [] });
         const i = frame.i++;
         const existing = frame.slots[i];
         if (

--- a/packages/ilha/src/runtime.ts
+++ b/packages/ilha/src/runtime.ts
@@ -17,6 +17,18 @@ export type Hole = {
   holeFiber?: FiberLocal;
 };
 
+export type IslandSlot = {
+  type: unknown;
+  host: Element;
+  updateProps?: (props?: Record<string, unknown>) => void;
+  unmount?: () => void;
+};
+
+export type IslandFrame = {
+  i: number;
+  slots: (IslandSlot | undefined)[];
+};
+
 export interface FiberLocal {
   root: ParentNode;
   registry: AtomRegistry;
@@ -32,6 +44,7 @@ export interface FiberLocal {
   primitives?: import("effect/unstable/reactivity/Atom").Atom<unknown>[];
   watchI?: number;
   watchSlots?: import("./watch.ts").WatchSlot[];
+  islandFrame?: IslandFrame;
   renderSub?: () => void;
   trackRestore?: () => void;
   propsBox?: { current: Record<string, unknown> };

--- a/packages/ilha/src/ssr-dom.ts
+++ b/packages/ilha/src/ssr-dom.ts
@@ -1,0 +1,129 @@
+const VOID = new Set([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+]);
+
+export function escapeText(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+// SAFETY: escapes values embedded in double-quoted HTML attributes only.
+// Do not reuse for single-quoted or unquoted attribute contexts.
+export function escapeAttr(s: string): string {
+  return escapeText(s).replace(/"/g, "&quot;");
+}
+
+export type SsrText = { kind: "text"; text: string };
+
+export type SsrEl = {
+  kind: "element";
+  tag: string;
+  attrs: Map<string, string>;
+  children: SsrNode[];
+  isConnected: boolean;
+  tagName: string;
+  localName: string;
+  setAttribute(name: string, value: string): void;
+  getAttribute(name: string): string | null;
+  removeAttribute(name: string): void;
+  hasAttribute(name: string): boolean;
+  replaceChildren(...nodes: SsrNode[]): void;
+  appendChild(node: SsrNode): void;
+  textContent: string;
+};
+
+export type SsrNode = SsrText | SsrEl;
+
+export type SsrRoot = {
+  kind: "root";
+  children: SsrNode[];
+  appendChild(node: SsrNode): void;
+  replaceChildren(): void;
+  readonly innerHTML: string;
+};
+
+export function createSsrText(text: string): SsrText {
+  return { kind: "text", text };
+}
+
+export function createSsrElement(tag: string): SsrEl {
+  const lower = tag.toLowerCase();
+  const children: SsrNode[] = [];
+  const el: SsrEl = {
+    kind: "element",
+    tag: lower,
+    attrs: new Map(),
+    children,
+    isConnected: true,
+    tagName: lower.toUpperCase(),
+    localName: lower,
+    setAttribute(name, value) {
+      el.attrs.set(name, value);
+    },
+    getAttribute(name) {
+      return el.attrs.has(name) ? el.attrs.get(name)! : null;
+    },
+    removeAttribute(name) {
+      el.attrs.delete(name);
+    },
+    hasAttribute(name) {
+      return el.attrs.has(name);
+    },
+    replaceChildren(...nodes) {
+      children.length = 0;
+      children.push(...nodes);
+    },
+    appendChild(node) {
+      children.push(node);
+    },
+    get textContent() {
+      return children.map((n) => (n.kind === "text" ? n.text : n.textContent)).join("");
+    },
+    set textContent(value) {
+      children.length = 0;
+      children.push(createSsrText(value));
+    },
+  };
+  return el;
+}
+
+export function createSsrRoot(): SsrRoot {
+  const children: SsrNode[] = [];
+  return {
+    kind: "root",
+    children,
+    appendChild(node) {
+      children.push(node);
+    },
+    replaceChildren() {
+      children.length = 0;
+    },
+    get innerHTML() {
+      return children.map(serializeNode).join("");
+    },
+  };
+}
+
+export function serializeNode(node: SsrNode): string {
+  if (node.kind === "text") return escapeText(node.text);
+  const parts: string[] = [];
+  for (const [name, value] of node.attrs) {
+    parts.push(`${name}="${escapeAttr(value)}"`);
+  }
+  const attr = parts.length > 0 ? ` ${parts.join(" ")}` : "";
+  const tag = node.tag;
+  if (VOID.has(tag)) return `<${tag}${attr}>`;
+  return `<${tag}${attr}>${node.children.map(serializeNode).join("")}</${tag}>`;
+}

--- a/packages/ilha/src/ssr-dom.ts
+++ b/packages/ilha/src/ssr-dom.ts
@@ -120,8 +120,11 @@ export function createSsrRoot(): SsrRoot {
 }
 
 function serializeRawText(tag: string, text: string): string {
-  // Reject content that would close the element early (`</script`, `</style`).
-  if (new RegExp(`</${tag}\\b`, "i").test(text)) return "";
+  // Raw-text tags cannot HTML-escape children; a matching closer would end the
+  // element early. Fail loudly so callers do not ship truncated markup.
+  if (new RegExp(`</${tag}\\b`, "i").test(text)) {
+    throw new Error(`ilha: unsafe raw text in <${tag}> (contains "</${tag}")`);
+  }
   return text;
 }
 

--- a/packages/ilha/src/ssr-dom.ts
+++ b/packages/ilha/src/ssr-dom.ts
@@ -15,6 +15,9 @@ const VOID = new Set([
   "wbr",
 ]);
 
+/** Tags whose children are raw text — do not HTML-escape content. */
+const RAW_TEXT = new Set(["script", "style"]);
+
 export function escapeText(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
@@ -116,6 +119,12 @@ export function createSsrRoot(): SsrRoot {
   };
 }
 
+function serializeRawText(tag: string, text: string): string {
+  // Reject content that would close the element early (`</script`, `</style`).
+  if (new RegExp(`</${tag}\\b`, "i").test(text)) return "";
+  return text;
+}
+
 export function serializeNode(node: SsrNode): string {
   if (node.kind === "text") return escapeText(node.text);
   const parts: string[] = [];
@@ -125,5 +134,9 @@ export function serializeNode(node: SsrNode): string {
   const attr = parts.length > 0 ? ` ${parts.join(" ")}` : "";
   const tag = node.tag;
   if (VOID.has(tag)) return `<${tag}${attr}>`;
+  if (RAW_TEXT.has(tag)) {
+    const raw = serializeRawText(tag, node.textContent);
+    return `<${tag}${attr}>${raw}</${tag}>`;
+  }
   return `<${tag}${attr}>${node.children.map(serializeNode).join("")}</${tag}>`;
 }

--- a/packages/ilha/src/ssr-paint.ts
+++ b/packages/ilha/src/ssr-paint.ts
@@ -132,6 +132,8 @@ function unwrap(value: unknown, keep: View | undefined): View | typeof KEEP {
 
 function paintHole(fiber: FiberLocal, view: View | typeof KEEP): void {
   if (view === KEEP) return;
+  const frame = (fiber.islandFrame ??= { i: 0, slots: [] });
+  frame.i = 0;
   const list = Array.isArray(view) ? view : null;
   if (list && list.length > 0 && list.every((v) => isVNode(v) && v.key != null)) {
     keyedPaintHole(fiber, list as import("./types.ts").VNode[]);
@@ -297,7 +299,7 @@ function materialize(view: View, fiber: FiberLocal): SsrNode[] {
       const props = { ...view.props, children: view.children };
       const type = view.type as ((p: Record<string, unknown>) => unknown) & Record<symbol, unknown>;
       if (type[ISLAND] === true) {
-        const frame = fiber.islandFrame!;
+        const frame = (fiber.islandFrame ??= { i: 0, slots: [] });
         const i = frame.i++;
         const existing = frame.slots[i];
         if (

--- a/packages/ilha/src/ssr-paint.ts
+++ b/packages/ilha/src/ssr-paint.ts
@@ -4,39 +4,65 @@ import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 
 import { isAtomHandle } from "./atom.ts";
 import { failureMessage } from "./errors.ts";
-import { bindEvents, isEventProp } from "./events.ts";
-import { KEY_ATTR, SLOT_ATTR, morphInner } from "./morph.ts";
-import { closeFiber, makeFiber, withFiber, type FiberLocal, type Hole } from "./runtime.ts";
+import { eventTypeFromProp, isEventProp } from "./events.ts";
+import { closeFiber, makeFiber, makeRuntime, withFiber, type FiberLocal } from "./runtime.ts";
 import { isSafeUrlAttrValue, isUrlAttributeName, serializeStyleAttr } from "./security.ts";
+import {
+  createSsrElement,
+  createSsrRoot,
+  createSsrText,
+  type SsrEl,
+  type SsrNode,
+  type SsrRoot,
+} from "./ssr-dom.ts";
 import { runSetup } from "./start.ts";
-import { Fragment, type Component, type View } from "./types.ts";
+import { Fragment, type Component, type IlhaRuntime, type View } from "./types.ts";
 import { isSetupFn, isVNode } from "./vnode.ts";
+
+const KEY_ATTR = "data-ilha-key";
+const SLOT_ATTR = "data-ilha-slot";
 
 const ISLAND = Symbol.for("ilha.island");
 const ISLAND_MOUNT_INTERNAL = Symbol.for("ilha.islandMountInternal");
 const ISLAND_SLOT_TAG = Symbol.for("ilha.islandSlotTag");
 
-function insert(fiber: FiberLocal, nodes: Node[]): void {
-  for (const n of nodes) fiber.root.appendChild(n);
+type SsrHost = SsrRoot | SsrEl;
+
+function insert(fiber: FiberLocal, nodes: SsrNode[]): void {
+  const root = fiber.root as SsrHost;
+  for (const n of nodes) root.appendChild(n);
 }
 
-function disposeHoles(fiber: FiberLocal, opts?: { morph?: boolean }): void {
-  const keep: Hole[] = [];
-  for (const h of fiber.holes) {
-    if (opts?.morph && h.keepOnMorph) {
-      keep.push(h);
-      continue;
-    }
-    h.dispose();
-  }
-  fiber.holes = keep;
+function disposeHoles(fiber: FiberLocal): void {
+  for (const h of fiber.holes) h.dispose();
+  fiber.holes = [];
 }
 
 function skip(x: unknown): boolean {
   return x === null || x === undefined || typeof x === "boolean";
 }
 
-function applyProps(el: Element, props: Record<string, unknown>, fiber: FiberLocal): void {
+function bindSsrEvents(el: SsrEl, props: Record<string, unknown>, fiber: FiberLocal): void {
+  const seen = new Set<string>();
+  for (const key of Object.keys(props)) {
+    const type = eventTypeFromProp(key);
+    if (!type || seen.has(type)) continue;
+    seen.add(type);
+    const fn = props[key];
+    if (typeof fn !== "function") continue;
+    const branded = (fn as unknown as Record<symbol, { k?: string; a?: unknown[] }>)[
+      Symbol.for("ilha.actionCall")
+    ];
+    const rec = branded?.k ? { k: branded.k, a: branded.a ?? [] } : undefined;
+    if (!rec) continue;
+    const id = `${type}:${fiber.runtime.ssrEventI++}`;
+    fiber.runtime.ssrActions[id] = rec;
+    const existing = el.getAttribute("data-ilha-on");
+    el.setAttribute("data-ilha-on", existing ? `${existing},${id}` : id);
+  }
+}
+
+function applyProps(el: SsrEl, props: Record<string, unknown>, fiber: FiberLocal): void {
   for (const [k, v] of Object.entries(props)) {
     if (k === "children" || k === "key" || k === "ref") continue;
     if (k === "className") {
@@ -53,34 +79,22 @@ function applyProps(el: Element, props: Record<string, unknown>, fiber: FiberLoc
         typeof v === "string" || typeof v === "object"
           ? serializeStyleAttr(v as string | Record<string, unknown>)
           : "";
-      if (css) (el as HTMLElement).style.cssText = css;
+      if (css) el.setAttribute("style", css);
       continue;
     }
     if (isEventProp(k)) continue;
     if (/^on[A-Z]/.test(k)) continue;
     if (k === "value" || k === "checked" || k === "selected") {
       const setProp = (x: unknown) => {
-        const node = el as HTMLElement & {
-          value?: string;
-          checked?: boolean;
-          selected?: boolean;
-        };
-        if (k === "value") node.value = String(x ?? "");
+        if (k === "value") el.setAttribute("value", String(x ?? ""));
         else if (k === "checked") {
-          node.checked = Boolean(x);
-          if (fiber.runtime.ssr) {
-            if (x) el.setAttribute("checked", "");
-            else el.removeAttribute("checked");
-          }
-        } else node.selected = Boolean(x);
+          if (x) el.setAttribute("checked", "");
+          else el.removeAttribute("checked");
+        } else if (x) el.setAttribute("selected", "");
+        else el.removeAttribute("selected");
       };
       if (isAtomHandle(v)) {
-        const elAny = el as Element & { __ilhaVal?: unknown };
-        if (elAny.__ilhaVal === v) continue;
-        elAny.__ilhaVal = v;
-        const unsub = fiber.registry.subscribe(v.atom, setProp, {
-          immediate: true,
-        });
+        const unsub = fiber.registry.subscribe(v.atom, setProp, { immediate: true });
         fiber.holes.push({ dispose: unsub });
       } else setProp(v);
       continue;
@@ -93,10 +107,10 @@ function applyProps(el: Element, props: Record<string, unknown>, fiber: FiberLoc
       el.setAttribute(k, str);
     }
   }
-  bindEvents(el, props, fiber);
+  bindSsrEvents(el, props, fiber);
   const ref = props.ref;
   if (typeof ref === "function") {
-    ref(el);
+    ref(el as unknown as Element);
     fiber.holes.push({ dispose: () => ref(null) });
   }
 }
@@ -124,7 +138,7 @@ function paintHole(fiber: FiberLocal, view: View | typeof KEEP): void {
     return;
   }
   disposeHoles(fiber);
-  if (fiber.root instanceof Element) fiber.root.replaceChildren();
+  (fiber.root as SsrHost).replaceChildren();
   insert(fiber, materialize(view, fiber));
 }
 
@@ -135,13 +149,13 @@ function keyedPaintHole(fiber: FiberLocal, views: import("./types.ts").VNode[]):
     if (!keep.has(k)) closeFiber(h);
   }
   const next = new Map<string, FiberLocal>();
-  const nodes: Node[] = [];
+  const nodes: SsrNode[] = [];
   for (const v of views) {
     const k = String(v.key);
     const reuse = prev.get(k);
     if (reuse && !reuse.closed) {
       next.set(k, reuse);
-      nodes.push(reuse.root as Node);
+      nodes.push(reuse.root as SsrNode);
       continue;
     }
     const made = materialize(v, fiber);
@@ -150,30 +164,21 @@ function keyedPaintHole(fiber: FiberLocal, views: import("./types.ts").VNode[]):
     nodes.push(...made);
   }
   fiber.keyedHoles = next;
-  if (fiber.root instanceof Element) fiber.root.replaceChildren();
+  (fiber.root as SsrHost).replaceChildren();
   insert(fiber, nodes);
 }
 
-function openHole(parent: FiberLocal): { fiber: FiberLocal; nodes: Element[] } {
+function openHole(parent: FiberLocal): { fiber: FiberLocal; nodes: SsrEl[] } {
   const id = parent.runtime.nextHole();
-  const host = document.createElement("span");
+  const host = createSsrElement("span");
   host.setAttribute(SLOT_ATTR, String(id));
-  host.style.display = "contents";
-  const child = makeFiber(
-    parent.runtime,
-    host,
-    (f, v) => {
-      disposeHoles(f);
-      if (f.root instanceof Element) f.root.replaceChildren();
-      insert(f, materialize(v, f));
+  host.setAttribute("style", "display:contents");
+  const child = makeFiber(parent.runtime, host as unknown as ParentNode, paint, {
+    onFail: (e) => {
+      console.error(e);
+      paintHole(child, errorView(e));
     },
-    {
-      onFail: (e) => {
-        console.error(e);
-        paintHole(child, errorView(e));
-      },
-    },
-  );
+  });
   return { fiber: child, nodes: [host] };
 }
 
@@ -189,48 +194,20 @@ function errorView(e: unknown): View {
 function findReusableAtomHost(
   fiber: FiberLocal,
   atom: import("effect/unstable/reactivity/Atom").Atom<unknown>,
-): { host: Element; hole: FiberLocal } | undefined {
+): { host: SsrEl; hole: FiberLocal } | undefined {
   for (const h of fiber.holes) {
-    if (h.atom === atom && h.host?.isConnected && h.holeFiber && !h.holeFiber.closed) {
-      return { host: h.host, hole: h.holeFiber };
+    const host = h.host as SsrEl | undefined;
+    if (h.atom === atom && host?.isConnected && h.holeFiber && !h.holeFiber.closed) {
+      return { host, hole: h.holeFiber };
     }
   }
 }
 
-function refreshAtomHost(
-  fiber: FiberLocal,
-  atom: import("effect/unstable/reactivity/Atom").Atom<unknown>,
-  host: Element,
-  hole: FiberLocal,
-): void {
-  if (hole.closed || !host.isConnected) return;
-  const next = unwrap(fiber.registry.get(atom), undefined);
-  if (next === KEEP) return;
-  paintHole(hole, next as View);
-}
-
-function refreshAllAtomHosts(fiber: FiberLocal): void {
-  for (const h of fiber.holes) {
-    if (h.atom && h.host && h.holeFiber) {
-      refreshAtomHost(fiber, h.atom, h.host, h.holeFiber);
-    }
-  }
-}
-
-function pruneDisconnectedAtomHoles(fiber: FiberLocal): void {
-  fiber.holes = fiber.holes.filter((h) => {
-    if (!h.atom || !h.host || !h.holeFiber) return true;
-    if (h.host.isConnected) return true;
-    h.dispose();
-    return false;
-  });
-}
-
-function atomHostPlaceholder(host: Element): Element {
-  const placeholder = document.createElement("span");
+function atomHostPlaceholder(host: SsrEl): SsrEl {
+  const placeholder = createSsrElement("span");
   const slot = host.getAttribute(SLOT_ATTR);
   if (slot !== null) placeholder.setAttribute(SLOT_ATTR, slot);
-  placeholder.style.display = "contents";
+  placeholder.setAttribute("style", "display:contents");
   return placeholder;
 }
 
@@ -240,32 +217,31 @@ function trackHole(
   extra?: () => void,
   meta?: {
     atom?: import("effect/unstable/reactivity/Atom").Atom<unknown>;
-    host?: Element;
+    host?: SsrEl;
     keyed?: boolean;
   },
 ): void {
   parent.holes.push({
     keepOnMorph: !!(meta?.atom && meta?.host) || !!meta?.keyed,
     atom: meta?.atom,
-    host: meta?.host,
+    host: meta?.host as Element | undefined,
     holeFiber: hole,
     dispose() {
       extra?.();
+      if (meta?.host) meta.host.isConnected = false;
       closeFiber(hole);
     },
   });
 }
 
-function materialize(view: View, fiber: FiberLocal): Node[] {
+function materialize(view: View, fiber: FiberLocal): SsrNode[] {
   if (skip(view)) return [];
   if (typeof view === "string" || typeof view === "number" || typeof view === "bigint") {
-    return [document.createTextNode(String(view))];
+    return [createSsrText(String(view))];
   }
   if (isAtomHandle(view)) {
     const reused = findReusableAtomHost(fiber, view.atom);
-    if (reused) {
-      return [atomHostPlaceholder(reused.host)];
-    }
+    if (reused) return [atomHostPlaceholder(reused.host)];
 
     const { fiber: hole, nodes } = openHole(fiber);
     const host = nodes[0]!;
@@ -290,9 +266,8 @@ function materialize(view: View, fiber: FiberLocal): Node[] {
   }
   if (Stream.isStream(view)) {
     const { fiber: hole, nodes } = openHole(fiber);
-    const src = fiber.runtime.ssr ? view.pipe(Stream.take(1)) : view;
     hole.run(
-      Stream.runForEach(src, (v) =>
+      Stream.runForEach(view.pipe(Stream.take(1)), (v) =>
         Effect.sync(() => {
           if (!hole.closed) paintHole(hole, v);
         }),
@@ -303,7 +278,7 @@ function materialize(view: View, fiber: FiberLocal): Node[] {
           }),
         ),
       ) as never,
-      fiber.runtime.ssr ? () => {} : undefined,
+      () => {},
     );
     trackHole(fiber, hole);
     return nodes;
@@ -328,16 +303,16 @@ function materialize(view: View, fiber: FiberLocal): Node[] {
         if (
           existing &&
           existing.type === type &&
-          existing.host.isConnected &&
+          (existing.host as SsrEl).isConnected &&
           typeof existing.updateProps === "function"
         ) {
           existing.updateProps(props);
-          return [existing.host];
+          return [existing.host as SsrEl];
         }
         existing?.unmount?.();
         const tag =
           typeof type[ISLAND_SLOT_TAG] === "string" ? (type[ISLAND_SLOT_TAG] as string) : "div";
-        const el = document.createElement(tag);
+        const el = createSsrElement(tag);
         el.setAttribute("data-ilha", "");
         const mountFn = type[ISLAND_MOUNT_INTERNAL];
         if (typeof mountFn === "function") {
@@ -349,10 +324,10 @@ function materialize(view: View, fiber: FiberLocal): Node[] {
               unmount?: () => void;
               updateProps?: (props?: Record<string, unknown>) => void;
             }
-          )(el, props);
+          )(el as unknown as Element, props);
           const slot = {
             type,
-            host: el,
+            host: el as unknown as Element,
             updateProps: handle?.updateProps,
             unmount: handle?.unmount,
           };
@@ -360,6 +335,7 @@ function materialize(view: View, fiber: FiberLocal): Node[] {
           fiber.holes.push({
             keepOnMorph: true,
             dispose: () => {
+              el.isConnected = false;
               handle?.unmount?.();
               if (frame.slots[i] === slot) frame.slots[i] = undefined;
             },
@@ -375,7 +351,7 @@ function materialize(view: View, fiber: FiberLocal): Node[] {
         if (next && typeof (next as Promise<unknown>).then !== "function" && !isSetupFn(next)) {
           reuse.paint(next as View);
         }
-        return [reuse.root as Node];
+        return [reuse.root as SsrNode];
       }
       const { fiber: hole, nodes } = openHole(fiber);
       hole.propsBox = { current: props };
@@ -390,13 +366,13 @@ function materialize(view: View, fiber: FiberLocal): Node[] {
       trackHole(fiber, hole, undefined, k ? { keyed: true } : undefined);
       return nodes;
     }
-    const el = document.createElement(view.type);
+    const el = createSsrElement(view.type);
     if (view.key != null) el.setAttribute(KEY_ATTR, String(view.key));
     applyProps(el, view.props, fiber);
     fiber.keyedHoles ??= new Map();
     const childFiber: FiberLocal = {
       ...fiber,
-      root: el,
+      root: el as unknown as ParentNode,
       holes: fiber.holes,
       keyedHoles: fiber.keyedHoles,
     };
@@ -411,69 +387,54 @@ function materialize(view: View, fiber: FiberLocal): Node[] {
   ) {
     return [...(view as Iterable<View>)].flatMap((c) => materialize(c, fiber));
   }
-  return [document.createTextNode(String(view))];
-}
-
-function canHydrate(fiber: FiberLocal, view: View): boolean {
-  if (!isVNode(view) || typeof view.type !== "string") return false;
-  const el = fiber.root.firstElementChild;
-  return !!el && el.tagName === view.type.toUpperCase();
+  return [createSsrText(String(view))];
 }
 
 export function paint(fiber: FiberLocal, view: View): void {
   fiber.islandFrame ??= { i: 0, slots: [] };
-  if (fiber.hydrate) {
-    if (canHydrate(fiber, view)) {
-      const el = fiber.root.firstElementChild!;
-      fiber.hydrate = false;
-      fiber.liveEl = el;
-      applyProps(el, (view as import("./types.ts").VNode).props, fiber);
-      const childFiber: FiberLocal = {
-        ...fiber,
-        root: el,
-        holes: fiber.holes,
-      };
-      el.replaceChildren();
-      for (const c of (view as import("./types.ts").VNode).children) {
-        for (const n of materialize(c, childFiber)) el.appendChild(n);
-      }
-      return;
-    } else {
-      console.warn("[ilha] hydrate mismatch, full mount");
-      fiber.hydrate = false;
-      if (fiber.root instanceof Element) fiber.root.replaceChildren();
-    }
-  }
-  if (
-    fiber.liveEl &&
-    isVNode(view) &&
-    typeof view.type === "string" &&
-    fiber.liveEl.localName === view.type
-  ) {
-    disposeHoles(fiber, { morph: true });
-    applyProps(fiber.liveEl, view.props, fiber);
-    const tmp = document.createElement(fiber.liveEl.localName);
-    for (const c of view.children) for (const n of materialize(c, fiber)) tmp.appendChild(n);
-    morphInner(fiber.liveEl, tmp);
-    refreshAllAtomHosts(fiber);
-    pruneDisconnectedAtomHoles(fiber);
-    return;
-  }
+  // SSR rebuilds the whole tree each paint — no DOM morph identity to preserve.
   disposeHoles(fiber);
-  if (fiber.root instanceof Element && fiber.root.childNodes.length > 0) {
-    const tmp = document.createElement("div");
-    for (const n of materialize(view, fiber)) tmp.appendChild(n);
-    morphInner(fiber.root as Element, tmp);
-    const first = fiber.root.firstElementChild;
-    if (first) fiber.liveEl = first;
-    return;
-  }
+  (fiber.root as SsrHost).replaceChildren();
   insert(fiber, materialize(view, fiber));
-  const first = fiber.root instanceof Element ? fiber.root.firstElementChild : null;
-  if (first) fiber.liveEl = first;
 }
 
 export function paintError(fiber: FiberLocal, e: unknown): void {
   console.error(e);
   paint(fiber, errorView(e));
+}
+
+export function attachSsr(
+  fn: Component,
+  opts?: { onError?: (error: unknown) => void; ssrCapture?: boolean },
+): { root: SsrRoot; ready: Promise<void>; runtime: IlhaRuntime; unmount: () => void } {
+  const root = createSsrRoot();
+  const runtime = makeRuntime({
+    ssr: true,
+    ssrCapture: opts?.ssrCapture === true,
+  });
+  let resolve!: () => void;
+  const ready = new Promise<void>((r) => {
+    resolve = r;
+  });
+  const fiber = makeFiber(runtime, root as unknown as ParentNode, paint, {
+    onFail: (e) => {
+      opts?.onError?.(e);
+      paintError(fiber, e);
+      resolve();
+    },
+  });
+  runtime.begin();
+  runtime.setIdle(resolve);
+  runSetup(fiber, fn);
+  runtime.end();
+  return {
+    root,
+    ready,
+    runtime,
+    unmount() {
+      closeFiber(fiber);
+      runtime.close();
+      root.replaceChildren();
+    },
+  };
 }

--- a/packages/ilha/tests/island-props.test.ts
+++ b/packages/ilha/tests/island-props.test.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "bun:test";
+
+import * as Effect from "effect/Effect";
+
+import { atom, h, mount } from "../src/index.ts";
+
+test("island updateProps runs when parent passes new props", async () => {
+  const ISLAND = Symbol.for("ilha.island");
+  const MOUNT = Symbol.for("ilha.islandMountInternal");
+  const TAG = Symbol.for("ilha.islandSlotTag");
+  const Proxy = Object.assign(() => "", {
+    [ISLAND]: true,
+    [TAG]: "section",
+    [MOUNT]: (host: Element, props?: Record<string, unknown>) => {
+      host.textContent = String(props?.name ?? "");
+      return {
+        unmount() {
+          host.textContent = "";
+        },
+        updateProps(next?: Record<string, unknown>) {
+          host.textContent = String(next?.name ?? "");
+        },
+      };
+    },
+  });
+
+  const App = function* () {
+    const name = atom("Ilha");
+    yield h("div", null, h(Proxy as never, { name: name() }));
+    yield Effect.sleep(40);
+    yield h("div", null, h(Proxy as never, { name: "Ada" }));
+  };
+
+  const el = document.createElement("div");
+  document.body.append(el);
+  mount(el, App);
+  await Bun.sleep(5);
+  expect(el.querySelector("section")?.textContent).toBe("Ilha");
+  await Bun.sleep(60);
+  expect(el.querySelector("section")?.textContent).toBe("Ada");
+  el.remove();
+});
+
+test("island updateProps runs when a sync parent rerenders on atom change", async () => {
+  const ISLAND = Symbol.for("ilha.island");
+  const MOUNT = Symbol.for("ilha.islandMountInternal");
+  const TAG = Symbol.for("ilha.islandSlotTag");
+  const Proxy = Object.assign(() => "", {
+    [ISLAND]: true,
+    [TAG]: "section",
+    [MOUNT]: (host: Element, props?: Record<string, unknown>) => {
+      host.textContent = String(props?.name ?? "");
+      return {
+        unmount() {
+          host.textContent = "";
+        },
+        updateProps(next?: Record<string, unknown>) {
+          host.textContent = String(next?.name ?? "");
+        },
+      };
+    },
+  });
+
+  const App = () => {
+    const name = atom("Ilha");
+    return h("div", null, [
+      h("button", { onclick: () => name.set("Ada") }, "go"),
+      h(Proxy as never, { name: name() }),
+    ]);
+  };
+
+  const el = document.createElement("div");
+  document.body.append(el);
+  mount(el, App);
+  await Bun.sleep(5);
+  expect(el.querySelector("section")?.textContent).toBe("Ilha");
+  el.querySelector("button")!.click();
+  await Bun.sleep(5);
+  expect(el.querySelector("section")?.textContent).toBe("Ada");
+  el.remove();
+});
+
+test("island updateProps survives nested element materialization", async () => {
+  const ISLAND = Symbol.for("ilha.island");
+  const MOUNT = Symbol.for("ilha.islandMountInternal");
+  const TAG = Symbol.for("ilha.islandSlotTag");
+  const Proxy = Object.assign(() => "", {
+    [ISLAND]: true,
+    [TAG]: "section",
+    [MOUNT]: (host: Element, _props?: Record<string, unknown>) => {
+      host.textContent = "mounted";
+      return {
+        unmount() {
+          host.textContent = "";
+        },
+        updateProps(next?: Record<string, unknown>) {
+          host.textContent = String(next?.name ?? "");
+        },
+      };
+    },
+  });
+
+  const App = () => {
+    const name = atom("Ilha");
+    return h("div", { class: "card" }, [
+      h("div", { class: "card-body" }, h(Proxy as never, { name: name() })),
+      h("button", { onclick: () => name.set("Ada") }, "go"),
+    ]);
+  };
+
+  const el = document.createElement("div");
+  document.body.append(el);
+  mount(el, App);
+  await Bun.sleep(5);
+  expect(el.querySelector("section")?.textContent).toBe("mounted");
+  el.querySelector("button")!.click();
+  await Bun.sleep(5);
+  expect(el.querySelector("section")?.textContent).toBe("Ada");
+  el.remove();
+});

--- a/packages/ilha/tests/security.test.ts
+++ b/packages/ilha/tests/security.test.ts
@@ -108,6 +108,26 @@ test("rejects javascript: href during renderToString", async () => {
   expect(html).not.toContain("javascript:");
 });
 
+test("script and style SSR keep raw text and reject closing-tag breakouts", async () => {
+  const ok = await renderToString(() => h("script", null, "const x = 1 < 2 && true;"), {
+    markers: false,
+    snapshot: false,
+  });
+  expect(ok).toContain("<script>const x = 1 < 2 && true;</script>");
+
+  const style = await renderToString(() => h("style", null, "a > b { color: red; }"), {
+    markers: false,
+    snapshot: false,
+  });
+  expect(style).toContain("<style>a > b { color: red; }</style>");
+
+  const bad = await renderToString(
+    () => h("script", null, "alert(1)</script><img src=x onerror=alert(1)>"),
+    { markers: false, snapshot: false },
+  );
+  expect(bad).toBe("<script></script>");
+});
+
 test("never serializes function handlers as attributes", async () => {
   const html = await renderToString(() =>
     h("button", { onMouseOver: () => undefined, onClick: () => undefined }, "x"),

--- a/packages/ilha/tests/security.test.ts
+++ b/packages/ilha/tests/security.test.ts
@@ -103,6 +103,11 @@ test("rejects css url escapes and data urls in string styles", () => {
   expect(dataUrl.style.background).toBe("");
 });
 
+test("rejects javascript: href during renderToString", async () => {
+  const html = await renderToString(() => h("a", { href: "javascript:alert(1)" }, "x"));
+  expect(html).not.toContain("javascript:");
+});
+
 test("never serializes function handlers as attributes", async () => {
   const html = await renderToString(() =>
     h("button", { onMouseOver: () => undefined, onClick: () => undefined }, "x"),

--- a/packages/ilha/tests/security.test.ts
+++ b/packages/ilha/tests/security.test.ts
@@ -121,11 +121,12 @@ test("script and style SSR keep raw text and reject closing-tag breakouts", asyn
   });
   expect(style).toContain("<style>a > b { color: red; }</style>");
 
-  const bad = await renderToString(
-    () => h("script", null, "alert(1)</script><img src=x onerror=alert(1)>"),
-    { markers: false, snapshot: false },
-  );
-  expect(bad).toBe("<script></script>");
+  expect(
+    renderToString(() => h("script", null, "alert(1)</script><img src=x onerror=alert(1)>"), {
+      markers: false,
+      snapshot: false,
+    }),
+  ).rejects.toThrow(/unsafe raw text in <script>/);
 });
 
 test("never serializes function handlers as attributes", async () => {

--- a/packages/ilha/tests/ssr.test.ts
+++ b/packages/ilha/tests/ssr.test.ts
@@ -12,6 +12,18 @@ function branded(key: string, args: unknown[]) {
   return handler;
 }
 
+test("renderToString works without document", async () => {
+  const doc = globalThis.document;
+  // @ts-expect-error test isolation
+  delete globalThis.document;
+  try {
+    const html = await renderToString(() => h("p", null, "edge"));
+    expect(html).toContain(">edge<");
+  } finally {
+    globalThis.document = doc;
+  }
+});
+
 test("renderToString paints text without handlers", async () => {
   const App = async () => {
     const count = atom(0);

--- a/packages/ilha/tsdown.config.ts
+++ b/packages/ilha/tsdown.config.ts
@@ -6,5 +6,5 @@ export default defineConfig({
   platform: "neutral",
   dts: true,
   minify: false,
-  external: ["effect", "@happy-dom/global-registrator"],
+  external: ["effect"],
 });

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ilha/router",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "A tiny SPA router for Ilha",
   "keywords": [
     "frontend",
@@ -69,14 +69,21 @@
     "test": "bun test"
   },
   "dependencies": {
-    "effect": "^4.0.0-rc.112",
+    "effect": "4.0.0-rc.112",
     "unplugin": "3.3.0"
   },
   "devDependencies": {
-    "ilha": "0.14.1",
+    "ilha": "^0.14.2",
+    "oxidejs": "^0.3.0",
     "vite": "^8.2.2"
   },
   "peerDependencies": {
-    "ilha": ">=0.14.1"
+    "ilha": ">=0.14.2",
+    "oxidejs": ">=0.3.0"
+  },
+  "peerDependenciesMeta": {
+    "oxidejs": {
+      "optional": true
+    }
   }
 }

--- a/packages/router/src/frame-capture.test.ts
+++ b/packages/router/src/frame-capture.test.ts
@@ -7,6 +7,28 @@ import { h } from "ilha";
 import { __ilhaServerIsland } from "./server-island";
 import { __ilhaServerAction, registerServerIsland, renderServerIsland } from "./ssr";
 
+const ACTION_CALL = Symbol.for("ilha.actionCall");
+const ACTION_KEY = Symbol.for("oxidejs.actionKey");
+
+function testAction<A extends unknown[], R>(fn: (...args: A) => R) {
+  const handle = Object.assign((...args: A) => fn(...args), {
+    set: (...args: A) => fn(...args),
+    bind(...args: A) {
+      const key = (handle as { [ACTION_KEY]?: string })[ACTION_KEY];
+      const handler = ((..._ev: unknown[]) => fn(...args)) as ((...ev: unknown[]) => R) &
+        Record<typeof ACTION_CALL, { k: string; a: unknown[] }>;
+      if (key) handler[ACTION_CALL] = { k: key, a: args };
+      return handler;
+    },
+    with(...args: A) {
+      return handle.bind(...args);
+    },
+    atom: undefined,
+    $$atom: 1 as const,
+  });
+  return handle;
+}
+
 /** Run a render Effect to completion, rethrowing FrameError on failure. */
 const runIsland = async (
   id: string,
@@ -30,14 +52,17 @@ const runIsland = async (
 
 const SEAM_ID = "frame-capture-seam";
 
-const del = __ilhaServerAction("x:del", async (id: string) => `deleted:${id}`);
+const del = __ilhaServerAction(
+  "x:del",
+  testAction(async (id: string) => `deleted:${id}`),
+);
 
 function Tasks() {
   return h(
     "div",
     null,
-    h("button", { type: "button", "data-task": "1", onclick: del.with("1") }, "Delete 1"),
-    h("button", { type: "button", "data-task": "2", onclick: del.with("2") }, "Delete 2"),
+    h("button", { type: "button", "data-task": "1", onclick: del.bind("1") }, "Delete 1"),
+    h("button", { type: "button", "data-task": "2", onclick: del.bind("2") }, "Delete 2"),
   );
 }
 
@@ -151,22 +176,27 @@ describe("frame capture seam (SSR → client proxy)", () => {
 describe("__ilhaServerAction runtime wrapper", () => {
   it("invokes the function when no capture is active", async () => {
     const seen: unknown[] = [];
-    const act = __ilhaServerAction("x:probe", async (id: string) => {
-      seen.push(id);
-      return id;
-    });
+    const act = __ilhaServerAction(
+      "x:probe",
+      testAction(async (id: string) => {
+        seen.push(id);
+        return id;
+      }),
+    );
     await act("direct");
     expect(seen).toEqual(["direct"]);
   });
 
-  it(".with() brands the handler for SSR serialization", async () => {
+  it(".bind() brands the handler for SSR serialization", async () => {
     const BRAND = Symbol.for("ilha.actionCall");
-    const act = __ilhaServerAction("x:brand", async (id: string, _note: string) => id);
-    const handler = act.with("7", "hi");
+    const act = __ilhaServerAction(
+      "x:brand",
+      testAction(async (id: string, _note: string) => id),
+    );
+    const handler = act.bind("7", "hi");
     expect(typeof handler).toBe("function");
     const branded = (handler as unknown as Record<symbol, { k: string; a: unknown[] }>)[BRAND];
     expect(branded).toEqual({ k: "x:brand", a: ["7", "hi"] });
-    // Calling the handler on the server still reaches the function.
     await handler();
   });
 

--- a/packages/router/src/server-island.ts
+++ b/packages/router/src/server-island.ts
@@ -31,6 +31,26 @@ const ACTIONS_ATTR = "data-ilha-actions";
 const PROPS_ATTR = "data-ilha-props";
 const CLIENT_REF_ATTR = "data-ilha-client-ref";
 
+const moduleRepaints = new Map<string, Set<() => void>>();
+
+/** @internal Repaint every mounted island from the same `*.server` module. */
+export function __ilhaRepaintServerModule(moduleKey: string): void {
+  for (const repaint of moduleRepaints.get(moduleKey) ?? []) repaint();
+}
+
+function linkServerModuleRepaints(moduleKey: string, repaint: () => void): () => void {
+  let set = moduleRepaints.get(moduleKey);
+  if (!set) {
+    set = new Set();
+    moduleRepaints.set(moduleKey, set);
+  }
+  set.add(repaint);
+  return () => {
+    set!.delete(repaint);
+    if (set!.size === 0) moduleRepaints.delete(moduleKey);
+  };
+}
+
 export type ServerStreamFn = (signal: AbortSignal) => AsyncGenerator<unknown> | Generator<unknown>;
 
 export interface ServerIslandWiring {
@@ -130,6 +150,7 @@ function hydrateServerIsland(
   id: string,
   wiring: ServerIslandWiring,
   props?: Record<string, unknown>,
+  moduleKey?: string,
 ): ServerIslandHandle {
   const controller = new AbortController();
   const cleanups: Array<() => void> = [];
@@ -172,8 +193,11 @@ function hydrateServerIsland(
         }
       });
   };
-
-  // Reconnect event sentinels to named actions via the hydration manifest.
+  const repaintModule = (): void => {
+    if (moduleKey) __ilhaRepaintServerModule(moduleKey);
+    else scheduleRepaint();
+  };
+  if (moduleKey) cleanups.push(linkServerModuleRepaints(moduleKey, scheduleRepaint));
   // Frames re-render the island, so sentinel indexes and per-item args change
   // between renders — listeners are detached and rebuilt from scratch after
   // every morph, reading the FRESH manifest (host attr, or the <template>
@@ -226,7 +250,7 @@ function hydrateServerIsland(
         if (!action) continue;
         const listener = (): void => {
           void Promise.resolve(action(...callArgs))
-            .then(() => scheduleRepaint())
+            .then(() => repaintModule())
             .catch((err) => {
               console.error(`[ilha-router] action "${String(actionKey)}" failed:`, err);
             });
@@ -252,7 +276,7 @@ function hydrateServerIsland(
       const args = Array.isArray(marker.a) ? marker.a : [];
       props[key] = (..._runtimeArgs: unknown[]) =>
         Promise.resolve(action(...args)).then((result) => {
-          scheduleRepaint();
+          repaintModule();
           return result;
         });
     }
@@ -297,7 +321,7 @@ function hydrateServerIsland(
             const { done, value } = step;
             if (controller.signal.aborted || done) break;
             state[key] = value;
-            scheduleRepaint();
+            repaintModule();
             step = await gen.next();
           }
         } catch (err) {
@@ -366,6 +390,7 @@ export function __ilhaServerIsland(
   id: string,
   as: string,
   wiring: ServerIslandWiring = {},
+  moduleKey?: string,
 ): ServerIslandCallable {
   const slotTag = assertValidTag(as);
 
@@ -409,13 +434,13 @@ export function __ilhaServerIsland(
   (island as unknown as Record<symbol, unknown>)[ISLAND_MOUNT_INTERNAL] = (
     host: Element,
     mountProps?: Record<string, unknown>,
-  ): ServerIslandHandle => hydrateServerIsland(host, id, wiring, mountProps);
+  ): ServerIslandHandle => hydrateServerIsland(host, id, wiring, mountProps, moduleKey);
 
   // SAFETY: `.mount` mirrors the core island method surface on the proxy.
   (island as unknown as Record<string, unknown>).mount = (
     host: Element,
     mountProps?: Record<string, unknown>,
-  ): (() => void) => hydrateServerIsland(host, id, wiring, mountProps).unmount;
+  ): (() => void) => hydrateServerIsland(host, id, wiring, mountProps, moduleKey).unmount;
 
   return island;
 }

--- a/packages/router/src/server-islands.test.ts
+++ b/packages/router/src/server-islands.test.ts
@@ -133,6 +133,9 @@ describe("generateServerIslandModule", () => {
     expect(code).toContain(`export const ticks = (...args) => $$call("ticks", args)`);
     const id = serverIslandPublicId("/abs/tasks.server.ts", "T");
     expect(code).toContain(`export const T = __ilhaServerIsland("${id}", "div"`);
+    expect(code).toContain(`"${id}", "div", {`);
+    expect(code).toContain(`, "tasks")`);
+    expect(code).toContain(`$$rpc["tasks"][method](...args)`);
     expect(code).toContain(
       `JSON.stringify({ id: "${id}", path: location.pathname + location.search, props })`,
     );
@@ -460,6 +463,55 @@ describe("__ilhaServerIsland frames", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(calls).toEqual(["ping"]);
     unmount();
+  });
+});
+
+describe("__ilhaServerIsland shared module repaints", () => {
+  it("repaints every mounted island from the same server module", async () => {
+    let countFrames = 0;
+    let listFrames = 0;
+    const Count = __ilhaServerIsland(
+      "tasks.server.tsx#TaskCount",
+      "span",
+      {
+        frame: () => `<span class="badge">${++countFrames}</span>`,
+      },
+      "tasks",
+    );
+    const List = __ilhaServerIsland(
+      "tasks.server.tsx#TaskList",
+      "div",
+      {
+        actions: {
+          "x:toggle": () => Promise.resolve(),
+        },
+        frame: () =>
+          `<template data-ilha-actions='{"click:0":"x:toggle"}'></template><button data-ilha-on="click:0">go</button><p>list-${++listFrames}</p>`,
+      },
+      "tasks",
+    );
+
+    const countHost = document.createElement("div");
+    const listHost = document.createElement("div");
+    document.body.append(countHost, listHost);
+
+    const unmountCount = Count.mount(countHost);
+    const unmountList = List.mount(listHost);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(countFrames).toBe(1);
+    expect(listFrames).toBe(1);
+
+    listHost.querySelector<HTMLButtonElement>("button")?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(countFrames).toBe(2);
+    expect(listFrames).toBe(2);
+
+    unmountCount();
+    unmountList();
   });
 });
 

--- a/packages/router/src/server-islands.test.ts
+++ b/packages/router/src/server-islands.test.ts
@@ -134,13 +134,24 @@ describe("generateServerIslandModule", () => {
     const id = serverIslandPublicId("/abs/tasks.server.ts", "T");
     expect(code).toContain(`export const T = __ilhaServerIsland("${id}", "div"`);
     expect(code).toContain(`"${id}", "div", {`);
-    expect(code).toContain(`, "tasks")`);
+    expect(code).toContain(`, "/abs/tasks")`);
     expect(code).toContain(`$$rpc["tasks"][method](...args)`);
     expect(code).toContain(
       `JSON.stringify({ id: "${id}", path: location.pathname + location.search, props })`,
     );
     expect(code).not.toContain("#T");
     expect(code).not.toContain("state })");
+  });
+
+  it("same-basename modules get distinct repaint keys and shared rpc basenames", () => {
+    const scan = scanServerIslands(`export const T = async function T() { return "x"; };`);
+    const a = generateServerIslandModule("/proj/a/tasks.server.ts", scan);
+    const b = generateServerIslandModule("/proj/b/tasks.server.ts", scan);
+    expect(a).toContain(`$$rpc["tasks"][method](...args)`);
+    expect(b).toContain(`$$rpc["tasks"][method](...args)`);
+    expect(a).toContain(`, "/proj/a/tasks")`);
+    expect(b).toContain(`, "/proj/b/tasks")`);
+    expect(a).not.toContain(`, "/proj/b/tasks")`);
   });
 
   it("wires imported JSX islands into the client proxy", () => {
@@ -476,7 +487,7 @@ describe("__ilhaServerIsland shared module repaints", () => {
       {
         frame: () => `<span class="badge">${++countFrames}</span>`,
       },
-      "tasks",
+      "/abs/tasks",
     );
     const List = __ilhaServerIsland(
       "tasks.server.tsx#TaskList",
@@ -488,7 +499,7 @@ describe("__ilhaServerIsland shared module repaints", () => {
         frame: () =>
           `<template data-ilha-actions='{"click:0":"x:toggle"}'></template><button data-ilha-on="click:0">go</button><p>list-${++listFrames}</p>`,
       },
-      "tasks",
+      "/abs/tasks",
     );
 
     const countHost = document.createElement("div");
@@ -512,6 +523,50 @@ describe("__ilhaServerIsland shared module repaints", () => {
 
     unmountCount();
     unmountList();
+  });
+
+  it("same-basename modules in different directories keep distinct repaint groups", async () => {
+    let aFrames = 0;
+    let bFrames = 0;
+    const A = __ilhaServerIsland(
+      "a/tasks.server.tsx#A",
+      "div",
+      {
+        actions: { "x:go": () => Promise.resolve() },
+        frame: () =>
+          `<template data-ilha-actions='{"click:0":"x:go"}'></template><button data-ilha-on="click:0">a</button><p>a-${++aFrames}</p>`,
+      },
+      "/proj/a/tasks",
+    );
+    const B = __ilhaServerIsland(
+      "b/tasks.server.tsx#B",
+      "div",
+      {
+        frame: () => `<p>b-${++bFrames}</p>`,
+      },
+      "/proj/b/tasks",
+    );
+
+    const aHost = document.createElement("div");
+    const bHost = document.createElement("div");
+    document.body.append(aHost, bHost);
+    const unmountA = A.mount(aHost);
+    const unmountB = B.mount(bHost);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(aFrames).toBe(1);
+    expect(bFrames).toBe(1);
+
+    aHost.querySelector<HTMLButtonElement>("button")?.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(aFrames).toBe(2);
+    expect(bFrames).toBe(1);
+
+    unmountA();
+    unmountB();
   });
 });
 

--- a/packages/router/src/server-islands.ts
+++ b/packages/router/src/server-islands.ts
@@ -11,6 +11,16 @@ import { basename } from "node:path";
  * through oxidejs's tacho stub replacement.
  */
 
+/** Oxide RPC client key — basename without `.server.*` (oxide indexes by module name). */
+export function serverModuleRpcKey(spec: string): string {
+  return basename(spec).replace(/\.server\.(?:[jt]sx?)$/i, "");
+}
+
+/** Client repaint group key — full normalized path so same-basename files stay distinct. */
+export function serverModuleRepaintKey(spec: string): string {
+  return spec.replace(/\\/g, "/").replace(/\.server\.(?:[jt]sx?)$/i, "");
+}
+
 export interface ScannedServerIsland {
   /** Export binding name, or `"default"` for `export default ilha…`. */
   name: string;
@@ -264,11 +274,12 @@ export function serverIslandPublicId(spec: string, name: string): string {
 }
 
 export function generateServerIslandModule(spec: string, scan: ServerModuleScan): string {
-  const moduleKey = basename(spec).replace(/\.server\.(?:[jt]sx?)$/i, "");
+  const rpcKey = serverModuleRpcKey(spec);
+  const repaintKey = serverModuleRepaintKey(spec);
   const lines: string[] = [
     `import { client as $$rpc } from "virtual:oxide/client";`,
     `import { __ilhaApplyHead, __ilhaServerIsland } from "@ilha/router/server-island";`,
-    `const $$call = (method, args) => { const opts = args.at(-1); return opts && typeof opts === "object" && opts.signal instanceof AbortSignal && Object.keys(opts).length === 1 ? $$rpc[${JSON.stringify(moduleKey)}][method](...args.slice(0, -1), opts) : $$rpc[${JSON.stringify(moduleKey)}][method](...args); };`,
+    `const $$call = (method, args) => { const opts = args.at(-1); return opts && typeof opts === "object" && opts.signal instanceof AbortSignal && Object.keys(opts).length === 1 ? $$rpc[${JSON.stringify(rpcKey)}][method](...args.slice(0, -1), opts) : $$rpc[${JSON.stringify(rpcKey)}][method](...args); };`,
     ...scan.clientRefs.map((ref, index) =>
       ref.imported === "default"
         ? `import $$child${index} from ${JSON.stringify(ref.spec)};`
@@ -309,7 +320,7 @@ export function generateServerIslandModule(spec: string, scan: ServerModuleScan)
       `frame: (props) => fetch("/__ilha/frame", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ id: ${JSON.stringify(id)}, path: location.pathname + location.search, props }) }).then((r) => { if (!r.ok) throw new Error("frame failed"); return r.json(); }).then((j) => { if (j.redirect) { try { const u = new URL(j.redirect, location.href); if (u.origin === location.origin) location.assign(u.pathname + u.search + u.hash); } catch {} throw new Error("frame redirected"); } __ilhaApplyHead(j.head); return j.html; })`,
     );
 
-    const call = `__ilhaServerIsland(${JSON.stringify(id)}, ${JSON.stringify(island.as)}, { ${wiring.join(", ")} }, ${JSON.stringify(moduleKey)})`;
+    const call = `__ilhaServerIsland(${JSON.stringify(id)}, ${JSON.stringify(island.as)}, { ${wiring.join(", ")} }, ${JSON.stringify(repaintKey)})`;
     if (island.name === "default") {
       lines.push(`export default ${call};`);
     } else {

--- a/packages/router/src/server-islands.ts
+++ b/packages/router/src/server-islands.ts
@@ -268,7 +268,7 @@ export function generateServerIslandModule(spec: string, scan: ServerModuleScan)
   const lines: string[] = [
     `import { client as $$rpc } from "virtual:oxide/client";`,
     `import { __ilhaApplyHead, __ilhaServerIsland } from "@ilha/router/server-island";`,
-    `const $$call = (method, args) => { const opts = args.at(-1); return opts && typeof opts === "object" && opts.signal instanceof AbortSignal && Object.keys(opts).length === 1 ? $$rpc[${JSON.stringify(moduleKey)}][method](args.slice(0, -1), opts) : $$rpc[${JSON.stringify(moduleKey)}][method](args); };`,
+    `const $$call = (method, args) => { const opts = args.at(-1); return opts && typeof opts === "object" && opts.signal instanceof AbortSignal && Object.keys(opts).length === 1 ? $$rpc[${JSON.stringify(moduleKey)}][method](...args.slice(0, -1), opts) : $$rpc[${JSON.stringify(moduleKey)}][method](...args); };`,
     ...scan.clientRefs.map((ref, index) =>
       ref.imported === "default"
         ? `import $$child${index} from ${JSON.stringify(ref.spec)};`
@@ -309,7 +309,7 @@ export function generateServerIslandModule(spec: string, scan: ServerModuleScan)
       `frame: (props) => fetch("/__ilha/frame", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ id: ${JSON.stringify(id)}, path: location.pathname + location.search, props }) }).then((r) => { if (!r.ok) throw new Error("frame failed"); return r.json(); }).then((j) => { if (j.redirect) { try { const u = new URL(j.redirect, location.href); if (u.origin === location.origin) location.assign(u.pathname + u.search + u.hash); } catch {} throw new Error("frame redirected"); } __ilhaApplyHead(j.head); return j.html; })`,
     );
 
-    const call = `__ilhaServerIsland(${JSON.stringify(id)}, ${JSON.stringify(island.as)}, { ${wiring.join(", ")} })`;
+    const call = `__ilhaServerIsland(${JSON.stringify(id)}, ${JSON.stringify(island.as)}, { ${wiring.join(", ")} }, ${JSON.stringify(moduleKey)})`;
     if (island.name === "default") {
       lines.push(`export default ${call};`);
     } else {

--- a/packages/router/src/ssr.ts
+++ b/packages/router/src/ssr.ts
@@ -18,6 +18,7 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Result from "effect/Result";
 import { renderToString } from "ilha";
+import { action, brandServerAction } from "oxidejs";
 
 import { runWithIslandRequest } from "./request-scope";
 import { sanitizeSnapshotObject } from "./snapshot";
@@ -244,23 +245,16 @@ export function frameEnvelope(status: number, body: Record<string, unknown>): Fr
   };
 }
 
-const ACTION_CALL = Symbol.for("ilha.actionCall");
-
 /** @internal Brand an exported server action with its generated RPC transport key. */
 export function __ilhaServerAction<A extends unknown[], R>(
   key: string,
-  fn: (...args: A) => R,
-): ((...args: A) => R) & { with: (...args: A) => (...ev: unknown[]) => R } {
-  const wrapped = ((...args: A) => fn(...args)) as ((...args: A) => R) & {
-    with: (...args: A) => (...ev: unknown[]) => R;
-  };
-  wrapped.with = (...args: A) => {
-    const handler = ((..._ev: unknown[]) => wrapped(...args)) as ((...ev: unknown[]) => R) &
-      Record<symbol, { k: string; a: unknown[] }>;
-    handler[ACTION_CALL] = { k: key, a: args };
-    return handler;
-  };
-  return wrapped;
+  fn: (...args: A) => R | Promise<R>,
+) {
+  const handle =
+    typeof fn === "function" && (fn as { $$atom?: number }).$$atom === 1
+      ? (fn as ReturnType<typeof action<A, Awaited<R>>>)
+      : action(fn as (...args: A) => Awaited<R>);
+  return brandServerAction(key, handle);
 }
 
 export function registerServerIsland(id: string, render: () => unknown): void {

--- a/templates/oxide-spa/package.json
+++ b/templates/oxide-spa/package.json
@@ -10,16 +10,15 @@
     "start": "node dist/server.js"
   },
   "dependencies": {
-    "@ilha/router": "^0.11.1",
+    "@ilha/router": "^0.11.2",
     "effect": "^4.0.0-rc.112",
-    "ilha": "^0.14.1",
-    "tacho": "^0.6.1"
+    "ilha": "^0.14.2"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^24",
     "daisyui": "^5.7.22",
-    "oxidejs": "^0.2.4",
+    "oxidejs": "^0.3.0",
     "tailwindcss": "^4.3.3",
     "typescript": "^7.0.2",
     "vite": "^8.2.2"

--- a/templates/vite-spa/package.json
+++ b/templates/vite-spa/package.json
@@ -9,9 +9,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@ilha/router": "^0.11.1",
+    "@ilha/router": "^0.11.2",
     "effect": "^4.0.0-rc.112",
-    "ilha": "^0.14.1"
+    "ilha": "^0.14.2"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.3",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Server-side rendering now works without a DOM or DOM polyfill across Node, Bun, and edge runtimes.
  - Islands preserve mounted elements during updates and refresh props without unnecessary remounts.
  - Updates in one server-rendered island can refresh related islands from the same module.
  - Server actions now support asynchronous results.

- **Bug Fixes**
  - Prevented stale island content from persisting between renders.
  - Unsafe `javascript:` links are omitted from server-rendered HTML.
  - Protected server-rendered script and style content from HTML breakout payloads.

- **Documentation**
  - Updated SSR guidance to reflect DOM-free rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->